### PR TITLE
Add tests and refactor for meta-box-models.php

### DIFF
--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -176,7 +176,7 @@ public function validate_formset( $field, &$validate, $post_ID ) {
 *                         so data is saved through that array.
 */
 
-private function validate_fieldset( $field, &$validate, $post_ID ) {
+public function validate_fieldset( $field, &$validate, $post_ID ) {
     foreach ( $field['fields'] as $f ) {
         $f['meta_key'] = "{$field['meta_key']}_{$f['meta_key']}";
         $this->validate( $post_ID, $f, $validate );


### PR DESCRIPTION
#### This pull request is 1 of 3 that add tests and does general refactoring

This adds tests for the inc/meta-box-models.php file that cover the new formset and fieldset types. I have changed the access modifier for the validate_fieldset() function to be public in order to test it. I have deemed it non-harmful to do so. **PLEASE**, think about the implications of keeping the access modifier public and make any concerns known before pulling it in. The other 2 pull requests have the same situation.

- [View Pull Request](https://github.com/cfpb/cms-toolkit/pull/38)
- [HTML Pull Request](https://github.com/cfpb/cms-toolkit/pull/39)