### PR TITLE
Changes return; to continue; to let the loop proceed

### DIFF
--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -155,7 +155,6 @@ public function validate_link( $field, $post_id ) {
         $count = 1;
     }
     for ( $i = 0; $i <= $count; $i++ ) {
-        error_log("Saving {$i} out of {$count}", 0);
         if ( empty( $_POST[$key . '_url_' . $i] ) || empty( $_POST[$key.'_text_' . $i]) ) {
             continue;
         }


### PR DESCRIPTION
Fixes an issue where only the first value of a link set was saved. We were returning instead of continuing in the for loop. DUH, @gboone!
