### PR TITLE
Bug fix for editing existing links in link manager

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -21,16 +21,17 @@ function toggle_link_field(element) {
     var form_num = classes[3];
     var action = classes[2];
     var slug = classes[1];
-    if ( action == 'edit') {
-        var targeted_input = jQuery('div#'+slug+' fieldset#' + slug + '_' + form_num );
+    var targeted_input;
+    if ( action == 'edit' ) {
+        targeted_input = jQuery('div.' + slug + ' fieldset#' + slug + '_' + form_num);
         jQuery('div.' + slug + ' span.' + form_num).toggle();
     } else if ( action == 'add' ) {
-        var targeted_input = jQuery('div.' + slug + ' fieldset.hidden.new').first();
+        targeted_input = jQuery('div.' + slug + ' fieldset.hidden.new').first();
         jQuery(targeted_input).toggleClass('new');
         jQuery(targeted_input).toggleClass('expanded');
         jQuery(targeted_input).attr('disabled', false);
     } else if ( action == 'remove' ) {
-        var targeted_input = jQuery('div.' + slug + ' fieldset.expanded' ).first();
+        targeted_input = jQuery('div.' + slug + ' fieldset.expanded').first();
         jQuery(targeted_input).toggleClass('expanded');
         jQuery(targeted_input).toggleClass('new');
     }


### PR DESCRIPTION
The important thing is the jQuery selector change in line 26.

Before noticing the bug while creating the Offices post type, it worked
because we were getting lucky that the overall meta box name was the
same as the field name.

The other changes are just minor formatting cleanup.
