### PR TITLE
Add tests and refactor for meta-box-html.php

### DIFF
--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -3,7 +3,7 @@ namespace CFPB\Utils\MetaBox;
 use \WP_Error;
 class HTML {
 
-	public $elements = array(
+	private $elements = array(
 		'selects' => array( 'select', 'multiselect', 'taxonomyselect', 'tax_as_meta', 'post_select', 'post_multiselect' ),
 		'inputs' => array( 'text_area', 'number', 'text', 'boolean', 'email', 'url', 'date', 'radio', 'link', ),
 		'hidden' => array( 'nonce', 'hidden', 'separator', 'fieldset' ),
@@ -12,14 +12,12 @@ class HTML {
 	public function draw( $field, $form_id = NULL ) {
 		if ( empty( $field ) ) {
 			return new WP_Error( 'field_required', 'You need to pass a field array to this method. You passed a '. gettype( $field ) . ' .');
-		}?>
-		<div class="cms-toolkit-wrapper<?php if (isset( $field['class'] )) { echo ' ' . esc_attr( $field['class'] ); } ?>"><?php
-		if ( $field['type'] !== 'formset' ) {
-			if ( isset( $field['title'] ) ) {
-				?><h4 id="<?php echo "{$field['meta_key']}"; ?>" ><?php
-					echo "{$field['title']}"; 
-				?></h4><?php
-			}
+		}
+		?><div class="cms-toolkit-wrapper<?php if (isset( $field['class'] )) { echo ' ' . esc_attr( $field['class'] ); } ?>"><?php
+		if ( $field['type'] !== 'formset' and isset( $field['title'] ) ) {
+			?><h4 id="<?php echo "{$field['meta_key']}"; ?>" ><?php
+				echo "{$field['title']}"; 
+			?></h4><?php
 		}
 		if ( $field['type'] == 'formset' ) {
 			$this->draw_formset( $field );
@@ -32,64 +30,61 @@ class HTML {
 		} elseif ( in_array( $field['type'], $this->elements['selects'] ) ) {
 			$this->pass_select( $field, $form_id );
 		} elseif ( $field['type'] == 'hidden' ) {
-			HTML::hidden( $field['meta_key'], $field['value'], $form_id );
+			$this->hidden( $field['meta_key'], $field['value'], $form_id );
 		} elseif ( $field['type'] == 'nonce' ) {
 			wp_nonce_field( plugin_basename( __FILE__ ), $field['meta_key'] );
 		}
-		if ( isset( $field['howto'] ) ) { ?>
-			<p class="howto"><?php echo esc_html( $field['howto'] ) ?></p><?php
-		}?>
-		</div><?php
+		if ( isset( $field['howto'] ) ) { 
+			?><p class="howto"><?php echo esc_attr( $field['howto'] ) ?></p><?php
+		}
+		?></div><?php
 	}
 
-	private function draw_formset( $field ) {
+	public function draw_formset( $field ) {
 		global $post;
 		$post_id = $post->ID;	
 		$post_data = get_post_custom( $post_id );
 		$form_id = $this->get_formset_id( $field['meta_key'] );
 		$init = isset( $field['init'] ) ? true : false;
 		$existing = array();
-		$this->get_existing_data( $field, $existing, $post_data );?>
-		<div id="<?php echo "{$field['meta_key']}_formset"; ?>" <?php
-		  if ( empty( $existing ) and ! $init ) { echo 'class="hidden new" disabled'; } ?>><?php
-			if ( isset( $field['title'] ) ) {
-				?><h4 id="<?php echo "{$field['meta_key']}_header"; ?>" class="formset-header <?php
-				if ( empty( $existing ) and ! $init ) { echo 'hidden'; } ?>">
-					<?php echo $field['title'];
-				?> <a class="toggle_form_manager
-					<?php echo "{$field['meta_key']} remove {$form_id}";
-						  if ( empty( $existing ) and ! $init ) { echo " hidden"; } ?>"
-			   		href="#remove-formset_<?php echo $form_id; ?>">
-					<?php
-					if ( isset( $field['title'] ) ) {
-						echo "Remove";
-					} else {
-						echo "Remove formset " . ( $form_id + 1 );
-					}?>
-				</a></h4><?php
-			}
-			$this->pass_fieldset( $field, $form_id );?>
-		</div>
-		<a class="toggle_form_manager
-			<?php echo "{$field['meta_key']} add {$form_id}";
-				  if ( ! empty( $existing ) or $init ) { echo " hidden"; } ?>"
-		   href="#add-formset_<?php echo $form_id; ?>">
-			<?php
+		$this->get_existing_data( $field, $existing, $post_data );
+		?><div id="<?php echo "{$field['meta_key']}_formset"; ?>"<?php
+		  if ( empty( $existing ) and ! $init ) { echo ' class="hidden new" disabled'; } ?>><?php
+			?><h4 id="<?php echo "{$field['meta_key']}_header"; ?>" class="formset-header<?php
+			if ( empty( $existing ) and ! $init ) { echo ' hidden'; } ?>"><?php 
+				echo isset( $field['title'] ) ? $field['title'] : "Formset";
+				?><a class="toggle_form_manager <?php
+					echo "{$field['meta_key']} remove {$form_id}";
+					if ( empty( $existing ) and ! $init ) { echo " hidden"; } 
+					?>" href="#remove-formset_<?php echo $form_id; ?>"><?php
+						if ( isset( $field['title'] ) ) {
+							echo "Remove";
+						} else {
+							echo "Remove formset";
+						}
+				?></a><?php
+			?></h4><?php
+			$this->pass_fieldset( $field, $form_id );
+		?></div><?php
+		?><a class="toggle_form_manager <?php
+			echo "{$field['meta_key']} add {$form_id}";
+			if ( $existing or $init ) { echo " hidden"; } 
+			?>" href="#add-formset_<?php echo $form_id; ?>"><?php
 			if ( isset( $field['title'] ) ) {
 				echo "Add {$field['title']}";
 			} else {
-				echo "Add Formset " . ($form_id + 1);
-			}?>
-		</a><?php
+				echo "Add Formset";
+			}
+		?></a><?php
 	}
 
-	private function pass_fieldset( $field, $form_id = NULL ) {
+	public function pass_fieldset( $field, $form_id = NULL ) {
 		foreach ($field['fields'] as $f) {
 			$this->draw( $f, $form_id );
 		}
 	}
 
-	private function get_formset_id( $form_meta_key ) {
+	public function get_formset_id( $form_meta_key ) {
 		$id = "";
 		$key_parts = explode( '_', $form_meta_key );
 		foreach ( $key_parts as $part ) {
@@ -103,7 +98,7 @@ class HTML {
 		return $id;
 	}
 
-	private function get_existing_data( $field, &$existing, $data ) {
+	public function get_existing_data( $field, &$existing, $data ) {
 		foreach ( $field['fields'] as $f ) {
 			if ( $f['type'] == 'fieldset' ) {
 				$this->get_existing_data( $f, $existing, $data );
@@ -117,18 +112,19 @@ class HTML {
 		}
 	}
 
-	private function pass_select( $field, $form_id = NULL ) {
+	public function pass_select( $field, $form_id = NULL ) {
 		$required = isset( $field['required'] ) ? $field['required'] : false;
 		$key = isset( $field['meta_key'] ) ? $field['meta_key'] : $field['slug'];
 		$label = isset( $field['label'] ) ? $field['label'] : null;
 		$title = isset( $field['title'] ) ? $field['title'] : null;
-		$multi = isset( $field['multiple'] ) ? $field['multiple'] : null;
+		$multi = isset( $field['multiple'] ) ? $field['multiple'] : false;
 		if ( in_array( $field['type'], array('multiselect', 'select', 'taxonomyselect' ) ) ) {
-			HTML::select( 
+			$this->select( 
 				$key, 
 				$field['params'], 
 				$field['taxonomy'], 
-				$multi, 
+				$multi,
+				$field['value'],
 				$field['placeholder'],
 				$title,
 				$label,
@@ -136,16 +132,16 @@ class HTML {
 				$form_id
 			);
 		} elseif ( $field['type'] == 'tax_as_meta' ) {
-			HTML::taxonomy_as_meta(
+			$this->taxonomy_as_meta(
 				$slug = $field['slug'],
 				$params = $field['include'],
 				$taxonomy = $field['taxonomy'],
-				$key,
-				$placeholder = $field['placeholder'],
 				$value = $field['value'],
-				$title,
-				$label,
+				$multi,
+				$placeholder = $field['placeholder'],
 				$required,
+				// $title,
+				// $label,
 				$form_id
 			);
 		} elseif ( $field['type'] == 'post_select' || $field['type'] == 'post_multiselect' ) {
@@ -154,56 +150,55 @@ class HTML {
 			$posts = get_posts($args);
 			$value = get_post_meta( $post->ID, $field['meta_key'], $single = false );
 			$multi = $field['type'] == 'post_multiselect' ? 'multiple' : null;
-			HTML::post_select(
-				$meta_key = $field['meta_key'],
+			$this->post_select(
+				$key,
 				$posts,
 				$value,
 				$multi,
-				$placeholder = $field['placeholder'],
 				$title,
 				$label,
 				$required,
+				$placeholder = $field['placeholder'],
 				$form_id
 			);
 		}
 	}
 
-	private function draw_input( $field, $form_id = NULL ) {
+	public function draw_input( $field, $form_id = NULL ) {
 		$required = isset( $field['required'] ) ? $field['required'] : false;
 		$value = isset( $field['value'] ) ? $field['value'] : null;
 		$label = isset( $field['label'] ) ? $field['label'] : null;
 		$title = isset( $field['title'] ) ? $field['title'] : null;
-		$tax_nice_name = $title ? $title : $label;
 		if ( $field['type'] == 'text_area' ) {
-			HTML::text_area( $field['rows'], $field['cols'], $field['meta_key'], $value, $title, $label, $field['placeholder'], $required, $form_id );
+			$this->text_area( $field['rows'], $field['cols'], $field['meta_key'], $value, $title, $label, $field['placeholder'], $required, $form_id );
 		}
 
 		if ( in_array( $field['type'], array( 'number', 'text', 'email', 'url' ) ) ) {
-			HTML::single_input( $field['meta_key'], $field['type'], $field['max_length'], $value, $title, $label, $field['placeholder'], $required, $form_id );
+			$this->single_input( $field['meta_key'], $field['type'], $field['max_length'], $value, $title, $label, $field['placeholder'], $required, $form_id );
 		}
 
 		if ( $field['type'] == 'date' ) {
-			HTML::date( $taxonomy = $field['taxonomy'], $tax_nice_name, $multiples = $field['multiple'], $required, $form_id );
+			$this->date( $taxonomy = $field['taxonomy'], $multiples = $field['multiple'], $required, $form_id );
 		}
 
 		if ( $field['type'] == 'radio' ) {
-			HTML::single_input( $field['meta_key'], $field['type'] = 'radio', $max_length = null, $value = 'true', $title, $label, $field['placeholder'], $required, $form_id );
-			HTML::single_input( $field['meta_key'], $field['type'] = 'radio', $max_length = null, $value = 'false', $title, $label, $field['placeholder'], $required, $form_id );
+			$this->single_input( $field['meta_key'], $field['type'] = 'radio', $max_length = null, $value = 'true', $title, $label, $field['placeholder'], $required, $form_id );
+			$this->single_input( $field['meta_key'], $field['type'] = 'radio', $max_length = null, $value = 'false', $title, $label, $field['placeholder'], $required, $form_id );
 		}
 
 		if ( $field['type'] == 'boolean' ) {
-			HTML::boolean_input( $field['meta_key'], $title, $label, $value, $required, $form_id );
+			$this->boolean_input( $field['meta_key'], $title, $label, $value, $required, $form_id );
 		}
 
 		if ( $field['type'] == 'link' ) {
-			HTML::url_input($field['meta_key'], $value, $title, $label, $required, $form_id );
+			$this->url_input($field['meta_key'], $value, $title, $label, $required, $form_id );
 		}
 	}
 
 /**
 	 * Generate a <textarea> field
 	 *
-	 * Generates a textarea HTML field using defined parameters A protected
+	 * Generates a textarea HTML field using defined parameters A public
 	 * function, this method may only be called from within this class.
 	 *
 	 * All parameters are required
@@ -214,20 +209,20 @@ class HTML {
 	 * @param str $value a default value for the <textarea>
 	 *
 	**/
-	protected function text_area( $rows, $cols, $meta_key, $value, $title, $label, $placeholder, $required, $form_id = NULL ) {
-		?>
-		<label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>">
-			<?php echo $title ? esc_attr( $title ) : esc_attr( $label ); if ( $required ): echo ' (required)'; endif; ?>
-		</label>
-		<textarea id="<?php echo esc_attr( $meta_key ) ?>"
-				  class="cms-toolkit-textarea <?php echo "form-input_{$form_id}"; ?>"
-				  name="<?php echo esc_attr( $meta_key ) ?>"
-				  rows="<?php echo esc_attr( $rows ) ?>"
-				  cols="<?php echo esc_attr( $cols ) ?>"
-				  value="<?php echo esc_attr( $value ) ?>"
-				  placeholder="<?php echo esc_attr( $placeholder ) ?>"
-				  <?php if ( $required ): echo 'required'; endif; ?>><?php echo esc_html( $value ) ?></textarea>
-		<?php
+	public function text_area( $rows, $cols, $meta_key, $value, $title, $label, $placeholder, $required, $form_id = NULL ) {
+		?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php 
+			echo $title ? esc_attr( $title ) : esc_attr( $label ); if ( $required ): echo ' (required)'; endif; 
+		?></label><?php
+		// wp_editor( $value, $meta_key );
+		?><textarea id="<?php echo esc_attr( $meta_key ) 
+				  ?>" class="cms-toolkit-textarea <?php echo "form-input_{$form_id}"; 
+				  ?>" name="<?php echo esc_attr( $meta_key ) 
+				  ?>" rows="<?php echo esc_attr( $rows ) 
+				  ?>" cols="<?php echo esc_attr( $cols ) 
+				  ?>" value="<?php echo esc_attr( $value ) 
+				  ?>" placeholder="<?php echo esc_attr( $placeholder ) ?>"<?php
+				   if ( $required ): echo ' required'; endif; ?>><?php echo esc_attr( $value ) 
+		?></textarea><?php
 	}
 
 	/**
@@ -236,7 +231,7 @@ class HTML {
 	 * A single <input> is generated based on defined parameters.
 	 *
 	 * Slug and type parameters are required, all others default to null. A
-	 * protected function, this method may only be called from within this
+	 * public function, this method may only be called from within this
 	 * class.
 	 *
 	 * @param str $meta_key the meta_key for this field, used as 'name' and 'id'
@@ -248,50 +243,44 @@ class HTML {
 	 * @since 1.0
 	 *
 	**/
-	protected function single_input( $meta_key, $type, $max_length = NULL, $value = NULL, $title, $label = NULL, $placeholder = NULL, $required, $form_id = NULL ) {
+	public function single_input( $meta_key, $type, $max_length = NULL, $value = NULL, $title, $label = NULL, $placeholder = NULL, $required, $form_id = NULL ) {
 		$value       = 'value="' . $value . '"';
 		$max_length  = 'maxlength="' . $max_length . '"';
 		$placeholder = 'placeholder="' . $placeholder . '"';
-		?>
-		<label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>">
-			<?php echo $title ? esc_attr( $title ) : esc_attr( $label ); if ( $required ): echo ' (required)'; endif; ?>
-		</label>
-		<input id="<?php echo esc_attr( $meta_key ) ?>"
-			   class="cms-toolkit-input <?php echo "form-input_{$form_id}"; ?>"
-			   name="<?php echo esc_attr( $meta_key ) ?>"
-			   type="<?php echo esc_attr( $type ) ?>"
-			   <?php echo " $max_length $value $placeholder" ?>
-			   <?php if ( $required ): echo 'required '; endif; ?>/>
-		<?php
+		?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php 
+			echo $title ? esc_attr( $title ) : esc_attr( $label ); if ( $required ): echo ' (required)'; endif; 
+		?></label>
+		<input id="<?php echo esc_attr( $meta_key ) 
+			   ?>" class="cms-toolkit-input <?php echo "form-input_{$form_id}"; 
+			   ?>" name="<?php echo esc_attr( $meta_key ) 
+			   ?>" type="<?php echo esc_attr( $type ) ?>"<?php 
+			   echo " $max_length $value $placeholder";
+			   if ( $required ): echo ' required '; endif; ?>/><?php
 	}
 
-	protected function boolean_input( $meta_key, $title, $label, $value, $required, $form_id = NULL ) {
-		?>
-		<input id="<?php echo esc_attr( $meta_key ) ?>"
-			   class="cms-toolkit-checkbox <?php echo "form-input_{$form_id}"; ?>"
-			   name="<?php echo esc_attr( $meta_key ) ?>"
-			   type="checkbox"
-			   <?php if ( $value == 'on' ) { echo 'checked'; } ?>
-			   <?php if ( $required ) { echo 'required'; } ?>/>
-		<label class="cms-toolkit-label" for="<?php echo esc_attr( $meta_key ) ?>">
-			<?php echo $title ? esc_attr( $title ) : esc_attr( $label ); if ( $required ): echo ' (required)'; endif; ?>
-		</label>
-		<?php
+	public function boolean_input( $meta_key, $title, $label, $value, $required, $form_id = NULL ) {
+		?><input id="<?php echo esc_attr( $meta_key ) 
+			   ?>" class="cms-toolkit-checkbox <?php echo "form-input_{$form_id}"; 
+			   ?>" name="<?php echo esc_attr( $meta_key ) 
+			   ?>" type="checkbox" <?php
+			   if ( $value == 'on' ) { echo 'checked '; }
+			   if ( $required ) { echo 'required '; } ?>/>
+		<label class="cms-toolkit-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php
+			echo $title ? esc_attr( $title ) : esc_attr( $label ); if ( $required ): echo ' (required)'; endif; 
+		?></label><?php
 	}
 
-	protected function url_input( $meta_key, $value = NULL, $title, $label, $required, $form_id = NULL ) {
+	public function url_input( $meta_key, $value = NULL, $title, $label, $required, $form_id = NULL ) {
 		global $post;
 		$post_id = $post->ID;
-		?>
-		<div class="link-field <?php echo "{$meta_key}" ?>">
-		<?php
+		?><div class="link-field <?php echo "{$meta_key}" ?>"><?php
 		$existing = get_post_meta( $post_id, $meta_key, false);
 		if ( ! isset( $existing[0] ) || ! isset( $existing[1] ) ) { 
-				HTML::single_input( $meta_key . "_text", 'text', NULL, $value, NULL, 'Text', NULL, $required, $form_id );
-				HTML::single_input( $meta_key . "_url", 'url', NULL, $value, NULL, 'URL', NULL, $required, $form_id );
+				$this->single_input( $meta_key . "_text", 'text', NULL, $value, NULL, 'Text', NULL, $required, $form_id );
+				$this->single_input( $meta_key . "_url", 'url', NULL, $value, NULL, 'URL', NULL, $required, $form_id );
 		} else { 
-				HTML::single_input( $meta_key . "_text", 'text', NULL, $existing[1], NULL, 'Text', NULL, $required, $form_id );
-				HTML::single_input( $meta_key . "_url", 'url', NULL, $existing[0], NULL, 'URL', NULL, $required, $form_id );
+				$this->single_input( $meta_key . "_text", 'text', NULL, $existing[1], NULL, 'Text', NULL, $required, $form_id );
+				$this->single_input( $meta_key . "_url", 'url', NULL, $existing[0], NULL, 'URL', NULL, $required, $form_id );
 		}
 		?></div><?php
 	}
@@ -299,13 +288,11 @@ class HTML {
 	/**
 	 *  Generates a hidden field
 	**/
-	protected function hidden( $meta_key, $value, $form_id ) { ?>
-		<input class="cms-toolkit-input <?php echo "form-input_{$form_id}";?>"
-			   id="<?php echo esc_attr( $meta_key ) ?>"
-			   name="<?php echo esc_attr( $meta_key ) ?>"
-			   type="hidden"
-			   value="<?php echo esc_attr( $value ) ?>" />
-	<?php
+	public function hidden( $meta_key, $value, $form_id ) {
+		?><input class="cms-toolkit-input <?php echo "form-input_{$form_id}";
+			   ?>" id="<?php echo esc_attr( $meta_key ) 
+			   ?>" name="<?php echo esc_attr( $meta_key ) 
+			   ?>" type="hidden" value="<?php echo esc_attr( $value ) ?>" /><?php
 	}
 
 	/**
@@ -318,7 +305,7 @@ class HTML {
 	 * use it on has a term from that taxonomy it will be autoselected. Select
 	 * and multi-select fields use an array in the $param parameter to generate
 	 * options. To make a select a multi-select, just pass 'true' to the fifth
-	 * parameter. A protected function, this method may only be called from
+	 * parameter. A public function, this method may only be called from
 	 * within this class.
 	 *
 	 * @since v1.0
@@ -338,71 +325,66 @@ class HTML {
 	 *              if no value selected. Default: '--'
 	 *
 	**/
-	protected function select( $meta_key, $params = array(), $taxonomy = false, $multi = null, $value = null, $placeholder = '--', $title, $label, $required, $form_id = NULL ) {
+	public function select( $meta_key, $params = array(), $taxonomy = false, $multi = false, $value = null, $placeholder = '--', $title = NULL, $label = NULL, $required = false, $form_id = NULL ) {
 		if ( $taxonomy != false ) { // if a taxonomy is set, use wp_dropdown category to generate the select box
 			$IDs = wp_get_object_terms( get_the_ID(), $taxonomy, array( 'fields' => 'ids' ) );
 			wp_dropdown_categories( 'taxonomy=' . $taxonomy . '&hide_empty=0&orderby=name&name=' . $taxonomy . '&show_option_none=Select ' . $taxonomy . '&selected='. array_pop($IDs) );
 		} else {	// otherwise use all the values set in $param to generate the option
-				$multiple = isset($multi) ? 'multiple' : null;
-				?> 
-				<label for="<?php echo esc_attr($meta_key) ?>"><?php echo $title ? esc_attr( $title ) : esc_attr( $label ); ?></label>
-				<select id="<?php echo esc_attr( $meta_key ) ?>" name="<?php echo esc_attr( $meta_key ) ?>[]" class="<?php echo "form-input_{$form_id}"; ?>" <?php echo $multiple ?> <?php if ( $required ): echo 'required'; endif; ?>>
-				<?php
-				if ( empty( $value ) ) { ?>
-					<option selected value=""><?php echo esc_html( $placeholder ) ?></option>
-				<?php
-				} else { ?>
-					<option value=""><?php echo esc_html( $placeholder ) ?></option>
-					<option selected="selected" value="<?php echo esc_attr( $value ) ?>"><?php echo esc_html( $value ) ?></option><?php
-				}
-
-			foreach ( $params as $option ) { ?>
-				<option value="<?php echo esc_attr( $option ) ?>"><?php echo esc_html( $option ) ?></option>
-			<?php
+			$multiple = isset($multi) ? 'multiple' : null;
+			?><label for="<?php echo esc_attr($meta_key) ?>"><?php echo $title ? esc_attr( $title ) : esc_attr( $label ); ?></label><?php
+			?><select id="<?php echo esc_attr( $meta_key ) ?>" name="<?php echo esc_attr( $meta_key ) ?>[]" class="<?php echo "form-input_{$form_id}"; ?>" <?php echo $multiple ?> <?php if ( $required ): echo 'required'; endif; ?>><?php
+			if ( empty( $value ) ) {
+				?><option selected value=""><?php echo esc_attr( $placeholder ) ?></option><?php
+			} else {
+				?><option value=""><?php echo esc_attr( $placeholder ) ?></option><?php
+				?><option selected="selected" value="<?php echo esc_attr( $value ) ?>"><?php echo esc_attr( $value ) ?></option><?php
 			}
-		?>	</select> <?php
+			foreach ( $params as $option ) {
+				if ( $option != $value ) {
+					?><option value="<?php echo esc_attr( $option ) ?>"><?php echo esc_attr( $option ) ?></option><?php
+				}
+			}
+			?></select><?php
 		}
 	}
 
-	protected function post_select( $meta_key, $posts, $value, $multi, $placeholder = '--', $title, $label, $required, $form_id = NULL ) { 
+	public function post_select( $meta_key, $posts, $value, $multi, $title, $label, $required, $placeholder = '--', $form_id = NULL ) { 
 		global $post;
-		$selected = null;?>
-			<label for="<?php echo esc_attr( $meta_key ) ?>"><?php echo $title ? esc_attr( $title ) : esc_attr( $label ); ?></label>
-			<select class="<?php echo esc_attr($multi); echo "form-input_{$form_id}"; ?>" id="<?php echo esc_attr( $meta_key ) ?>" name="<?php echo esc_attr( $meta_key ) ?>[]" <?php echo $multi; ?>  <?php if ( $required ): echo 'required'; endif; ?>>
-				<?php if ( $multi == null ):
-						if ( empty( $value )  ): ?>
-							<option value='' selected>-- Nothing selected --</option>
-						<?php else: ?>
-					<option value=''>-- Nothing selected --</option>
-					<?php endif; 
-				endif; ?>
-				<?php foreach ( $posts as $p ):
-					if ( in_array($p->post_name, (array)$value) ):
-						$selected = "selected";
-					else:
-						$selected = null;
-					endif;?>
-					<option <?php echo $selected ?> value="<?php echo esc_attr( $p->post_name )?>"><?php echo $p->post_title; ?></option>
-				<?php endforeach; ?>
-			</select>			
-		<?php
+		$selected = null;
+		?><label for="<?php echo esc_attr( $meta_key ) ?>"><?php echo $title ? esc_attr( $title ) : esc_attr( $label ); ?></label><?php
+		?><select class="<?php echo $multi ? esc_attr( $multi ) . " ": null; echo "form-input_{$form_id}"; ?>" id="<?php echo esc_attr( $meta_key ) ?>" name="<?php echo esc_attr( $meta_key ) ?>[]"<?php echo " " . $multi; if ( $required ): echo ' required '; endif; ?>><?php
+			if ( $multi == null ) {
+				if ( empty( $value ) ) {
+					?><option selected value=""><?php echo esc_attr( $placeholder ); ?></option><?php
+				} else {
+					?><option value=""><?php echo esc_attr( $placeholder ); ?></option><?php
+				}
+			}
+			foreach ( $posts as $p ) {
+				if ( in_array($p->post_name, (array)$value) ) {
+					$selected = "selected";
+				} else {
+					$selected = null;
+				}
+				?><option <?php echo $selected ?> value="<?php echo esc_attr( $p->post_name )?>"><?php echo $p->post_title; ?></option><?php
+			}
+		?></select><?php
 	}
 
-	protected function taxonomy_as_meta( $slug, $params, $taxonomy, $key, $placeholder = '--', $value, $multi=null, $required, $form_id= NULL ) { // keep as slug?>
-		<select class="<?php echo esc_attr($multi); echo "form-input_{$form_id}"; ?>" name='<?php echo esc_attr( $slug )?>[]' <?php echo esc_attr( $multi )?>  <?php if ( $required ): echo 'required'; endif; ?>><?php
-			if ( isset( $value ) ):?>
-				<option selected value="<?php echo esc_attr( $value ) ?>" id="<?php echo esc_attr( $key ) ?>"><?php echo esc_html( $value ) ?></option><?php
-			else:?>
-			<option value="" id="no_<?php echo esc_attr( $slug ) ?>" name="<?php echo esc_attr( $slug ) ?>"><?php echo esc_html( $placeholder ) ?></option><?php
-			endif;
-				foreach ( $params as $term_id ):
-					$term = get_term_by( $field = 'id', $value = strval( $term_id ), $taxonomy, $output = OBJECT, $filter = 'raw' ); 
-					if ($term):?>
-					<option value="<?php echo esc_attr( $term->slug ) ?>"><?php echo esc_html( $term->name )  ?> (<?php echo esc_html( $term->count ) ?>)</option><?php
-					endif;
-				endforeach;?>
-		</select>
-		<?php
+	public function taxonomy_as_meta( $slug, $params, $taxonomy, $value, $multi = NULL, $placeholder = '--', $required = false, $form_id= NULL ) { // keep as slug
+		?><select class="<?php echo esc_attr($multi) . " "; echo "form-input_{$form_id}"; ?>" name="<?php echo esc_attr( $slug )?>[]" <?php echo esc_attr( $multi ) . " "; if ( $required ): echo 'required'; endif; ?>><?php
+			if ( isset( $value ) ) {
+				?><option selected value="<?php echo esc_attr( $value ) ?>" id="<?php echo esc_attr( $slug ) ?>" name="<?php echo esc_attr( $slug ) ?>"><?php echo esc_attr( $value ) ?></option><?php
+			} else {
+				?><option selected value="" id="no_<?php echo esc_attr( $slug ) ?>" name="<?php echo esc_attr( $slug ) ?>"><?php echo esc_attr( $placeholder ) ?></option><?php
+			}
+			foreach ( $params as $term_id ) {
+				$term = get_term_by( $field = 'id', $value = strval( $term_id ), $taxonomy, $output = OBJECT, $filter = 'raw' ); 
+				if ($term) {
+					?><option value="<?php echo esc_attr( $term->slug ) ?>"><?php echo esc_attr( $term->name ) ?> (<?php echo esc_attr( $term->count ) ?>)</option><?php
+				}
+			}
+		?></select><?php
 	}
 
 	/**
@@ -413,7 +395,7 @@ class HTML {
 	 * date_meta_box() the standard checklist for hierarchical categories will
 	 * be replaced with a month dropdown and text input fields for day and
 	 * year. The metabox will still need to be added with add_metabox and
-	 * attached to a callback (like date_callback()). A protected function,
+	 * attached to a callback (like date_callback()). A public function,
 	 * this method may only be called from within this class.
 	 *
 	 * @since 0.5.5
@@ -422,35 +404,28 @@ class HTML {
 	 * @uses get_grandchildren() to spit out list items for term items
 	 *
 	 * @param str  $taxonomy      the slug of the target taxonomy for this metabox (i.e., cfpb_input_date)
-	 * @param str  $tax_nice_name the name of the target taxonomy (i.e. Input Date)
 	 * @param bool $multiples     whether the term shoud append (true) or replace (false) existing terms
 	 **/
-	protected function date( $taxonomy, $tax_nice_name, $multiples = false, $required, $form_id = NULL ) {?>
-		<?php
-			$tax_name = stripslashes( $taxonomy );
-			global $post, $wp_locale;
+	public function date( $taxonomy, $multiple = false, $required=false, $form_id = NULL ) {
+		$tax_name = stripslashes( $taxonomy );
+		global $post, $wp_locale;
+		$month = NULL;
+		$day   = NULL;
+		$year  = NULL;
 
-			$month = NULL;
-			$day   = NULL;
-			$year  = NULL;
-
-			?><select id="<?php echo esc_attr( $tax_name ) ?>_month" name="<?php echo esc_attr( $tax_name ) ?>_month" class="<?php echo "form-input_{$form_id}"; ?>"><option selected="selected" value='<?php echo esc_attr( $month ) ?>' <?php if ( $required ): echo 'required'; endif; ?>>Month</option>
-		<?php
-			for ( $i = 1; $i < 13; $i++ ) {
-				?><option value="<?php echo esc_attr( $wp_locale->get_month( $i ) ) ?>"><?php echo esc_attr( $wp_locale->get_month( $i ) )  ?></option>
-		<?php } ?>
-		</select>
-		<input id="<?php echo esc_attr( $tax_name ) ?>_day" type="text" name="<?php echo esc_attr( $tax_name ) ?>_day" class="<?php echo "form-input_{$form_id}"; ?>" value="<?php echo esc_attr( $day ) ?>" size="2" maxlength="2" placeholder="DD"/>
-		<input id="<?php echo esc_attr( $tax_name ) ?>_year" type="text" name="<?php echo esc_attr( $tax_name ) ?>_year" class="<?php echo "form-input_{$form_id}"; ?>" value="<?php echo esc_attr( $year ) ?>" size="4" maxlength="4" placeholder="YYYY"/>
-		<?php
-			if ( $multiples == false ) { ?>
-		  <p class="howto">If one is set already, selecting a new month, day and year will override it.</p>
-		<?php } else { ?>
-		  <p class='howto'>Select a month, day and year to add another.</p>
-		<?php } ?>
-
-		<div class='tagchecklist'>
-		<?php
+		?><select id="<?php echo esc_attr( $tax_name ) ?>_month" name="<?php echo esc_attr( $tax_name ) ?>_month" class="<?php echo "form-input_{$form_id}"; ?>"><option selected="selected" value="<?php echo esc_attr( $month ) ?>" <?php if ( $required ): echo 'required'; endif; ?>>Month</option><?php
+		for ( $i = 1; $i < 13; $i++ ) {
+			?><option value="<?php echo esc_attr( $wp_locale->get_month( $i ) ) ?>"><?php echo esc_attr( $wp_locale->get_month( $i ) )  ?></option><?php 
+		} 
+		?></select><?php
+		?><input id="<?php echo esc_attr( $tax_name ) ?>_day" type="text" name="<?php echo esc_attr( $tax_name ) ?>_day" class="<?php echo "form-input_{$form_id}"; ?>" value="<?php echo esc_attr( $day ) ?>" size="2" maxlength="2" placeholder="DD"/><?php
+		?><input id="<?php echo esc_attr( $tax_name ) ?>_year" type="text" name="<?php echo esc_attr( $tax_name ) ?>_year" class="<?php echo "form-input_{$form_id}"; ?>" value="<?php echo esc_attr( $year ) ?>" size="4" maxlength="4" placeholder="YYYY"/><?php
+		if ( $multiple ) {
+			?><p class="howto">Select a month, day and year to add another.</p><?php 
+		} else {
+			?><p class="howto">If one is set already, selecting a new month, day and year will override it.</p><?php
+		} 
+		?><div class="tagchecklist"><?php
 			if ( has_term( '', $taxonomy, $post->id ) ) {
 				$terms = get_the_terms( $post->id, $tax_name );
 				$i     = 0;
@@ -458,20 +433,14 @@ class HTML {
 					// Checks if the current set term is wholly numeric (in this case a timestamp)
 					if ( is_numeric( $term->name ) ) {
 						$natdate = date( 'j F, Y', intval( $term->name ) );
-	?>
-			  <span><a id='<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>' class='datedelbutton <?php echo esc_attr( $term->name ) ?>'><?php echo esc_attr( $term->name ) ?></a>&nbsp;<?php echo esc_attr( $natdate ) ?></span>
-			<?php
+						?><span><a id="<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>" class="ntdelbutton<?php echo esc_attr( $term->name ) ?>"><?php echo esc_attr( $term->name ) ?></a>&nbsp;<?php echo $natdate ?></span><?php
 					} else {
-						$date = strtotime( $term->name ); // If it isn't, convert it to a timestamp -- why? ?>
-			<span><a id='<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>' class='datedelbutton <?php echo esc_attr( $date ) ?>'><?php echo esc_attr( $term->name ) ?></a>&nbsp;<?php echo esc_attr( $term->name ) ?></span>
-			<?php
+						?><span><a id="<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>" class="ntdelbutton<?php echo esc_attr( $term->name ) ?>"><?php echo esc_attr( $term->name ) ?></a>&nbsp;<?php echo esc_attr( $term->name ) ?></span><?php
 					}
-					HTML::hidden( 'rm_' . $tax_name . '_' . $i, null, null );
+					$this->hidden( 'rm_' . $tax_name . '_' . $i, null, null );
 					$i++;
 				}
 			}
-			?>
-		</div>
-	<?php
+		?></div><?php
 	}
 }

--- a/tests/test-meta_box_html.php
+++ b/tests/test-meta_box_html.php
@@ -29,8 +29,1310 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 
 		$HTML = new HTML();
 		\WP_Mock::wpPassthruFunction('esc_attr');
-		\WP_Mock::wpPassthruFunction('esc_html');
 		// Act
 		$HTML->draw($fields);
+	}
+
+	function testDrawWithEmptyFieldExpectsWPErrorReturned() {
+		// arrange
+		$field = array();
+		$HTML = new HTML();
+		$mock = $this->getMock('WP_Error');
+
+		//act
+		$error = $HTML->draw( $field );
+
+		//assert
+		$this->assertInstanceOf( 'WP_Error', $error );
+	}
+
+	function testDrawNotFormsetWithTitleExpectsH4Title() {
+		//arrange
+		$field = array(
+			'type' => 'text',
+			'title' => 'Test Title',
+			'meta_key' => 'field'
+		);
+		$HTML = new HTML();
+		$needle = '<h4 id="field" >Test Title</h4>';
+
+		//act
+		ob_start();
+		$HTML->draw( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDrawWithFieldTypeFormsetCallsDrawFormset() {
+		//arrange
+		$field = array(
+			'type' => 'formset'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'draw_formset', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'draw_formset' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw( $field );
+
+		//assert
+		// Passes when called for formset type
+	}
+
+	function testDrawWithFieldTypeFieldsetCallsPassFieldset() {
+		//arrange
+		$field = array(
+			'type' => 'fieldset'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'pass_fieldset', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'pass_fieldset' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw( $field );
+
+		//assert
+		// Passes when called for formset type
+	}
+
+	function testDrawWithInputFieldCallsDrawInput() {
+		//arrange
+		$field = array(
+			'type' => 'text'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'draw_input', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'draw_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw( $field );
+
+		//assert
+		// Passes when called for formset type
+	}
+
+	function testDrawWithSelectFieldCallsPassSelect() {
+		//arrange
+		$field = array(
+			'type' => 'select'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'pass_select', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'pass_select' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw( $field );
+
+		//assert
+		// Passes when called for formset type
+	}
+
+	function testDrawWithHiddenFieldCallsHidden() {
+		//arrange
+		$field = array(
+			'type' => 'hidden'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'hidden', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'hidden' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw( $field );
+
+		//assert
+		// Passes when called for formset type
+	}
+
+	function testDrawWithNonceFieldCallsWPNonceField() {
+		//arrange
+		$field = array(
+			'type' => 'nonce'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction('wp_nonce_field', array( 'times' => 1, ) );
+		\WP_Mock::wpPassthruFunction('plugin_basename', array( 'times' => 1, ) );
+
+		//act
+		$HTML->draw( $field );
+
+		//assert
+		// Passes when called for formset type
+	}
+
+	function testDrawFieldHasHowToGetsEchoed() {
+		//arrange
+		$field = array(
+			'howto' => 'Testing howto'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<p class="howto">Testing howto</p>';
+
+		//act
+		ob_start();
+		$HTML->draw( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDrawFieldWrapsWithCMSToolkitWrapperDiv() {
+		//arrange
+		$field = array( 'class' => 'test' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
+		$needle = '<div class="cms-toolkit-wrapper test"></div>';
+
+		//act
+		ob_start();
+		$HTML->draw( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDrawFormsetShowsNewInitialField() {
+		//arrange
+		$field = array( 
+			'init' => true,
+			'meta_key' => 'test',
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_post_custom' );
+		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
+		$needle = '<div id="test_formset">';
+
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDrawFormsetHidesAddLinkForExistingField() {
+		//arrange
+		$field = array( 
+			'fields' => array(
+				array(
+					'meta_key' => 'test_field',
+				),
+			),
+			'meta_key' => 'test' 
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		$HTML->method( 'get_formset_id' )
+			 ->will( $this->returnValue( 1 ) );
+		\WP_Mock::wpFunction( 'get_post_custom', array( 'return' => array('test_field' => 'add 1 hidden' ) ) );
+		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
+		$needle = 'add 1 hidden';
+
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDrawFormsetHidesNonexistentNoninitialField() {
+		//arrange
+		$field = array( 'meta_key' => 'test' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_post_custom' );
+		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
+		$needle = '<div id="test_formset" class="hidden new" disabled>';
+
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDrawFormsetHidesHeaderForInvisibleField() {
+		//arrange
+		$field = array(
+			'title' => 'Test Title',
+			'fields' => array(
+				array(
+					'meta_key' => 'test_field',
+				),
+			),
+			'meta_key' => 'test' 
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'get_post_custom' );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<h4 id="test_header" class="formset-header hidden">';
+		
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDrawFormsetShowsHeaderForVisibleField() {
+		//arrange
+		$field = array(
+			'title' => 'Test Title',
+			'fields' => array(
+				array(
+					'meta_key' => 'test_field',
+				),
+			),
+			'meta_key' => 'test',
+			'init' => true
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'get_post_custom' );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<h4 id="test_header" class="formset-header">';
+		
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDrawFormsetShowsRemoveButtonAndHidesAddButtonForVisibleField() {
+		//arrange
+		$field = array(
+			'title' => 'Test Title',
+			'fields' => array(
+				array(
+					'meta_key' => 'test_field',
+				),
+			),
+			'meta_key' => 'test' 
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_post_custom', array( 'return' => array('test_field' => 'data' ) ) );
+		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
+		$needle = '<div id="test_formset">';
+		$remove_button = '<a class="toggle_form_manager test remove " href="#remove-formset_">Remove</a>';
+		$add_button = '<a class="toggle_form_manager test add  hidden" href="#add-formset_">Add Test Title</a>';
+		
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+		$this->assertContains( $remove_button, $haystack );
+		$this->assertContains( $add_button, $haystack );
+	}	
+
+	function testDrawFormsetHidesRemoveButtonAndShowsAddButtonForInvisibleField() {
+		//arrange
+		$field = array(
+			'title' => 'Test Title',
+			'fields' => array(
+				array(
+					'meta_key' => 'test_field',
+				),
+			),
+			'meta_key' => 'test' 
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'get_post_custom' );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<div id="test_formset" class="hidden new" disabled>';
+		$remove_button = '<a class="toggle_form_manager test remove  hidden" href="#remove-formset_">Remove</a>';
+		$add_button = '<a class="toggle_form_manager test add " href="#add-formset_">Add Test Title</a>';
+		
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+		$this->assertContains( $remove_button, $haystack );
+		$this->assertContains( $add_button, $haystack );
+	}
+
+	function testDrawFormsetShouldCallGetPostCustom() {
+		//arrange
+		$field = array();
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_post_custom', array( 'times' => 1 ) );
+		
+		//act
+		$HTML->draw_formset( $field );
+
+		//assert
+		// Passes if get_post_custom() is called once.
+	}
+
+	function testDrawFormsetShouldCallGetFormsetID() {
+		//arrange
+		$field = array(
+			'meta_key' => 'test_0'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'get_formset_id' )
+			 ->	will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_formset( $field );
+
+		//assert
+		// Passes if get_formset_id() is called once.
+	}
+
+	function testDrawFormsetShouldCallGetExistingData() {
+		//arrange
+		$field = array(
+			'meta_key' => 'test_0'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'get_existing_data' )
+			 ->	will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_formset( $field );
+
+		//assert
+		// Passes if get_existing_data() is called once.
+	}
+
+	function testDrawFormsetShouldCallPassFieldset() {
+		//arrange
+		$field = array(
+			'meta_key' => 'test_0'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'pass_fieldset' ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'pass_fieldset' )
+			 ->	will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_formset( $field );
+
+		//assert
+		// Passes if pass_fieldset() is called once.
+	}
+
+	function testPassFieldsetCallsDrawThreeTimesForThreeFields() {
+		//arrange
+		$field = array(
+			'fields' => array(
+				'field',
+				'field',
+				'field',
+			),
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'draw', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 3 ) )
+			 ->method( 'draw' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->pass_fieldset( $field );
+
+		//arrange
+		// Passes if draw() is called 3 times
+	}
+
+	function testGetFormsetIDReturnsExpectedOutput() {
+		// arrange
+		$form_meta_key = 'test_0_3';
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$expected = '0-3';
+
+		//act
+		$actual = $HTML->get_formset_id( $form_meta_key );
+
+		//assert
+		$this->assertEquals( $actual, $expected );
+	}
+
+	function testGetExistingDataWithNonFieldsetFieldAddsExistingDataToArray() {
+		//arrange
+		$field = array(
+			'fields' => array(
+				array( 'meta_key' => 'field'),
+			),
+		);
+		$existing = array();
+		$data = array( 'field' => 'data' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$expected = array( 0 => 'data' );
+
+		// act
+		$HTML->get_existing_data( $field, $existing, $data );
+
+		// assert
+		$this->assertEquals( $existing, $expected );
+	}
+
+	function testPassSelectCallsSelectForSelectMultiselectAndTaxonomySelectTypes() {
+		//arrange
+		$selections = array();
+		$selections[0] = array('type' => 'select');
+		$selections[1] = array('type' => 'multiselect');
+		$selections[2] = array('type' => 'taxonomyselect');
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'select', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 3 ) )
+			 ->method( 'select' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		foreach ( $selections as $selection ) {
+			$HTML->pass_select( $selection );
+		}
+
+		//assert
+		// Passes when select() is called 3 times
+	}
+
+	function testPassSelectCallsTaxonomyAsMetaForTaxAsMetaType() {		
+		//arrange
+		$field = array( 'type' => 'tax_as_meta' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'taxonomy_as_meta', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'taxonomy_as_meta' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->pass_select( $field );
+
+		//assert
+		// Passes when taxonomy_as_meta() is called once
+	}
+
+	function testPassSelectCallsGetPosts() {
+		//arrange
+		$field = array('type' => 'post_select');
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'post_select', ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'get_posts', array( 'times' => 1 ) );
+		\WP_Mock::wpPassthruFunction( 'get_post_meta' );
+
+		//act
+		$HTML->pass_select( $field );
+
+		//assert
+		// Passes when get_posts() is called once
+	}
+
+	function testPassSelectCallsGetPostMeta() {
+		//arrange
+		$field = array('type' => 'post_select');
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'post_select', ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'get_posts' );
+		\WP_Mock::wpPassthruFunction( 'get_post_meta', array( 'times' => 1 ) );
+
+		//act
+		$HTML->pass_select( $field );
+
+		//assert
+		// Passes when get_posts() is called once
+	}
+
+	function testPassSelectCallsSelectForPostSelectAndPostMultiselectTypes() {
+		//arrange
+		$selections = array();
+		$selections[0] = array('type' => 'post_select');
+		$selections[1] = array('type' => 'post_multiselect');
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'post_select', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 2 ) )
+			 ->method( 'post_select' )
+			 ->will( $this->returnValue( true ) );
+		\WP_Mock::wpPassthruFunction( 'get_posts' );
+		\WP_Mock::wpPassthruFunction( 'get_post_meta' );
+
+		//act
+		foreach ( $selections as $selection ) {
+			$HTML->pass_select( $selection );
+		}
+
+		//assert
+		// Passes when select() is called 2 times
+	}
+
+	function testDrawInputCallsTextAreaForTextAreaType() {
+		//arrange
+		$field = array( 'type' => 'text_area' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'text_area', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'text_area' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_input( $field );
+
+		//assert
+		// Passes when text_area() is called once
+	}
+
+	function testDrawInputCallsSingleInputForNumberTextEmailURLTypes() {
+		//arrange
+		$fields = array(
+			array( 'type' => 'number' ),
+			array( 'type' => 'text' ),
+			array( 'type' => 'email' ),
+			array( 'type' => 'url' ),
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'single_input', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 4 ) )
+			 ->method( 'single_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		foreach ( $fields as $field ) {
+			$HTML->draw_input( $field );
+		}
+
+		//assert
+		// Passes when single_input() is called 4 times
+	}
+
+	function testDrawInputCallsDateForDateType() {
+		//arrange
+		$field = array( 'type' => 'date' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'date', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'date' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_input( $field );
+
+		//assert
+		// Passes when date() is called once
+	}
+
+	function testDrawInputCallsSingleInputForRadioTypeTwice() {
+		//arrange
+		$field = array( 'type' => 'radio' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'single_input', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 2 ) )
+			 ->method( 'single_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_input( $field );
+
+		//assert
+		// Passes when single_input() is called twice
+	}
+
+	function testDrawInputCallsBooleanInputForBooleanType() {
+		//arrange
+		$field = array( 'type' => 'boolean' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'boolean_input', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'boolean_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_input( $field );
+
+		//assert
+		// Passes when boolean_input() is called once
+	}
+
+	function testDrawInputCallsURLInputForLinkType() {
+		//arrange
+		$field = array( 'type' => 'link' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'url_input', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'url_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_input( $field );
+
+		//assert
+		// Passes when url_input() is called once
+	}
+
+	function testTextAreaDrawsLabelForFieldMetaKey() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label block-label" for="field">';
+
+		//act
+		ob_start();
+		$HTML->text_area( null, null, 'field', null, null, null, null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testTextAreaDrawsLabelForFieldMetaKeyWithTitle() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label block-label" for="field">title</label>';
+
+		//act
+		ob_start();
+		$HTML->text_area( null, null, 'field', null, 'title', null, null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testTextAreaDrawsLabelForFieldMetaKeyWithLabelIfNoTitle() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label block-label" for="field">label</label>';
+
+		//act
+		ob_start();
+		$HTML->text_area( null, null, 'field', null, null, 'label', null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testTextAreaDrawsTitleOverLabelIfBothExist() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label block-label" for="field">title</label>';
+
+		//act
+		ob_start();
+		$HTML->text_area( null, null, 'field', null, 'title', 'label', null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testTextAreaDrawsTextareaElement() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<textarea id="field_key" class="cms-toolkit-textarea form-input_12" name="field_key" rows="10" cols="40" value="This is the text." placeholder="Placeholder text." required>This is the text.</textarea>';
+
+		//act
+		ob_start();
+		$HTML->text_area( 10, 40, 'field_key', 'This is the text.', null, null, 'Placeholder text.', true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testSingleInputDrawsLabel() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label block-label" for="field">title</label>';
+
+		//act
+		ob_start();
+		$HTML->single_input( 'field', 'text', null, null, 'title', 'label', null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testSingleInputDrawsGivenTypeInput() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<input id="field" class="cms-toolkit-input form-input_12" name="field" type="text" maxlength="30" value="The text." placeholder="placeholder" required />';
+
+		//act
+		ob_start();
+		$HTML->single_input( 'field', 'text', 30, 'The text.', 'title', 'label', 'placeholder', true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testBooleanInputPrintsLabel() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label" for="field">title</label>';
+
+		//act
+		ob_start();
+		$HTML->boolean_input( 'field', 'title', null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testBooleanInputPrintsCheckboxInput() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<input id="field" class="cms-toolkit-checkbox form-input_12" name="field" type="checkbox" checked required />';
+
+		//act
+		ob_start();
+		$HTML->boolean_input( 'field', 'title', 'label', 'on', true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testURLInputCallsSingleInputTwice() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'single_input' ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$HTML->expects( $this->exactly( 2 ) )
+			 ->method( 'single_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->url_input( 'field', 'title', null, null, null );
+
+		//assert
+		// Passes when single_input() is called only once
+	}
+
+	function testURLInputPrintsDiv() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<div class="link-field field_key">';
+
+		//act
+		ob_start();
+		$HTML->url_input( 'field_key', null, null, null, null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testHiddenPrintsHiddenField() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<input class="cms-toolkit-input form-input_12" id="field_key" name="field_key" type="hidden" value="value" />';
+
+		//act
+		ob_start();
+		$HTML->hidden( 'field_key', 'value', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testSelectWithGivenTaxonomyCallsWPGetObjectTermsAndGetTheIDAndWPDropdownCategories() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_the_ID' );
+		\WP_Mock::wpFunction( 'wp_get_object_terms', array( 'return' => array() ) );
+		\WP_Mock::wpFunction( 'wp_dropdown_categories' );
+
+		//act
+		$HTML->select( null, null, 'tax', null, null, null, null, null, null, null );
+	}
+
+	function testSelectWithoutTaxonomyPrintsLabel() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label for="field_key">Title</label>';
+
+		//act
+		ob_start();
+		$HTML->select( 'field_key', array(), false, null, null, null, null, 'Title', null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testSelectWithoutTaxonomyAndWithoutOptionsPrintsSelectFieldWithOnlyBlankOption() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<select id="field_key" name="field_key[]" class="form-input_12" multiple required>';
+		$needle .= '<option selected value="">--</option></select>';
+
+		//act
+		ob_start();
+		$HTML->select( 'field_key', array(), false, true, null, '--', 'Title', null, true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testSelectWithoutTaxonomyAndWithOptionsPrintsSelectFieldWithBlankOptionSelected() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<option selected value="">--</option>';
+		$needle .= '<option value="option1">option1</option>';
+		$needle .= '<option value="option2">option2</option></select>';
+
+		//act
+		ob_start();
+		$HTML->select( 'field_key', array( 'option1', 'option2' ), false, true, null, '--', 'Title', null, true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testSelectWithoutTaxonomyAndWithOptionsPrintsSelectFieldWithValueSelected() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<option selected="selected" value="option1">option1</option>';
+		$needle .= '<option value="option2">option2</option></select>';
+
+		//act
+		ob_start();
+		$HTML->select( 'field_key', array( 'option1', 'option2' ), false, true, 'option1', '--', 'Title', null, true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testPostSelectPrintsLabel() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label for="field_key">title</label>';
+
+		//act
+		ob_start();
+		$HTML->post_select( 'field_key', array(), null, null, null, 'title', null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testPostSelectPrintsSelect() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<select class="multi form-input_12" id="field_key" name="field_key[]" multi required >';
+
+		//act
+		ob_start();
+		$HTML->post_select( 'field_key', array(), null, 'multi', 'title', null, true, '--', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testPostSelectPrintsBlankOptionSelectedWithoutValue() {
+		//arrange
+		$posts = array();
+		$post = new \StdClass;
+		$post->post_name = 'name1';
+		$post->post_title = 'title1';
+		array_push($posts, $post);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<option selected value="">--</option>';
+
+		//act
+		ob_start();
+		$HTML->post_select( 'field_key', $posts, null, null, 'Title', null, true, '--', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testPostSelectPrintsBlankOptionWithSelectedValue() {
+		//arrange
+		$posts = array();
+		$post = new \StdClass;
+		$post->post_name = 'name1';
+		$post->post_title = 'title1';
+		array_push($posts, $post);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<option selected value="name1">title1</option>';
+
+		//act
+		ob_start();
+		$HTML->post_select( 'field_key', $posts, 'name1', null, 'Title', null, true, '--', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testTaxonomyAsMetaPrintsSelect() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<select class="multi form-input_12" name="field_slug[]" multi required>';
+
+		//act
+		ob_start();
+		$HTML->taxonomy_as_meta( 'field_slug', array(), 'tax', null, 'multi', '--', true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testTaxonomyAsMetaPrintsBlankOptionSelectedWithoutValue() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$term = new \StdClass;
+		$term->slug = 'option1';
+		$term->name = 'Option 1';
+		$term->count = 2;
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'get_term_by', array( 'return' => $term ) );
+		$needle = '<option selected value="" id="no_field_slug" name="field_slug">--</option>';
+		$needle .= '<option value="option1">Option 1 (2)</option></select>';
+
+		//act
+		ob_start();
+		$HTML->taxonomy_as_meta( 'field_slug', array( 'option1' ), 'tax', null, 'multi',  '--', true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testTaxonomyAsMetaPrintsBlankOptionWithValueSelected() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$term = new \StdClass;
+		$term->slug = 'option2';
+		$term->name = 'Option 2';
+		$term->count = 1;
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'get_term_by', array( 'return' => $term ) );
+		$needle = '<option selected value="option1" id="field_slug" name="field_slug">option1</option>';
+		$needle .= '<option value="option2">Option 2 (1)</option></select>';
+
+		//act
+		ob_start();
+		$HTML->taxonomy_as_meta( 'field_slug', array( 'option2' ), 'tax', 'option1', 'multi', '--', true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDatePrintSelectElementWithGenericOptionSelected() {
+		//arrange
+		global $wp_locale;
+		$wp_locale = $this->getMockBuilder( '\WP_Locale' )
+						  ->setMethods( array( 'get_month' ) )
+						  ->getMock();
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$wp_locale->expects( $this->exactly( 24 ) )
+				  ->method( 'get_month' )
+				  ->will( $this->returnValue( 'month' ) );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpPassthruFunction( 'sanitize_text_field' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+		$needle = '<select id="tax_month" name="tax_month" class="form-input_12">';
+		$needle .= '<option selected="selected" value="" >Month</option>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', false ,false, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDatePrintsAll12Months() {
+		//arrange
+		global $wp_locale;
+		$wp_locale = $this->getMockBuilder( '\WP_Locale' )
+						  ->setMethods( array( 'get_month' ) )
+						  ->getMock();
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$wp_locale->expects( $this->exactly( 24 ) )
+				  ->method( 'get_month' )
+				  ->will( $this->returnValue( 'month' ) );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpPassthruFunction( 'sanitize_text_field' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+		$needle = '<option value="month">month</option><option value="month">month</option>';
+		$needle .= '<option value="month">month</option><option value="month">month</option>';
+		$needle .= '<option value="month">month</option><option value="month">month</option>';
+		$needle .= '<option value="month">month</option><option value="month">month</option>';
+		$needle .= '<option value="month">month</option><option value="month">month</option>';
+		$needle .= '<option value="month">month</option><option value="month">month</option></select>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', false ,false, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDatePrintsInputsForDayAndYear() {
+		//arrange
+		global $wp_locale;
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpPassthruFunction( 'sanitize_text_field' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+		$needle = '<input id="tax_day" type="text" name="tax_day" class="form-input_12" value="" size="2" maxlength="2" placeholder="DD"/>';
+		$needle .= '<input id="tax_year" type="text" name="tax_year" class="form-input_12" value="" size="4" maxlength="4" placeholder="YYYY"/>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', false ,false, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDatePrintsOutputMessageForSingleDate() {
+		//arrange
+		global $wp_locale;
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpPassthruFunction( 'sanitize_text_field' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+		$needle = '<p class="howto">If one is set already, selecting a new month, day and year will override it.</p>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax' );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDatePrintsMessageForMultipleDates() {
+		//arrange
+		global $wp_locale;
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpPassthruFunction( 'sanitize_text_field' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+		$needle = '<p class="howto">Select a month, day and year to add another.</p>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', true );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDatePrintsDateWhenStoredAsNumeric() {
+		//arrange
+		global $wp_locale;
+		$term = new \StdClass;
+		$term->name = '1420748634';
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpPassthruFunction( 'sanitize_text_field' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( $term ) ) );
+		$needle = '<span><a id="tax-check-num-0" class="ntdelbutton1420748634">1420748634</a>&nbsp;8 January, 2015</span>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', true );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+
+	function testDatePrintsDateWhenStoredAsString() {
+		//arrange
+		global $wp_locale;
+		$term = new \StdClass;
+		$term->name = '1 April, 1992';
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpPassthruFunction( 'sanitize_text_field' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( $term ) ) );
+		$needle = '<span><a id="tax-check-num-0" class="ntdelbutton1 April, 1992">1 April, 1992</a>&nbsp;1 April, 1992</span>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', true );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
 	}
 }


### PR DESCRIPTION
#### This pull request is 1 of 3 that add tests and does general refactoring

This adds tests for the inc/meta-box-models.php file that cover the new formset and fieldset types. I have changed the access modifier for the validate_fieldset() function to be public in order to test it. I have deemed it non-harmful to do so. **PLEASE**, think about the implications of keeping the access modifier public and make any concerns known before pulling it in. The other 2 pull requests have the same situation.

- [Model Pull Request](https://github.com/cfpb/cms-toolkit/pull/37)
- [View Pull Request](https://github.com/cfpb/cms-toolkit/pull/38)