### PR TITLE
Fix formset overwrite bug

### DIFF
--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -187,6 +187,9 @@ public function validate_formset_of_fieldsets( $field, $post_id ) {
     $validate = array();
     for ( $i = 0; $i < $count; $i++ ) {
         $ready[$i] = $field;
+        $ready[$i]['meta_key'] .= '_' . $i;
+        $ready[$i]['slug'] .= '_' . $i;
+        // $ready[$i]['title'] .= ' ' . $i;
         for ($j = 0; $j < count( $field['fields'] ); $j++ ){
             $meta_key = $ready[$i]['fields'][$j]['meta_key'];
             $ready[$i]['fields'][$j]['meta_key'] = "{$key}_{$meta_key}_{$i}";
@@ -417,7 +420,10 @@ public function validate_and_save( $post_ID ) {
     foreach ( $this->fields as $field ) {
         if ( $field['type'] == 'fieldset') {
             if ( isset( $field['params']['is_formset_of_fieldsets'] ) ) {
-                $validate = $this->validate_formset_of_fieldsets( $field, $post_ID );
+                $prevalidate = $this->validate_formset_of_fieldsets( $field, $post_ID );
+                foreach ( $prevalidate as $f ) {
+                    $validate[$f['meta_key']] = $f;
+                }
             } else {
                 foreach ( $field['fields'] as $f ) {
                     $f['meta_key'] = $field['meta_key'] . '_' . $f['meta_key'];

--- a/inc/meta-box-view.php
+++ b/inc/meta-box-view.php
@@ -64,7 +64,10 @@ class View {
 				// in the group.
 				if ( isset( $field['params']['is_formset_of_fieldsets'] ) ) {
 					$field['init_num_forms'] = $this->formset_count( $field );
-					$ready = $this->process_defaults_for_formset_of_fieldsets( $field );
+					$preready = $this->process_defaults_for_formset_of_fieldsets( $field );
+					foreach ( $preready as $f ) {
+						$ready[$f['meta_key']] = $f;
+					}
 				} else {
 					$fields = $field['slug']['fields'];
 					$i = 0;
@@ -91,6 +94,9 @@ class View {
 		$key = $field['meta_key'];
 		for ( $i = 0; $i < $field['params']['max_num_forms']; $i++ ) {
 			$ready[$i] = $field;
+			$ready[$i]['meta_key'] .= '_' . $i;
+	        $ready[$i]['slug'] .= '_' . $i;
+	        // $ready[$i]['title'] .= ' ' . $i;
 			for ( $j = 0; $j < count( $field['fields'] ); $j++ ) {
 				$meta_key = $ready[$i]['fields'][$j]['meta_key'];
 				$ready[$i]['fields'][$j]['meta_key'] = "{$key}_{$meta_key}_{$i}";


### PR DESCRIPTION
This fixes the bug that occurs when the declaration of the formset of fieldsets in the metabox would overwrite any field that was declared before it.

_Reproducing the bug_
When defining a metabox in your metabox code, define a field before the formset of fieldsets field. That field will not show when rendering the metabox.
