### PR TITLE
Test and refactor for more test coverage and increase robustness

### DIFF
--- a/inc/README.md
+++ b/inc/README.md
@@ -157,19 +157,12 @@ into `save_post` as illustrated above.
 Because all of these functions are contained in classes you are extending, you 
 can overwrite them if needed. Just declare a function with the same name as the 
 one in the parent class and WordPress will use yours instead of ours. If you 
-want to still run the parent's version, you can always call `parent::
-overwritten_function_name()`. In certain cases you can also fully replace a 
-class from the cms-toolkit by injecting a new dependency. See the unit tests for
-an example of how to do this.
+want to still run the parent's version, you can always call `parent::overwritten_function_name()`. In certain cases you can also fully replace a class from the cms-toolkit by injecting a new dependency. See the unit tests for an example of how to do this.
 
 ### Fields
 
 A meta box class can accept many different field types that correspond to valid
-HTML elements. Each field array should contain the following keys: 'slug',
-'title', 'type', 'params', 'placeholder', 'howto', and 'meta_key'. It can also
-contain 'class', which assigns a class to a div wrapping the header and fields.
-With the exception of 'params' these are all strings. A field array like the
-following:
+HTML elements. Each field array should contain the following keys: 'slug', 'title' or 'label', 'type', 'params', 'placeholder', 'howto', and 'meta_key'. It can also contain 'class', which assigns a class to a div wrapping the header and fields. With the exception of 'params' these are all strings. A field array like the following:
 
 ```php 
 <?php 
@@ -208,11 +201,7 @@ correspond to IDs and classes used in the WordPress admin. Changing the value of
 below. Check the unit tests for examples of how to use each type.
 
 * `text_area` generates a text area meta box.
-* `wysiwyg` calls `wp_editor` to generate a text editor. Defaults to TinyMCE with
-Quicktags enabled. A `params` array is directly related to the `settings` array
-seen [here](http://codex.wordpress.org/Function_Reference/wp_editor) so use it
-the same way.
-that is used as the settings for the 
+* `wysiwyg` calls `wp_editor` to generate a text editor. Defaults to TinyMCE with Quicktags enabled. A `params` array is directly related to the `settings` array seen [here](http://codex.wordpress.org/Function_Reference/wp_editor) so use it the same way.
 * `number` generates an input field with the number type, optionally add a 
 'max_num' key to the params array to limit the length of input. For example:
 `'param' => array( 'max_length' => 2),` 
@@ -227,9 +216,7 @@ as an array like `array(0 => 'url', 1 => 'text')`;
 input fields for day and year 
 * `select` generates a `<select>` field with options specified in the 'params' 
 array. For example `'param' => array( 'one', 'two', 'three',),` 
-* `mutliselect` is identical to `select` except that it
-passes the 'multiple' attribute, generating a multiselect box styled with
-[multiselect.js](http://loudev.com) 
+* `mutliselect` is identical to `select` except that it passes the 'multiple' attribute, generating a multiselect box styled with [multiselect.js](http://loudev.com) 
 * `taxonomyselect` generates a `<select>`
 field with options pulled from the terms attached to the taxonomy specified in
 `meta_key` 

--- a/inc/README.md
+++ b/inc/README.md
@@ -216,7 +216,7 @@ as an array like `array(0 => 'url', 1 => 'text')`;
 input fields for day and year 
 * `select` generates a `<select>` field with options specified in the 'params' 
 array. For example `'param' => array( 'one', 'two', 'three',),` 
-* `mutliselect` is identical to `select` except that it passes the 'multiple' attribute, generating a multiselect box styled with [multiselect.js](http://loudev.com) 
+* `multiselect` is identical to `select` except that it passes the 'multiple' attribute, generating a multiselect box styled with [multiselect.js](http://loudev.com) 
 * `taxonomyselect` generates a `<select>`
 field with options pulled from the terms attached to the taxonomy specified in
 `meta_key` 

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -3,7 +3,7 @@ namespace CFPB\Utils\MetaBox;
 use \WP_Error;
 class HTML {
 
-	public $elements = array(
+	private $elements = array(
 		'selects' => array( 'select', 'multiselect', 'taxonomyselect', 'tax_as_meta', 'post_select', 'post_multiselect' ),
 		'inputs' => array( 'text_area', 'number', 'text', 'boolean', 'email', 'url', 'date', 'radio', 'link', ),
 		'hidden' => array( 'nonce', 'hidden', 'separator', 'fieldset' ),
@@ -12,84 +12,71 @@ class HTML {
 	public function draw( $field, $form_id = NULL ) {
 		if ( empty( $field ) ) {
 			return new WP_Error( 'field_required', 'You need to pass a field array to this method. You passed a '. gettype( $field ) . ' .');
-		}?>
-		<div class="cms-toolkit-wrapper<?php if (isset( $field['class'] )) { echo ' ' . esc_attr( $field['class'] ); } ?>"><?php
-		if ( $field['type'] !== 'formset' ) {
-			if ( isset( $field['title'] ) ) {
-				?><h4 id="<?php echo "{$field['meta_key']}"; ?>" ><?php
-					echo "{$field['title']}"; 
-				?></h4><?php
-			}
+		}
+		?><div class="cms-toolkit-wrapper<?php if (isset( $field['class'] )) { echo ' ' . esc_attr( $field['class'] ); } ?>"><?php
+		if ( $field['type'] !== 'formset' and isset( $field['title'] ) ) {
+			?><h4 id="<?php echo "{$field['meta_key']}"; ?>" ><?php
+				echo "{$field['title']}"; 
+			?></h4><?php
 		}
 		if ( $field['type'] == 'formset' ) {
 			$this->draw_formset( $field );
 		} elseif ( $field['type'] == 'fieldset' ) {
 			?><fieldset><?php
-				$this->pass_fieldset( $field, $form_id );
+				foreach ($field['fields'] as $f) {
+					$this->draw( $f, $form_id );
+				}
 			?></fieldset><?php				
 		} elseif ( in_array( $field['type'], $this->elements['inputs'] ) ) {
 			$this->draw_input( $field, $form_id );
 		} elseif ( in_array( $field['type'], $this->elements['selects'] ) ) {
 			$this->pass_select( $field, $form_id );
 		} elseif ( $field['type'] == 'hidden' ) {
-			HTML::hidden( $field['meta_key'], $field['value'], $form_id );
+			$this->hidden( $field['meta_key'], $field['value'], $form_id );
 		} elseif ( $field['type'] == 'nonce' ) {
 			wp_nonce_field( plugin_basename( __FILE__ ), $field['meta_key'] );
 		}
-		if ( isset( $field['howto'] ) ) { ?>
-			<p class="howto"><?php echo esc_html( $field['howto'] ) ?></p><?php
-		}?>
-		</div><?php
+		if ( isset( $field['howto'] ) ) { 
+			?><p class="howto"><?php echo esc_attr( $field['howto'] ) ?></p><?php
+		}
+		?></div><?php
 	}
 
-	private function draw_formset( $field ) {
+	public function draw_formset( $field ) {
 		global $post;
 		$post_id = $post->ID;	
 		$post_data = get_post_custom( $post_id );
 		$form_id = $this->get_formset_id( $field['meta_key'] );
 		$init = isset( $field['init'] ) ? true : false;
 		$existing = array();
-		$this->get_existing_data( $field, $existing, $post_data );?>
-		<div id="<?php echo "{$field['meta_key']}_formset"; ?>" <?php
-		  if ( empty( $existing ) and ! $init ) { echo 'class="hidden new" disabled'; } ?>><?php
-			if ( isset( $field['title'] ) ) {
-				?><h4 id="<?php echo "{$field['meta_key']}_header"; ?>" class="formset-header <?php
-				if ( empty( $existing ) and ! $init ) { echo 'hidden'; } ?>">
-					<?php echo $field['title'];
-				?> <a class="toggle_form_manager
-					<?php echo "{$field['meta_key']} remove {$form_id}";
-						  if ( empty( $existing ) and ! $init ) { echo " hidden"; } ?>"
-			   		href="#remove-formset_<?php echo $form_id; ?>">
-					<?php
-					if ( isset( $field['title'] ) ) {
-						echo "Remove";
-					} else {
-						echo "Remove formset " . ( $form_id + 1 );
-					}?>
-				</a></h4><?php
+		$this->get_existing_data( $field, $existing, $post_data );
+		?><div id="<?php echo "{$field['meta_key']}_formset"; ?>"<?php
+		  if ( empty( $existing ) and ! $init ) { echo ' class="hidden new" disabled'; } ?>><?php
+			?><h4 id="<?php echo "{$field['meta_key']}_header"; ?>" class="formset-header<?php
+			if ( empty( $existing ) and ! $init ) { echo ' hidden'; } ?>"><?php 
+				echo isset( $field['title'] ) ? $field['title'] : "Formset";
+				?><a class="toggle_form_manager <?php
+					echo "{$field['meta_key']} remove {$form_id}";
+					if ( empty( $existing ) and ! $init ) { echo " hidden"; } 
+					?>" href="#remove-formset_<?php echo $form_id; ?>">Remove</a><?php
+			?></h4><?php
+			foreach ($field['fields'] as $f) {
+				$this->draw( $f, $form_id );
 			}
-			$this->pass_fieldset( $field, $form_id );?>
-		</div>
-		<a class="toggle_form_manager
-			<?php echo "{$field['meta_key']} add {$form_id}";
-				  if ( ! empty( $existing ) or $init ) { echo " hidden"; } ?>"
-		   href="#add-formset_<?php echo $form_id; ?>">
-			<?php
+		?></div><?php
+		?><a class="toggle_form_manager <?php
+			echo "{$field['meta_key']} add {$form_id}";
+			if ( $existing or $init ) { echo " hidden"; } 
+			?>" href="#add-formset_<?php echo $form_id; ?>"><?php
 			if ( isset( $field['title'] ) ) {
 				echo "Add {$field['title']}";
 			} else {
-				echo "Add Formset " . ($form_id + 1);
-			}?>
-		</a><?php
+				echo "Add Formset";
+			}
+		?></a><?php
 	}
 
-	private function pass_fieldset( $field, $form_id = NULL ) {
-		foreach ($field['fields'] as $f) {
-			$this->draw( $f, $form_id );
-		}
-	}
-
-	private function get_formset_id( $form_meta_key ) {
+	public function get_formset_id( $form_meta_key ) {
 		$id = "";
 		$key_parts = explode( '_', $form_meta_key );
 		foreach ( $key_parts as $part ) {
@@ -103,7 +90,7 @@ class HTML {
 		return $id;
 	}
 
-	private function get_existing_data( $field, &$existing, $data ) {
+	public function get_existing_data( $field, &$existing, $data ) {
 		foreach ( $field['fields'] as $f ) {
 			if ( $f['type'] == 'fieldset' ) {
 				$this->get_existing_data( $f, $existing, $data );
@@ -117,35 +104,32 @@ class HTML {
 		}
 	}
 
-	private function pass_select( $field, $form_id = NULL ) {
+	public function pass_select( $field, $form_id = NULL ) {
+		$taxonomy = isset( $field['taxonomy'] ) ? $field['taxonomy'] : false;
 		$required = isset( $field['required'] ) ? $field['required'] : false;
-		$key = isset( $field['meta_key'] ) ? $field['meta_key'] : $field['slug'];
-		$label = isset( $field['label'] ) ? $field['label'] : null;
-		$title = isset( $field['title'] ) ? $field['title'] : null;
-		$multi = isset( $field['multiple'] ) ? $field['multiple'] : null;
+		$multi = isset( $field['multiple'] ) ? $field['multiple'] : false;
 		if ( in_array( $field['type'], array('multiselect', 'select', 'taxonomyselect' ) ) ) {
-			HTML::select( 
-				$key, 
+			$this->select( 
+				$field['meta_key'], 
 				$field['params'], 
-				$field['taxonomy'], 
-				$multi, 
-				$field['placeholder'],
-				$title,
-				$label,
+				$taxonomy, 
+				$multi,
+				$field['value'],
 				$required,
+				$field['placeholder'],
+				$field['label'],
 				$form_id
 			);
 		} elseif ( $field['type'] == 'tax_as_meta' ) {
-			HTML::taxonomy_as_meta(
+			$this->taxonomy_as_meta(
 				$slug = $field['slug'],
 				$params = $field['include'],
-				$taxonomy = $field['taxonomy'],
-				$key,
-				$placeholder = $field['placeholder'],
+				$taxonomy = $taxonomy,
 				$value = $field['value'],
-				$title,
-				$label,
+				$multi,
 				$required,
+				$field['label'],
+				$placeholder = $field['placeholder'],
 				$form_id
 			);
 		} elseif ( $field['type'] == 'post_select' || $field['type'] == 'post_multiselect' ) {
@@ -154,56 +138,54 @@ class HTML {
 			$posts = get_posts($args);
 			$value = get_post_meta( $post->ID, $field['meta_key'], $single = false );
 			$multi = $field['type'] == 'post_multiselect' ? 'multiple' : null;
-			HTML::post_select(
-				$meta_key = $field['meta_key'],
+			$this->post_select(
+				$field['meta_key'],
 				$posts,
 				$value,
 				$multi,
-				$placeholder = $field['placeholder'],
-				$title,
-				$label,
 				$required,
+				$field['label'],
+				$field['placeholder'],
 				$form_id
 			);
 		}
 	}
 
-	private function draw_input( $field, $form_id = NULL ) {
+	public function draw_input( $field, $form_id = NULL ) {
 		$required = isset( $field['required'] ) ? $field['required'] : false;
 		$value = isset( $field['value'] ) ? $field['value'] : null;
 		$label = isset( $field['label'] ) ? $field['label'] : null;
-		$title = isset( $field['title'] ) ? $field['title'] : null;
-		$tax_nice_name = $title ? $title : $label;
+		$max_length = isset ( $field['max_length'] ) ? $field['max_length'] : null;
 		if ( $field['type'] == 'text_area' ) {
-			HTML::text_area( $field['rows'], $field['cols'], $field['meta_key'], $value, $title, $label, $field['placeholder'], $required, $form_id );
+			$this->text_area( $field['meta_key'], $value, $required, $field['rows'], $field['cols'], $label, $field['placeholder'], $form_id );
 		}
 
 		if ( in_array( $field['type'], array( 'number', 'text', 'email', 'url' ) ) ) {
-			HTML::single_input( $field['meta_key'], $field['type'], $field['max_length'], $value, $title, $label, $field['placeholder'], $required, $form_id );
+			$this->single_input( $field['meta_key'], $value, $field['type'], $required, $max_length, $label, $field['placeholder'], $form_id );
 		}
 
 		if ( $field['type'] == 'date' ) {
-			HTML::date( $taxonomy = $field['taxonomy'], $tax_nice_name, $multiples = $field['multiple'], $required, $form_id );
+			$this->date( $field['taxonomy'], $field['multiple'], $required, $label, $form_id );
 		}
 
 		if ( $field['type'] == 'radio' ) {
-			HTML::single_input( $field['meta_key'], $field['type'] = 'radio', $max_length = null, $value = 'true', $title, $label, $field['placeholder'], $required, $form_id );
-			HTML::single_input( $field['meta_key'], $field['type'] = 'radio', $max_length = null, $value = 'false', $title, $label, $field['placeholder'], $required, $form_id );
+			$this->single_input( $field['meta_key'], $value = 'true', $field['type'] = 'radio', $required, $max_length = null, $label, $field['placeholder'], $form_id );
+			$this->single_input( $field['meta_key'], $value = 'false', $field['type'] = 'radio', $required, $max_length = null,  $label, $field['placeholder'], $form_id );
 		}
 
 		if ( $field['type'] == 'boolean' ) {
-			HTML::boolean_input( $field['meta_key'], $title, $label, $value, $required, $form_id );
+			$this->boolean_input( $field['meta_key'], $value, $required, $label, $form_id );
 		}
 
 		if ( $field['type'] == 'link' ) {
-			HTML::url_input($field['meta_key'], $value, $title, $label, $required, $form_id );
+			$this->link_input($field['meta_key'], $value, $required, $label, $form_id );
 		}
 	}
 
 /**
 	 * Generate a <textarea> field
 	 *
-	 * Generates a textarea HTML field using defined parameters A protected
+	 * Generates a textarea HTML field using defined parameters A public
 	 * function, this method may only be called from within this class.
 	 *
 	 * All parameters are required
@@ -214,20 +196,22 @@ class HTML {
 	 * @param str $value a default value for the <textarea>
 	 *
 	**/
-	protected function text_area( $rows, $cols, $meta_key, $value, $title, $label, $placeholder, $required, $form_id = NULL ) {
-		?>
-		<label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>">
-			<?php echo $title ? esc_attr( $title ) : esc_attr( $label ); if ( $required ): echo ' (required)'; endif; ?>
-		</label>
-		<textarea id="<?php echo esc_attr( $meta_key ) ?>"
-				  class="cms-toolkit-textarea <?php echo "form-input_{$form_id}"; ?>"
-				  name="<?php echo esc_attr( $meta_key ) ?>"
-				  rows="<?php echo esc_attr( $rows ) ?>"
-				  cols="<?php echo esc_attr( $cols ) ?>"
-				  value="<?php echo esc_attr( $value ) ?>"
-				  placeholder="<?php echo esc_attr( $placeholder ) ?>"
-				  <?php if ( $required ): echo 'required'; endif; ?>><?php echo esc_html( $value ) ?></textarea>
-		<?php
+	public function text_area( $meta_key, $value, $required, $rows, $cols, $label, $placeholder, $form_id = NULL ) {
+		if ( $label ) {
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php 
+				echo esc_attr( $label ); if ( $required ): echo ' (required)'; endif; 
+			?></label><?php
+		}
+		// wp_editor( $value, $meta_key );
+		?><textarea id="<?php echo esc_attr( $meta_key ) 
+				  ?>" class="cms-toolkit-textarea <?php echo "form-input_{$form_id}"; 
+				  ?>" name="<?php echo esc_attr( $meta_key ) 
+				  ?>" rows="<?php echo esc_attr( $rows ) 
+				  ?>" cols="<?php echo esc_attr( $cols ) 
+				  ?>" value="<?php echo esc_attr( $value ) 
+				  ?>" placeholder="<?php echo esc_attr( $placeholder ) ?>"<?php
+				   if ( $required ): echo ' required'; endif; ?>><?php echo esc_attr( $value ) 
+		?></textarea><?php
 	}
 
 	/**
@@ -236,7 +220,7 @@ class HTML {
 	 * A single <input> is generated based on defined parameters.
 	 *
 	 * Slug and type parameters are required, all others default to null. A
-	 * protected function, this method may only be called from within this
+	 * public function, this method may only be called from within this
 	 * class.
 	 *
 	 * @param str $meta_key the meta_key for this field, used as 'name' and 'id'
@@ -248,50 +232,48 @@ class HTML {
 	 * @since 1.0
 	 *
 	**/
-	protected function single_input( $meta_key, $type, $max_length = NULL, $value = NULL, $title, $label = NULL, $placeholder = NULL, $required, $form_id = NULL ) {
+	public function single_input( $meta_key, $value, $type, $required, $max_length, $label, $placeholder, $form_id = NULL ) {
 		$value       = 'value="' . $value . '"';
 		$max_length  = 'maxlength="' . $max_length . '"';
 		$placeholder = 'placeholder="' . $placeholder . '"';
-		?>
-		<label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>">
-			<?php echo $title ? esc_attr( $title ) : esc_attr( $label ); if ( $required ): echo ' (required)'; endif; ?>
-		</label>
-		<input id="<?php echo esc_attr( $meta_key ) ?>"
-			   class="cms-toolkit-input <?php echo "form-input_{$form_id}"; ?>"
-			   name="<?php echo esc_attr( $meta_key ) ?>"
-			   type="<?php echo esc_attr( $type ) ?>"
-			   <?php echo " $max_length $value $placeholder" ?>
-			   <?php if ( $required ): echo 'required '; endif; ?>/>
-		<?php
+		if ( $label ) {
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php 
+				echo esc_attr( $label ); if ( $required ): echo ' (required)'; endif; 
+			?></label><?php
+		}
+		?><input id="<?php echo esc_attr( $meta_key ) 
+			   ?>" class="cms-toolkit-input <?php echo "form-input_{$form_id}"; 
+			   ?>" name="<?php echo esc_attr( $meta_key ) 
+			   ?>" type="<?php echo esc_attr( $type ) ?>"<?php 
+			   echo " $max_length $value $placeholder";
+			   if ( $required ): echo ' required '; endif; ?>/><?php
 	}
 
-	protected function boolean_input( $meta_key, $title, $label, $value, $required, $form_id = NULL ) {
-		?>
-		<input id="<?php echo esc_attr( $meta_key ) ?>"
-			   class="cms-toolkit-checkbox <?php echo "form-input_{$form_id}"; ?>"
-			   name="<?php echo esc_attr( $meta_key ) ?>"
-			   type="checkbox"
-			   <?php if ( $value == 'on' ) { echo 'checked'; } ?>
-			   <?php if ( $required ) { echo 'required'; } ?>/>
-		<label class="cms-toolkit-label" for="<?php echo esc_attr( $meta_key ) ?>">
-			<?php echo $title ? esc_attr( $title ) : esc_attr( $label ); if ( $required ): echo ' (required)'; endif; ?>
-		</label>
-		<?php
+	public function boolean_input( $meta_key, $value, $required, $label, $form_id = NULL ) {
+		?><input id="<?php echo esc_attr( $meta_key ) 
+			   ?>" class="cms-toolkit-checkbox <?php echo "form-input_{$form_id}"; 
+			   ?>" name="<?php echo esc_attr( $meta_key ) 
+			   ?>" type="checkbox" <?php
+			   if ( $value == 'on' ) { echo 'checked '; }
+			   if ( $required ) { echo 'required '; } ?>/><?php
+		if ( $label ) {
+			?><label class="cms-toolkit-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php
+			 echo esc_attr( $label ); if ( $required ): echo ' (required)'; endif; 
+			?></label><?php
+		}
 	}
 
-	protected function url_input( $meta_key, $value = NULL, $title, $label, $required, $form_id = NULL ) {
+	public function link_input( $meta_key, $value, $required, $label, $form_id = NULL ) {
 		global $post;
 		$post_id = $post->ID;
-		?>
-		<div class="link-field <?php echo "{$meta_key}" ?>">
-		<?php
 		$existing = get_post_meta( $post_id, $meta_key, false);
+		?><div class="link-field <?php echo "{$meta_key}" ?>"><?php
 		if ( ! isset( $existing[0] ) || ! isset( $existing[1] ) ) { 
-				HTML::single_input( $meta_key . "_text", 'text', NULL, $value, NULL, 'Text', NULL, $required, $form_id );
-				HTML::single_input( $meta_key . "_url", 'url', NULL, $value, NULL, 'URL', NULL, $required, $form_id );
+				$this->single_input( $meta_key . "_text", $value, 'text', $required, NULL, 'Text', 'Url text here', $form_id );
+				$this->single_input( $meta_key . "_url", $value, 'url', $required, NULL, 'URL', 'Url here', $form_id );
 		} else { 
-				HTML::single_input( $meta_key . "_text", 'text', NULL, $existing[1], NULL, 'Text', NULL, $required, $form_id );
-				HTML::single_input( $meta_key . "_url", 'url', NULL, $existing[0], NULL, 'URL', NULL, $required, $form_id );
+				$this->single_input( $meta_key . "_text", $existing[1], 'text', $required, NULL, 'Text', NULL, $form_id );
+				$this->single_input( $meta_key . "_url", $existing[0], 'url', $required, NULL, 'URL', NULL, $form_id );
 		}
 		?></div><?php
 	}
@@ -299,13 +281,11 @@ class HTML {
 	/**
 	 *  Generates a hidden field
 	**/
-	protected function hidden( $meta_key, $value, $form_id ) { ?>
-		<input class="cms-toolkit-input <?php echo "form-input_{$form_id}";?>"
-			   id="<?php echo esc_attr( $meta_key ) ?>"
-			   name="<?php echo esc_attr( $meta_key ) ?>"
-			   type="hidden"
-			   value="<?php echo esc_attr( $value ) ?>" />
-	<?php
+	public function hidden( $meta_key, $value, $form_id ) {
+		?><input class="cms-toolkit-input <?php echo "form-input_{$form_id}";
+			   ?>" id="<?php echo esc_attr( $meta_key ) 
+			   ?>" name="<?php echo esc_attr( $meta_key ) 
+			   ?>" type="hidden" value="<?php echo esc_attr( $value ) ?>" /><?php
 	}
 
 	/**
@@ -318,7 +298,7 @@ class HTML {
 	 * use it on has a term from that taxonomy it will be autoselected. Select
 	 * and multi-select fields use an array in the $param parameter to generate
 	 * options. To make a select a multi-select, just pass 'true' to the fifth
-	 * parameter. A protected function, this method may only be called from
+	 * parameter. A public function, this method may only be called from
 	 * within this class.
 	 *
 	 * @since v1.0
@@ -338,71 +318,73 @@ class HTML {
 	 *              if no value selected. Default: '--'
 	 *
 	**/
-	protected function select( $meta_key, $params = array(), $taxonomy = false, $multi = null, $value = null, $placeholder = '--', $title, $label, $required, $form_id = NULL ) {
-		if ( $taxonomy != false ) { // if a taxonomy is set, use wp_dropdown category to generate the select box
+	public function select( $meta_key, $params, $taxonomy, $multi, $value, $required, $placeholder, $label, $form_id = NULL ) {
+		if ( $label ) {
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php echo esc_attr( $label ); ?></label><?php
+		}		
+		if ( $taxonomy ) { // if a taxonomy is set, use wp_dropdown category to generate the select box
 			$IDs = wp_get_object_terms( get_the_ID(), $taxonomy, array( 'fields' => 'ids' ) );
 			wp_dropdown_categories( 'taxonomy=' . $taxonomy . '&hide_empty=0&orderby=name&name=' . $taxonomy . '&show_option_none=Select ' . $taxonomy . '&selected='. array_pop($IDs) );
 		} else {	// otherwise use all the values set in $param to generate the option
-				$multiple = isset($multi) ? 'multiple' : null;
-				?> 
-				<label for="<?php echo esc_attr($meta_key) ?>"><?php echo $title ? esc_attr( $title ) : esc_attr( $label ); ?></label>
-				<select id="<?php echo esc_attr( $meta_key ) ?>" name="<?php echo esc_attr( $meta_key ) ?>[]" class="<?php echo "form-input_{$form_id}"; ?>" <?php echo $multiple ?> <?php if ( $required ): echo 'required'; endif; ?>>
-				<?php
-				if ( empty( $value ) ) { ?>
-					<option selected value=""><?php echo esc_html( $placeholder ) ?></option>
-				<?php
-				} else { ?>
-					<option value=""><?php echo esc_html( $placeholder ) ?></option>
-					<option selected="selected" value="<?php echo esc_attr( $value ) ?>"><?php echo esc_html( $value ) ?></option><?php
-				}
-
-			foreach ( $params as $option ) { ?>
-				<option value="<?php echo esc_attr( $option ) ?>"><?php echo esc_html( $option ) ?></option>
-			<?php
+			$multiple = isset($multi) ? 'multiple' : null;
+			?><select id="<?php echo esc_attr( $meta_key ) ?>" name="<?php echo esc_attr( $meta_key ) ?>[]" class="<?php echo "form-input_{$form_id}"; ?>" <?php echo $multiple ?> <?php if ( $required ): echo 'required'; endif; ?>><?php
+			if ( empty( $value ) ) {
+				?><option selected value=""><?php echo esc_attr( $placeholder ) ?></option><?php
+			} else {
+				?><option value=""><?php echo esc_attr( $placeholder ) ?></option><?php
+				?><option selected="selected" value="<?php echo esc_attr( $value ) ?>"><?php echo esc_attr( $value ) ?></option><?php
 			}
-		?>	</select> <?php
+			foreach ( $params as $option ) {
+				if ( $option != $value ) {
+					?><option value="<?php echo esc_attr( $option ) ?>"><?php echo esc_attr( $option ) ?></option><?php
+				}
+			}
+			?></select><?php
 		}
 	}
 
-	protected function post_select( $meta_key, $posts, $value, $multi, $placeholder = '--', $title, $label, $required, $form_id = NULL ) { 
+	public function post_select( $meta_key, $posts, $value, $multi, $required, $label, $placeholder, $form_id = NULL ) { 
 		global $post;
-		$selected = null;?>
-			<label for="<?php echo esc_attr( $meta_key ) ?>"><?php echo $title ? esc_attr( $title ) : esc_attr( $label ); ?></label>
-			<select class="<?php echo esc_attr($multi); echo "form-input_{$form_id}"; ?>" id="<?php echo esc_attr( $meta_key ) ?>" name="<?php echo esc_attr( $meta_key ) ?>[]" <?php echo $multi; ?>  <?php if ( $required ): echo 'required'; endif; ?>>
-				<?php if ( $multi == null ):
-						if ( empty( $value )  ): ?>
-							<option value='' selected>-- Nothing selected --</option>
-						<?php else: ?>
-					<option value=''>-- Nothing selected --</option>
-					<?php endif; 
-				endif; ?>
-				<?php foreach ( $posts as $p ):
-					if ( in_array($p->post_name, (array)$value) ):
-						$selected = "selected";
-					else:
-						$selected = null;
-					endif;?>
-					<option <?php echo $selected ?> value="<?php echo esc_attr( $p->post_name )?>"><?php echo $p->post_title; ?></option>
-				<?php endforeach; ?>
-			</select>			
-		<?php
+		$selected = null;
+		if ( $label ) {
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php echo esc_attr( $label ); ?></label><?php
+		}
+		?><select class="<?php echo "form-input_{$form_id}"; ?>" id="<?php echo esc_attr( $meta_key ) ?>" name="<?php echo esc_attr( $meta_key ) ?>[]"<?php echo " " . $multi; if ( $required ): echo ' required '; endif; ?>><?php
+			if ( $multi == null ) {
+				if ( empty( $value ) ) {
+					?><option selected value=""><?php echo esc_attr( $placeholder ); ?></option><?php
+				} else {
+					?><option value=""><?php echo esc_attr( $placeholder ); ?></option><?php
+				}
+			}
+			foreach ( $posts as $p ) {
+				if ( in_array($p->post_name, (array)$value) ) {
+					$selected = "selected";
+				} else {
+					$selected = null;
+				}
+				?><option <?php echo $selected ?> value="<?php echo esc_attr( $p->post_name )?>"><?php echo $p->post_title; ?></option><?php
+			}
+		?></select><?php
 	}
 
-	protected function taxonomy_as_meta( $slug, $params, $taxonomy, $key, $placeholder = '--', $value, $multi=null, $required, $form_id= NULL ) { // keep as slug?>
-		<select class="<?php echo esc_attr($multi); echo "form-input_{$form_id}"; ?>" name='<?php echo esc_attr( $slug )?>[]' <?php echo esc_attr( $multi )?>  <?php if ( $required ): echo 'required'; endif; ?>><?php
-			if ( isset( $value ) ):?>
-				<option selected value="<?php echo esc_attr( $value ) ?>" id="<?php echo esc_attr( $key ) ?>"><?php echo esc_html( $value ) ?></option><?php
-			else:?>
-			<option value="" id="no_<?php echo esc_attr( $slug ) ?>" name="<?php echo esc_attr( $slug ) ?>"><?php echo esc_html( $placeholder ) ?></option><?php
-			endif;
-				foreach ( $params as $term_id ):
-					$term = get_term_by( $field = 'id', $value = strval( $term_id ), $taxonomy, $output = OBJECT, $filter = 'raw' ); 
-					if ($term):?>
-					<option value="<?php echo esc_attr( $term->slug ) ?>"><?php echo esc_html( $term->name )  ?> (<?php echo esc_html( $term->count ) ?>)</option><?php
-					endif;
-				endforeach;?>
-		</select>
-		<?php
+	public function taxonomy_as_meta( $slug, $params, $taxonomy, $value, $multi, $required, $label, $placeholder, $form_id= NULL ) { // keep as slug
+		if ( $label ) {
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $slug ) ?>"><?php echo esc_attr( $label ); ?></label><?php
+		}
+		?><select class="<?php echo esc_attr($multi) . " "; echo "form-input_{$form_id}"; ?>" name="<?php echo esc_attr( $slug )?>[]" <?php echo esc_attr( $multi ) . " "; if ( $required ): echo 'required'; endif; ?>><?php
+			if ( isset( $value ) ) {
+				?><option selected value="<?php echo esc_attr( $value ) ?>" id="<?php echo esc_attr( $slug ) ?>" name="<?php echo esc_attr( $slug ) ?>"><?php echo esc_attr( $value ) ?></option><?php
+			} else {
+				?><option selected value="" id="no_<?php echo esc_attr( $slug ) ?>" name="<?php echo esc_attr( $slug ) ?>"><?php echo esc_attr( $placeholder ) ?></option><?php
+			}
+			foreach ( $params as $term_id ) {
+				$term = get_term_by( $field = 'id', $value = strval( $term_id ), $taxonomy, $output = OBJECT, $filter = 'raw' ); 
+				if ($term) {
+					?><option value="<?php echo esc_attr( $term->slug ) ?>"><?php echo esc_attr( $term->name ) ?> (<?php echo esc_attr( $term->count ) ?>)</option><?php
+				}
+			}
+		?></select><?php
 	}
 
 	/**
@@ -413,7 +395,7 @@ class HTML {
 	 * date_meta_box() the standard checklist for hierarchical categories will
 	 * be replaced with a month dropdown and text input fields for day and
 	 * year. The metabox will still need to be added with add_metabox and
-	 * attached to a callback (like date_callback()). A protected function,
+	 * attached to a callback (like date_callback()). A public function,
 	 * this method may only be called from within this class.
 	 *
 	 * @since 0.5.5
@@ -422,35 +404,31 @@ class HTML {
 	 * @uses get_grandchildren() to spit out list items for term items
 	 *
 	 * @param str  $taxonomy      the slug of the target taxonomy for this metabox (i.e., cfpb_input_date)
-	 * @param str  $tax_nice_name the name of the target taxonomy (i.e. Input Date)
 	 * @param bool $multiples     whether the term shoud append (true) or replace (false) existing terms
 	 **/
-	protected function date( $taxonomy, $tax_nice_name, $multiples = false, $required, $form_id = NULL ) {?>
-		<?php
-			$tax_name = stripslashes( $taxonomy );
-			global $post, $wp_locale;
+	public function date( $taxonomy, $multiple, $required, $label, $form_id = NULL ) {
+		$tax_name = stripslashes( $taxonomy );
+		global $post, $wp_locale;
+		$month = NULL;
+		$day   = NULL;
+		$year  = NULL;
 
-			$month = NULL;
-			$day   = NULL;
-			$year  = NULL;
-
-			?><select id="<?php echo esc_attr( $tax_name ) ?>_month" name="<?php echo esc_attr( $tax_name ) ?>_month" class="<?php echo "form-input_{$form_id}"; ?>"><option selected="selected" value='<?php echo esc_attr( $month ) ?>' <?php if ( $required ): echo 'required'; endif; ?>>Month</option>
-		<?php
-			for ( $i = 1; $i < 13; $i++ ) {
-				?><option value="<?php echo esc_attr( $wp_locale->get_month( $i ) ) ?>"><?php echo esc_attr( $wp_locale->get_month( $i ) )  ?></option>
-		<?php } ?>
-		</select>
-		<input id="<?php echo esc_attr( $tax_name ) ?>_day" type="text" name="<?php echo esc_attr( $tax_name ) ?>_day" class="<?php echo "form-input_{$form_id}"; ?>" value="<?php echo esc_attr( $day ) ?>" size="2" maxlength="2" placeholder="DD"/>
-		<input id="<?php echo esc_attr( $tax_name ) ?>_year" type="text" name="<?php echo esc_attr( $tax_name ) ?>_year" class="<?php echo "form-input_{$form_id}"; ?>" value="<?php echo esc_attr( $year ) ?>" size="4" maxlength="4" placeholder="YYYY"/>
-		<?php
-			if ( $multiples == false ) { ?>
-		  <p class="howto">If one is set already, selecting a new month, day and year will override it.</p>
-		<?php } else { ?>
-		  <p class='howto'>Select a month, day and year to add another.</p>
-		<?php } ?>
-
-		<div class='tagchecklist'>
-		<?php
+		if ( $label ) {
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $taxonomy ) ?>"><?php echo esc_attr( $label ); ?></label><?php
+		}
+		?><select id="<?php echo esc_attr( $tax_name ) ?>_month" name="<?php echo esc_attr( $tax_name ) ?>_month" class="<?php echo "form-input_{$form_id}"; ?>"><option selected="selected" value="<?php echo esc_attr( $month ) ?>" <?php if ( $required ): echo 'required'; endif; ?>>Month</option><?php
+		for ( $i = 1; $i < 13; $i++ ) {
+			?><option value="<?php echo esc_attr( $wp_locale->get_month( $i ) ) ?>"><?php echo esc_attr( $wp_locale->get_month( $i ) )  ?></option><?php 
+		} 
+		?></select><?php
+		?><input id="<?php echo esc_attr( $tax_name ) ?>_day" type="text" name="<?php echo esc_attr( $tax_name ) ?>_day" class="<?php echo "form-input_{$form_id}"; ?>" value="<?php echo esc_attr( $day ) ?>" size="2" maxlength="2" placeholder="DD"/><?php
+		?><input id="<?php echo esc_attr( $tax_name ) ?>_year" type="text" name="<?php echo esc_attr( $tax_name ) ?>_year" class="<?php echo "form-input_{$form_id}"; ?>" value="<?php echo esc_attr( $year ) ?>" size="4" maxlength="4" placeholder="YYYY"/><?php
+		if ( $multiple ) {
+			?><p class="howto">Select a month, day and year to add another.</p><?php 
+		} else {
+			?><p class="howto">If one is set already, selecting a new month, day and year will override it.</p><?php
+		} 
+		?><div class="tagchecklist"><?php
 			if ( has_term( '', $taxonomy, $post->id ) ) {
 				$terms = get_the_terms( $post->id, $tax_name );
 				$i     = 0;
@@ -458,20 +436,14 @@ class HTML {
 					// Checks if the current set term is wholly numeric (in this case a timestamp)
 					if ( is_numeric( $term->name ) ) {
 						$natdate = date( 'j F, Y', intval( $term->name ) );
-	?>
-			  <span><a id='<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>' class='datedelbutton <?php echo esc_attr( $term->name ) ?>'><?php echo esc_attr( $term->name ) ?></a>&nbsp;<?php echo esc_attr( $natdate ) ?></span>
-			<?php
+						?><span><a id="<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>" class="datedelbutton <?php echo esc_attr( $term->name ) ?>"><?php echo esc_attr( $term->name ) ?></a>&nbsp;<?php echo $natdate ?></span><?php
 					} else {
-						$date = strtotime( $term->name ); // If it isn't, convert it to a timestamp -- why? ?>
-			<span><a id='<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>' class='datedelbutton <?php echo esc_attr( $date ) ?>'><?php echo esc_attr( $term->name ) ?></a>&nbsp;<?php echo esc_attr( $term->name ) ?></span>
-			<?php
+						?><span><a id="<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>" class="datedelbutton <?php echo esc_attr( $term->name ) ?>"><?php echo esc_attr( $term->name ) ?></a>&nbsp;<?php echo esc_attr( $term->name ) ?></span><?php
 					}
-					HTML::hidden( 'rm_' . $tax_name . '_' . $i, null, null );
+					$this->hidden( 'rm_' . $tax_name . '_' . $i, null, null );
 					$i++;
 				}
 			}
-			?>
-		</div>
-	<?php
+		?></div><?php
 	}
 }

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -121,332 +121,374 @@ class Models {
             $exists = $this->check_post_type($p);
             if ( $exists != false ) {
                 add_meta_box(
-                $id = $this->slug,
-                $title = $this->title,
-                $callback = array( $this->View, 'ready_and_print_html' ),
-                $post_type = $p,
-                $context = $this->context,
-                $priority = $this->priority,
-                $callback_args = $fields
-            );
-        } else {
-            $error = new $this->error( 'post_type', 'Invalid post type: ' . $p);
-            echo $error->get_error_message('post_type');
+                    $id = $this->slug,
+                    $title = $this->title,
+                    $callback = array( $this->View, 'ready_and_print_html' ),
+                    $post_type = $p,
+                    $context = $this->context,
+                    $priority = $this->priority,
+                    $callback_args = $fields
+                );
+            } else {
+                $error = new $this->error( 'post_type', 'Invalid post type: ' . $p);
+                echo $error->get_error_message('post_type');
+            }
         }
     }
-}
 
-/**
-* validate_formset validates a formset
-*
-* @param  arr  $field     The formset to validate. 
-* @param  arr  $validate  The array that holds all the data to save in an
-*                         associative array that is passed by reference.
-* @param  arr  $post_ID   The post's ID
-*
-* @return  void           No return value. The validate array is passed by reference
-*                         so data is saved through that array.
-*/
+    /**
+    * validate_formset validates a formset
+    *
+    * @param  arr  $field     The formset to validate. 
+    * @param  arr  $validate  The array that holds all the data to save in an
+    *                         associative array that is passed by reference.
+    * @param  arr  $post_ID   The post's ID
+    *
+    * @return  void           No return value. The validate array is passed by reference
+    *                         so data is saved through that array.
+    */
 
-public function validate_formset( $field, &$validate, $post_ID ) {
-    if ( array_key_exists('max_num_forms', $field['params'] ) ) {
-        $count = $field['params']['max_num_forms'];
-    } else {
-        $count = 1;
+    public function validate_formset( $field, &$validate, $post_ID ) {
+        for ( $i = 0; $i < $field['params']['max_num_forms']; $i++ ) {
+            $processed[$i] = $field;
+            if ( isset( $processed[$i]['meta_key'] ) ) {
+                $processed[$i]['meta_key'] .= '_' . $i;
+            }
+            if ( isset( $processed[$i]['meta_key'] ) ) {
+                $processed[$i]['slug'] .= '_' . $i;
+            }
+            foreach ( $processed[$i]['fields'] as $f ) {
+                if ( isset( $processed[$i]['meta_key'] ) and isset( $f['meta_key'] ) ) {
+                    $f['meta_key'] = "{$processed[$i]['meta_key']}_{$f['meta_key']}";
+                }
+                if ( isset( $processed[$i]['slug'] ) and isset( $f['slug'] ) ) {
+                    $f['slug'] = "{$processed[$i]['slug']}_{$f['slug']}";
+                }
+                $this->validate( $post_ID, $f, $validate );
+            }
+        }
     }
-    for ( $i = 0; $i < $count; $i++ ) {
-        $processed[$i] = $field;
-        $processed[$i]['meta_key'] .= '_' . $i;
-        foreach ( $processed[$i]['fields'] as $f ) {
-            $f['meta_key'] = "{$processed[$i]['meta_key']}_{$f['meta_key']}";
+
+    /**
+    * validate_fieldset validates a fieldset
+    *
+    * @param  arr  $field     The formset to validate. 
+    * @param  arr  $validate  The array that holds all the data to save in an
+    *                         associative array that is passed by reference.
+    * @param  arr  $post_ID   The post's ID
+    *
+    * @return  void           No return value. The validate array is passed by reference
+    *                         so data is saved through that array.
+    */
+
+    public function validate_fieldset( $field, &$validate, $post_ID ) {
+        foreach ( $field['fields'] as $f ) {
+            if ( isset( $field['meta_key'] ) and isset( $f['meta_key'] ) ) {
+                $f['meta_key'] = "{$field['meta_key']}_{$f['meta_key']}";
+            }
+            if ( isset( $field['slug'] ) and isset( $f['slug'] ) ) {
+                $f['slug'] = "{$field['slug']}_{$f['slug']}";
+            }
             $this->validate( $post_ID, $f, $validate );
         }
     }
-}
 
-/**
-* validate_fieldset validates a fieldset
-*
-* @param  arr  $field     The formset to validate. 
-* @param  arr  $validate  The array that holds all the data to save in an
-*                         associative array that is passed by reference.
-* @param  arr  $post_ID   The post's ID
-*
-* @return  void           No return value. The validate array is passed by reference
-*                         so data is saved through that array.
-*/
-
-private function validate_fieldset( $field, &$validate, $post_ID ) {
-    foreach ( $field['fields'] as $f ) {
-        $f['meta_key'] = "{$field['meta_key']}_{$f['meta_key']}";
-        $this->validate( $post_ID, $f, $validate );
+    /**
+     * validate_link validates a field with type = 'link'
+     * 
+     * @param  arr $field   The field to validate, normally passed by looping through 
+     *                      $this->fields
+     * @param  int $post_ID The post ID to have post values saved to
+     * @return void         No return value, updates or adds post meta if successful. New
+     *                      metadata are saved to the post as an array of the form
+     *                      array(0 => 'url', 1 => 'text')
+     */
+    public function validate_link( $field, $post_ID ) {
+        if ( isset( $_POST["{$field['meta_key']}_url"] ) 
+         and isset( $_POST["{$field['meta_key']}_text"] ) ) {
+            $url = $_POST["{$field['meta_key']}_url"];
+            $text = $_POST["{$field['meta_key']}_text"];
+            $full_link = array( 0 => $url, 1 => $text );
+            $existing = get_post_meta( $post_ID, $field['meta_key'], $single = false );
+            
+            if ( empty( $_POST["{$field['meta_key']}_url"] ) 
+              or empty( $_POST["{$field['meta_key']}_text"] ) ) {
+                delete_post_meta( $post_ID, $field['meta_key']);
+            } elseif ( empty($existing) ) {
+                add_post_meta( $post_ID, $field['meta_key'], $url, false );
+                add_post_meta( $post_ID, $field['meta_key'], $text, false );
+            } elseif ( $existing != $full_link ) {
+                update_post_meta( $post_ID, $field['meta_key'], $url, $existing[0] );
+                update_post_meta( $post_ID, $field['meta_key'], $text, $existing[1] );
+            }
+        }
     }
-}
 
-/**
- * validate_link validates a field with type = 'link'
- * 
- * @param  arr $field   The field to validate, normally passed by looping through 
- *                      $this->fields
- * @param  int $post_ID The post ID to have post values saved to
- * @return void         No return value, updates or adds post meta if successful. New
- *                      metadata are saved to the post as an array of the form
- *                      array(0 => 'url', 1 => 'text')
- */
-public function validate_link( $field, $post_ID ) {
-    if ( array_key_exists("{$field['meta_key']}_url", $_POST) 
-        and array_key_exists("{$field['meta_key']}_text", $_POST) ) {
-        $url = $_POST["{$field['meta_key']}_url"];
-        $text = $_POST["{$field['meta_key']}_text"];
-        $full_link = array( 0 => $url, 1 => $text );
-        $existing = get_post_meta( $post_ID, $field['meta_key'], $single = false );
-        
-        if ( empty( $_POST["{$field['meta_key']}_url"] ) 
-            or empty( $_POST["{$field['meta_key']}_text"] ) ) {
+    /**
+     * validate_select validates a <select> field
+     * 
+     * @param  arr $field   The field to validate, normally passed by looping through 
+     *                      $this->fields
+     * @param  int $post_ID The post ID to have post values saved to
+     * @return void         No return value, adds or deletes post meta if successful. New
+     *                      data are saved to the post as new values in an array or 
+     *                      deleted.
+     */
+
+    public function validate_select( $field, $post_ID ) {
+        if ( !isset( $_POST[$field['meta_key']] ) ) {
             delete_post_meta( $post_ID, $field['meta_key']);
-        } elseif ( empty($existing) ) {
-            add_post_meta( $post_ID, $field['meta_key'], $url, false );
-            add_post_meta( $post_ID, $field['meta_key'], $text, false );
-        } elseif ( $existing != $full_link ) {
-            update_post_meta( $post_ID, $field['meta_key'], $url, $existing[0] );
-            update_post_meta( $post_ID, $field['meta_key'], $text, $existing[1] );
-        }
-    }
-}
-
-/**
- * validate_select validates a <select> field
- * 
- * @param  arr $field   The field to validate, normally passed by looping through 
- *                      $this->fields
- * @param  int $post_ID The post ID to have post values saved to
- * @return void         No return value, adds or deletes post meta if successful. New
- *                      data are saved to the post as new values in an array or 
- *                      deleted.
- */
-
-public function validate_select( $field, $post_ID ) {
-    $key = $field['meta_key'];
-    if ( !isset( $_POST[$key] ) ) {
-        delete_post_meta( $post_ID, $key);
-        return;
-    }
-    if ( array_key_exists($key, $_POST) ) {
-        $existing = get_post_meta( $post_ID, $key, false );
-        $data = $_POST[$key];
-        foreach ( (array)$data as $d ) {
-            // Adding or updating terms
-            $term = sanitize_text_field( $d );
-            $e_key = array_search($term, $existing);
-            if ( ! in_array($d, (array)$existing) ) {
-                // if the term is not in $existing, it's a new term, add it
-                // we use add_post_meta instead of update so we can have more
-                // than one value on the array
-                add_post_meta( $post_ID, $key, $term );
-            }
-        }
-        // delete terms if they're not in the $_POST data
-        foreach ( (array)$existing as $e ) {
-            if ( ! in_array($e, (array)$data) ) {
-                delete_post_meta( $post_ID, $key, $meta_value = $e );
-            }
-        }
-    }
-}
-
-public function validate_taxonomyselect($field, $post_ID) {
-    $key = $field['slug'];
-    if ( isset($_POST[$key] )) {
-        $term = sanitize_text_field( $_POST[$key] );
-        $term_exists = get_term_by('id', $term, $field['taxonomy']);
-        if ( $term_exists ){
-            wp_set_object_terms(
-            $post_ID,
-            $term_exists->name,
-            $field['taxonomy'],
-            $append = $field['multiple']
-        );
-    } else {
-        wp_set_object_terms(
-        $post_ID,
-        $term,
-        $field['taxonomy'],
-        $append = $field['multiple']
-    );
-    }
-}
-}
-
-/** 
- * Validates a date field by converting $_POST keys into date strings before passing
- * to a date method in $this->Callbacks->date()
- * 
- * @param  array $field    The field to be processed
- * @param  [type] $post_ID The ID of the object to be manipulated
- * @return void
- */
-
-public function validate_date($field, $post_ID) {
-    $terms = wp_get_post_terms( $post_ID, $field['taxonomy'], array( 'fields' => 'ids' ) );
-    $terms_to_remove = array();
-    for ( $i = 0; $i < count( $terms ); $i++ ) {
-        if ( isset( $_POST['rm_' . $field['taxonomy'] . '_' . $i ] ) ) {
-            array_push( $terms_to_remove, $i );
-        }
-    }
-    foreach ( $terms_to_remove as $t ) {
-        $this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], null, $t );
-    }
-    $year = $field['taxonomy'] . '_year';
-    $month = $field['taxonomy'] . '_month';
-    $day = $field['taxonomy'] . '_day';
-    $data = array($field['taxonomy'] => '');
-    if ( isset($_POST[$month]) ) {
-        $data[$field['taxonomy']] = $_POST[$month];
-    }
-    if ( isset( $_POST[$day] ) ) {
-        $data[$field['taxonomy']] .= ' ' . $_POST[$day];
-    }
-    if ( isset( $_POST[$year] ) ) {
-        $data[$field['taxonomy']] .= ' ' . $_POST[$year];
-    }
-    $date = DateTime::createFromFormat('F j Y', $data[$field['taxonomy']]);
-    if ( $date ) {
-        $this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $data, null );
-    }
-}
-
-/**
- * Checks that data is coming through in the types we expect or ferries out form 
- * data to the appropriate validator. Run before save to ensure you're saving
- * correct data. Essentially this takes in $_POST and pushes all the good stuff from
- * $_POST into a separate, cleaned array and returns the cleaned data.
- *
- * @param int $post_ID The post targeted for custom data
- * 
- * @return array A version of $_POST with cleaned data ready to be sent to a save method
- *               like $this->save()
- */
-
-public function validate( $post_ID, $field, &$validate ) {
-    // $data = array_intersect_key($_POST, $this->fields);
-    if ( array_key_exists( 'meta_key', $field ) ) {
-        $key = $field['meta_key'];
-    } elseif ( array_key_exists( 'taxonomy', $field ) ) {
-        $key = $field['taxonomy'];
-    } else {
-        return null;
-    }
-    if ( array_key_exists('do_not_validate', $field) ) {
-        return;
-    }
-    if ( ! array_key_exists( 'type', $field ) ) {
-        return;
-    }
-
-    /* if this field is a formset, fieldset, taxonomy select, date, link or 
-       select field, we send it out to another validator
-    */
-    if ( $field['type'] == 'formset' ) {
-        $this->validate_formset( $field, $validate, $post_ID );
-        return;
-    } elseif ( $field['type'] == 'fieldset' ) {
-        $this->validate_fieldset( $field, $validate, $post_ID );
-        return;
-    } elseif ( $field['type'] == 'taxonomyselect') {
-        $this->validate_taxonomyselect( $field, $post_ID );
-        return;
-    } elseif ( in_array( $field['type'], $this->selects ) ) {
-        $this->validate_select( $field, $post_ID );
-        return;
-    } elseif ( $field['type'] === 'date' ) {
-        $this->validate_date( $field, $post_ID );
-        return;
-    } elseif ( $field['type'] === 'link' ) {
-        $this->validate_link($field, $post_ID);
-        return;
-    } else {
-        /* 
-            For most field types we just need to make sure we have the data
-            we expect from the form and sanitize them before sending them to
-            save
-        */
-        if ( ! array_key_exists( $key, $_POST ) ) {
             return;
         }
-        $value = $_POST[$key];
-        if ( $field['type'] === 'number' ) {
-            if ( is_numeric( $value ) ) {
-                // if we're expecting a number, make sure we get a number
-                $value = intval( $value ); 
+        if ( array_key_exists($field['meta_key'], $_POST) ) {
+            $existing = get_post_meta( $post_ID, $field['meta_key'], false );
+            $data = $_POST[$field['meta_key']];
+            foreach ( (array)$data as $d ) {
+                // Adding or updating terms
+                $term = sanitize_text_field( $d );
+                $e_key = array_search($term, $existing);
+                if ( ! in_array($d, (array)$existing) ) {
+                    // if the term is not in $existing, it's a new term, add it
+                    // we use add_post_meta instead of update so we can have more
+                    // than one value on the array
+                    add_post_meta( $post_ID, $field['meta_key'], $term );
+                }
+            }
+            // delete terms if they're not in the $_POST data
+            foreach ( (array)$existing as $e ) {
+                if ( ! in_array($e, (array)$data) ) {
+                    delete_post_meta( $post_ID, $field['meta_key'], $meta_value = $e );
+                }
+            }
+        }
+    }
+
+    public function validate_taxonomyselect($field, $post_ID) {
+        $field['multiple'] = isset( $field['multiple'] ) ? $field['multiple'] : false;
+        if ( isset($_POST[$field['slug']] )) {
+            $term = sanitize_text_field( $_POST[$field['slug']] );
+            $term_exists = get_term_by('id', $term, $field['taxonomy']);
+            if ( $term_exists ){
+                wp_set_object_terms(
+                    $post_ID,
+                    $term_exists->name,
+                    $field['taxonomy'],
+                    $append = $field['multiple']
+                );
             } else {
-                $value = null;
+                wp_set_object_terms(
+                    $post_ID,
+                    $term,
+                    $field['taxonomy'],
+                    $append = $field['multiple']
+                );
             }
-        } elseif ( $field['type'] === 'url' && isset( $value ) ) {
-            // if we're expecting a url, make sure we get a url
-            $value = esc_url_raw( $value ); 
-        } elseif ( $field['type'] === 'email' ) {
-            // if we're expecting an email, make sure we get an email
-            $value = sanitize_email( $value ); 
-        } elseif ( ! empty( $value ) && ! is_array($value ) ) {
-            // make sure whatever we get for anything else is a string
-            $value = (string)$value;
         }
     }
-    $validate[$field['meta_key']] = $value;
-}
 
-/**
- * Takes cleaned $_POST data and save it as custom post meta
- * 
- * @param  int $post_ID      The post we save data to
- * @param  array $postvalues Cleaned version of $_POST or some other array of trusted 
- *                           data to be saved
- * @return nothing           Either deletes or updates post meta or returns empty
- */
-public function save( $post_ID, $postvalues ) {
-    // Do nothing if we're auto saving
-    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) 
-    return;
+    /** 
+     * Validates a date field by converting $_POST keys into date strings before passing
+     * to a date method in $this->Callbacks->date()
+     * 
+     * @param  array $field    The field to be processed
+     * @param  [type] $post_ID The ID of the object to be manipulated
+     * @return void
+     */
 
-    if ( empty( $postvalues ) ) {
-        // if we're passed an empty array, don't do anything
-        return;
+    public function validate_date($field, $post_ID) {
+        $terms = wp_get_post_terms( $post_ID, $field['taxonomy'], array( 'fields' => 'ids' ) );
+        $terms_to_remove = array();
+        $field['multiple'] = isset( $field['multiple'] ) ? $field['multiple'] : false;
+        for ( $i = 0; $i < count( $terms ); $i++ ) {
+            if ( isset( $_POST['rm_' . $field['taxonomy'] . '_' . $i ] ) ) {
+                array_push( $terms_to_remove, $i );
+            }
+        }
+        foreach ( $terms_to_remove as $t ) {
+            $this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], null, $t );
+        }
+        $year = $field['taxonomy'] . '_year';
+        $month = $field['taxonomy'] . '_month';
+        $day = $field['taxonomy'] . '_day';
+        $data = array($field['taxonomy'] => '');
+        if ( isset($_POST[$month]) ) {
+            $data[$field['taxonomy']] = $_POST[$month];
+        }
+        if ( isset( $_POST[$day] ) ) {
+            $data[$field['taxonomy']] .= ' ' . $_POST[$day];
+        }
+        if ( isset( $_POST[$year] ) ) {
+            $data[$field['taxonomy']] .= ' ' . $_POST[$year];
+        }
+        $date = DateTime::createFromFormat('F j Y', $data[$field['taxonomy']]);
+        if ( $date ) {
+            $this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $data, null );
+        }
     }
 
-    // save post data for any fields that sent them
-    foreach ( $postvalues as $key => $value ) {
-        $existing = get_post_meta( $post_ID, $key, $single = true );
-        if ( $value == null && isset( $existing ) ) {
-            delete_post_meta( $post_ID, $key );
-        } elseif ( isset( $value ) ) {
-            update_post_meta( $post_ID, $meta_key = $key, $meta_value = $value );
-        } else {
+    /**
+     * Checks that data is coming through in the types we expect or ferries out form 
+     * data to the appropriate validator. Run before save to ensure you're saving
+     * correct data. Essentially this takes in $_POST and pushes all the good stuff from
+     * $_POST into a separate, cleaned array and returns the cleaned data.
+     *
+     * @param int $post_ID The post targeted for custom data
+     * 
+     * @return array A version of $_POST with cleaned data ready to be sent to a save method
+     *               like $this->save()
+     */
+
+    public function validate( $post_ID, $field, &$validate ) {
+        if ( isset( $field['do_not_validate'] ) ) {
+            return;
+        } elseif ( ! isset( $field['type'] ) ) {
+            $error = new $this->error( 'no_type', __( 'No field type set.' ) );
+            echo $error->get_error_message('no_type');
             return;
         }
+        if ( isset( $field['meta_key'] ) ) {
+            $key = $field['meta_key'];
+        } elseif ( isset( $field['slug'] ) ) {
+            $key = $field['slug'];
+        } elseif ( isset( $field['taxonomy'] ) ) {
+            $key = $field['taxonomy'];
+        } else {
+            $error = new $this->error( 'no_slug', __( 'No meta_key/slug/taxonomy is set.' ) );
+            echo $error->get_error_message('no_slug');
+            return;
+        }
+        /* if this field is a formset, fieldset, taxonomy select, date, link or 
+           select field, we send it out to another validator
+        */
+        if ( $field['type'] == 'formset' ) {
+           if ( isset( $field['params'] ) ) {
+                if ( isset( $field['params']['max_num_forms'] ) ) {
+                    if ( ! is_numeric( $field['params']['max_num_forms'] ) ) {
+                        $error = new $this->error( 'formset_params_max_num',
+                                    __( "The 'max_num_forms' in params array for the"
+                                        . "formset field needs to be an integer." ) );
+                        return $error->get_error_message('formset_params_max_num');
+                    }
+                } else {
+                    $field['params']['max_num_forms'] = 1;
+                }            
+            } else {
+                $error = new $this->error( 'formset_params',
+                                    __( "There must be a params array set in the field"
+                                         . "for a formset." ) );
+                return $error->get_error_message('formset_params');
+            }
+            $this->validate_formset( $field, $validate, $post_ID );
+            return;
+        } elseif ( $field['type'] == 'fieldset' ) {
+            $this->validate_fieldset( $field, $validate, $post_ID );
+            return;
+        } elseif ( $field['type'] == 'taxonomyselect') {
+            if ( ! isset( $field['taxonomy'] ) ) {
+                $error = new $this->error( 'no_taxonomy', __( 'No taxonomy set'
+                                           . ' for field that requires it.' ) );
+                echo $error->get_error_message('no_taxonomy');
+                return;
+            }
+            $this->validate_taxonomyselect( $field, $post_ID );
+            return;
+        } elseif ( in_array( $field['type'], $this->selects ) ) {
+            if ( ! isset( $field['meta_key'] ) ) {
+                $error = new $this->error( 'no_meta_key', __( 'No meta_key is set.' ) );
+                echo $error->get_error_message('no_meta_key');
+                return;
+            }
+            $this->validate_select( $field, $post_ID );
+            return;
+        } elseif ( $field['type'] == 'date' ) {
+            if ( ! isset( $field['taxonomy'] ) ) {
+                $error = new $this->error( 'no_taxonomy', __( 'No taxonomy set'
+                                           . ' for field that requires it.' ) );
+                echo $error->get_error_message('no_taxonomy');
+                return;
+            }
+            $this->validate_date( $field, $post_ID );
+            return;
+        } elseif ( $field['type'] == 'link' ) {
+            $this->validate_link($field, $post_ID);
+            return;
+        } else {
+            /* 
+                For most field types we just need to make sure we have the data
+                we expect from the form and sanitize them before sending them to
+                save
+            */
+            if ( ! isset( $_POST[$key] ) ) {
+                return;
+            }
+            $value = $_POST[$key];
+            if ( $field['type'] == 'number' ) {
+                if ( is_numeric( $value ) ) {
+                    // if we're expecting a number, make sure we get a number
+                    $value = intval( $value ); 
+                } else {
+                    $value = null;
+                }
+            } elseif ( $field['type'] == 'url' && isset( $value ) ) {
+                // if we're expecting a url, make sure we get a url
+                $value = esc_url_raw( $value ); 
+            } elseif ( $field['type'] == 'email' ) {
+                // if we're expecting an email, make sure we get an email
+                $value = sanitize_email( $value ); 
+            } elseif ( ! empty( $value ) && ! is_array($value ) ) {
+                // make sure whatever we get for anything else is a string
+                $value = (string)$value;
+            }
+        }
+        $validate[$key] = $value;
     }
-}
-/**
- * Runs validate, then save on $_POST data
- * 
- * @param  int $post_ID The id of the object we're saving
- * @return void
- */
-public function validate_and_save( $post_ID ) {
-    $validate = array();
-    foreach ( $this->fields as $field ) {
-        $this->validate( $post_ID, $field, $validate );
+
+    /**
+     * Takes cleaned $_POST data and save it as custom post meta
+     * 
+     * @param  int $post_ID      The post we save data to
+     * @param  array $postvalues Cleaned version of $_POST or some other array of trusted 
+     *                           data to be saved
+     * @return nothing           Either deletes or updates post meta or returns empty
+     */
+    public function save( $post_ID, $postvalues ) {
+        // Do nothing if we're auto saving
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) 
+        return;
+
+        if ( empty( $postvalues ) ) {
+            // if we're passed an empty array, don't do anything
+            return;
+        }
+
+        // save post data for any fields that sent them
+        foreach ( $postvalues as $key => $value ) {
+            $existing = get_post_meta( $post_ID, $key, $single = true );
+            if ( $value == null && isset( $existing ) ) {
+                delete_post_meta( $post_ID, $key );
+            } elseif ( isset( $value ) ) {
+                update_post_meta( $post_ID, $meta_key = $key, $meta_value = $value );
+            } else {
+                return;
+            }
+        }
     }
-    $this->save( $post_ID, $validate );
-}
-/**
-* Moved premanently: This function is now located in the \CFPB\Utils\MetaBox\Template namespace, in the HTML class.
-*
-* @since v1.0
-*
-**/
-public function date_meta_box( $taxonomy, $tax_nice_name, $multiples = false ) {
-    $error = new $this->error( 'moved', __( 'This function has moved to the \CFPB\Utils\MetaBox\HTML namespace. Look for it there as simply date()!' ) );
-    echo $error->get_error_message('moved');
-}
+    /**
+     * Runs validate, then save on $_POST data
+     * 
+     * @param  int $post_ID The id of the object we're saving
+     * @return void
+     */
+    public function validate_and_save( $post_ID ) {
+        $validate = array();
+        if ( empty( $this->fields ) ) {
+            $error = new $this->error( 'empty_fields', __( 'Empty fields array' ) );
+            echo $error->get_error_message('empty_fields');
+            return;
+        }
+        foreach ( $this->fields as $field ) {
+            $this->validate( $post_ID, $field, $validate );
+        }
+        $this->save( $post_ID, $validate );
+    }
 }

--- a/inc/meta-box-view.php
+++ b/inc/meta-box-view.php
@@ -27,6 +27,7 @@ class View {
 	private $other   = array( 'separator', 'fieldset', 'formset' );
 	public $elements;
 	private $HTML;
+	private $error;
 
 	function __construct() {
 		$this->HTML     = new HTML();
@@ -36,44 +37,51 @@ class View {
 			$this->hidden,
 			$this->other
 		);
+		$this->error = '\WP_Error';
 	}
 
 	public function replace_html( $HTML ) {
 		$this->HTML = $HTML;
 	}
 
+    public function error_handler( $Class ) {
+        $this->error = $Class;
+    }
+
 	public function process_defaults( $fields ) {
 		$ready = array();
 		foreach ( $fields as $field ) {
 			// check if this post has post meta or a taxonomy term already, if it does, set that as the value
 			if ( ! in_array( $field['type'], $this->elements ) ) {
-				return  new WP_Error( 'invalid_type', "Invalid type {$field['type']} given for {$field['slug']} in this model. Acceptable elements: {$this->elements}");
+				return new WP_Error( 'invalid_type', "Invalid type {$field['type']} given for {$field['slug']} in this model. Acceptable elements: {$this->elements}");
 			}
 			$ID = get_the_ID();
 			if ( isset($field['meta_key'] ) ) {
+				if ( ! isset( $field['slug'] ) ) {
+					$field['slug'] = $field['meta_key'];
+				}
 				$field['value'] = $this->default_value($ID, $field);
-			} else {
+			} elseif ( isset( $field['taxonomy'] ) ) {
 				$field['value'] = wp_get_object_terms(
 					$ID,
 					$taxonomy = $field['taxonomy'],
 					array( 'fields' => 'names' )
 				);
+			} else {
+				return new WP_Error( 'no_slug', "No meta_key/slug/taxonomy is set.");
+			}
+			if ( isset( $field['slug'] ) ) {
+				if ( ! isset( $field['meta_key'] ) ) {
+					$field['meta_key'] = $field['slug'];
+				}
 			}
 			if ( $field['type'] == 'formset' ) {
+				$field = $this->assign_defaults($field);
 				$this->process_formset_defaults( $field, $ready );
 			} elseif ( $field['type'] == 'fieldset' ) {
-				for ($i = 0; $i < count( $field['fields'] ); $i++ ) {
-					$field['fields'][$i]['meta_key'] = "{$field['meta_key']}_{$field['fields'][$i]['meta_key']}";
-					$field['fields'][$i] = $this->assign_defaults( $field['fields'][$i] );
-					$field['fields'][$i]['value'] = $this->default_value( $ID, $field['fields'][$i] );
-				}
-				$ready[$field['meta_key']] = $field;
+				$ready[$field['meta_key']] = $this->process_fieldset( $field );
 			} else {
-				if ( isset( $field['meta_key'] ) ) {
-					$ready[$field['meta_key']] = $this->assign_defaults($field);
-				} elseif ( isset( $field['slug'] ) ) {                  
-					$ready[$field['slug']] = $this->assign_defaults($field);
-				}
+				$ready[$field['meta_key']] = $this->assign_defaults($field);
 			}
 		}
 		return $ready;
@@ -92,18 +100,44 @@ class View {
 			$processed[$i]['slug'] .= '_' . $i;
 			$processed[$i]['title'] .= isset( $processed[$i]['title'] ) ? ' ' . ( $i + 1 ) : "";
 			for ( $j = 0; $j < count( $field['fields'] ); $j++ ) {
-				$meta_key = $processed[$i]['fields'][$j]['meta_key'];
-				$processed[$i]['fields'][$j]['meta_key'] = "{$processed[$i]['meta_key']}_{$meta_key}";
+				if ( isset( $processed[$i]['fields'][$j]['meta_key'] ) ) {
+					$processed[$i]['fields'][$j]['meta_key'] = "{$processed[$i]['meta_key']}_{$processed[$i]['fields'][$j]['meta_key']}";
+				}
+				if ( isset( $processed[$i]['fields'][$j]['slug'] ) ) {
+					$processed[$i]['fields'][$j]['slug'] = "{$processed[$i]['slug']}_{$processed[$i]['fields'][$j]['slug']}";
+				}
 			}
 			$processed[$i]['fields'] = $this->process_defaults( $processed[$i]['fields'] );
 		}
 		foreach ( $processed as $f ) {
-			$ready[$f['meta_key']] = $f;
+			if ( isset( $f['meta_key'] ) ) {
+				$ready[$f['meta_key']] = $f;
+			} elseif ( isset( $f['slug'] ) ) {
+				$ready[$f['slug']] = $f;
+			}
 		}
 	}
 
+	public function process_fieldset( $field ){
+		$ID = get_the_ID();
+		for ($i = 0; $i < count( $field['fields'] ); $i++ ) {
+			if ( isset( $field['fields'][$i]['meta_key'] ) ) {
+				$field['fields'][$i]['meta_key'] = "{$field['meta_key']}_{$field['fields'][$i]['meta_key']}";
+			}
+			if ( isset( $field['fields'][$i]['slug'] ) ) {
+				$field['fields'][$i]['slug'] = "{$field['slug']}_{$field['fields'][$i]['slug']}";
+			}
+			if ( $field['fields'][$i]['type'] == 'fieldset' ) {
+				$field['fields'][$i] = $this->process_fieldset( $field['fields'][$i] );
+			} else {
+				$field['fields'][$i] = $this->assign_defaults( $field['fields'][$i] );
+				$field['fields'][$i]['value'] = $this->default_value( $ID, $field['fields'][$i] );
+			}
+		}
+		return $field;
+	}
+
 	public function assign_defaults( $field ) {
-		
 		$field['label'] = $this->default_label($field);
 		if ( ! in_array( $field['type'], $this->hidden ) ) {
 			$field['max_length'] = $this->default_max_length($field);
@@ -122,14 +156,20 @@ class View {
 		} else {
 			$field['multiselect'] = false;
 		}
-		if ( ! in_array($field['type'], array( 'taxonomyselect', 'tax_as_meta', 'date' ) ) ) {
+		if ( ! in_array($field['type'], array( 'select', 'taxonomyselect', 'tax_as_meta', 'date' ) ) ) {
 			$field['taxonomy'] = false;
+		}
+		if ( $field['type'] == 'formset' ) {
+			$field = $this->default_formset_params( $field );
 		}
 		return $field;
 	}
 
 	public function default_value( $ID, $field, $index = 0 ) {
-		if ( $field['type'] == 'link' ) {
+		if ( $field['type'] == 'link' or 
+			 $field['type'] == 'fieldset' or 
+			 $field['type'] == 'formset' or 
+			 $field['type'] == 'date' ) {
 			$default = null;
 		} else {
 			$existing = get_post_meta( $ID, $field['meta_key'], false );
@@ -166,6 +206,19 @@ class View {
 	public function default_options( $field ) {
 		$default = ! isset( $field['params']['include'] ) ? array() : $field['params']['include'];
 		return $default;
+	}
+	public function default_formset_params( $field ) {
+        if ( isset( $field['params'] ) ) {
+        	if ( ! isset( $field['params']['init_num_forms'] ) ) {
+        		$field['params']['init_num_forms'] = 1;
+        	}
+            if ( ! isset( $field['params']['max_num_forms'] ) ) {
+            	$field['params']['max_num_forms'] = 1;
+            }
+        } else {
+            $field['params'] = array( 'init_num_forms' => 1, 'max_num_forms' => 1 );
+        }
+        return $field;
 	}
 
 	public function ready_and_print_html( $post, $fields ) {

--- a/inc/meta-box-view.php
+++ b/inc/meta-box-view.php
@@ -75,13 +75,17 @@ class View {
 					$field['meta_key'] = $field['slug'];
 				}
 			}
-			if ( $field['type'] == 'formset' ) {
-				$field = $this->assign_defaults($field);
-				$this->process_formset_defaults( $field, $ready );
-			} elseif ( $field['type'] == 'fieldset' ) {
-				$ready[$field['meta_key']] = $this->process_fieldset( $field );
+			if ( isset( $field['meta_key'] ) ) {
+				if ( $field['type'] == 'formset' ) {
+					$field = $this->assign_defaults($field);
+					$this->process_formset_defaults( $field, $ready );
+				} elseif ( $field['type'] == 'fieldset' ) {
+					$ready[$field['meta_key']] = $this->process_fieldset( $field );
+				} else {
+					$ready[$field['meta_key']] = $this->assign_defaults($field);
+				}
 			} else {
-				$ready[$field['meta_key']] = $this->assign_defaults($field);
+				return new WP_Error( 'no_metakey-slug', "'meta_key' and 'slug' are not set for this field." );
 			}
 		}
 		return $ready;

--- a/tests/test-meta_box_html.php
+++ b/tests/test-meta_box_html.php
@@ -3,34 +3,1649 @@ use \CFPB\Utils\MetaBox\HTML;
 use \Mockery as m;
 
 class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
+
 	function setUp() {
+		global $wp_locale;
+		$wp_locale = $this->getMockBuilder( '\WP_Locale' )
+						  ->setMethods( array( 'get_month' ) )
+						  ->getMock();
 		\WP_Mock::setUp();
 	}
 
 	function tearDown() {
 		\WP_Mock::tearDown();
 	}
-
-	function testDrawExpectsHTML() {
-		// Arrange
-
-		$fields = array(
-			'title' => 'This is a field',
-			'slug' => 'field_one',
-			'type' => 'text_area',
-			'cols' => 27,
-			'rows' => 2,
-			'placeholder' => 'Enter text',
-			'howto' => 'Type some text',
-			'meta_key' => 'field_one',
-			'value' => null,
-			'label' => null,
-		);
-
+	/***************************
+	 * HTML method tests *
+	 ***************************/
+    /**
+     * Tests whether the draw method will return WP_Error if given empty field
+     *
+     * @group stable
+     * @group wp_error
+     */
+	function testDrawWithEmptyFieldExpectsWPErrorReturned() {
+		// arrange
+		$field = array();
 		$HTML = new HTML();
-		\WP_Mock::wpPassthruFunction('esc_attr');
-		\WP_Mock::wpPassthruFunction('esc_html');
-		// Act
-		$HTML->draw($fields);
+		$mock = $this->getMock('WP_Error');
+
+		//act
+		$error = $HTML->draw( $field );
+
+		//assert
+		$this->assertInstanceOf( 'WP_Error', $error );
+	}
+	/**
+     * Tests that the draw method will call draw_formset() if given field of
+     * of type 'formset'.
+     *
+     * @group stable
+     * @group formset
+     */
+	function testDrawWithFieldTypeFormsetCallsDrawFormset() {
+		//arrange
+		$field = array( 'type' => 'formset' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'draw_formset', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'draw_formset' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw( $field );
+
+		//assert
+		// Passes when called for formset type
+	}
+	/**
+     * Tests that the draw method will call draw_input() if given fields of 
+     * input types.
+     *
+     * @group stable
+     * @group draw_input
+     */
+	function testDrawWithInputFieldCallsDrawInput() {
+		//arrange
+		$fields = array(
+			array( 'type' => 'text' ),
+			array( 'type' => 'text_area' ),
+			array( 'type' => 'number' ),
+			array( 'type' => 'boolean' ),
+			array( 'type' => 'email' ),
+			array( 'type' => 'url' ),
+			array( 'type' => 'date' ),
+			array( 'type' => 'radio' ),
+			array( 'type' => 'link' ),
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'draw_input', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 9 ) )
+			 ->method( 'draw_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		foreach ( $fields as $field ) {
+			$HTML->draw( $field );
+		}
+
+		//assert
+		// Passes when called for input types
+	}
+	/**
+     * Tests that the draw method will call draw_input() if given fields of 
+     * select types.
+     *
+     * @group stable
+     * @group select
+     */
+	function testDrawWithSelectFieldCallsPassSelect() {
+		//arrange
+		$fields = array(
+			array( 'type' => 'select' ),
+			array( 'type' => 'multiselect' ),
+			array( 'type' => 'taxonomyselect' ),
+			array( 'type' => 'tax_as_meta' ),
+			array( 'type' => 'post_select' ),
+			array( 'type' => 'post_multiselect' ),
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'pass_select', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 6 ) )
+			 ->method( 'pass_select' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		foreach ( $fields as $field ) {
+			$HTML->draw( $field );
+		}
+
+		//assert
+		// Passes when called for select types
+	}
+	/**
+     * Tests that the draw method will call hidden() if given field of
+     * of type 'hidden'.
+     *
+     * @group stable
+     * @group hidden
+     */
+	function testDrawWithHiddenFieldCallsHidden() {
+		//arrange
+		$field = array( 'type' => 'hidden' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'hidden', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'hidden' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw( $field );
+
+		//assert
+		// Passes when called for hidden type
+	}
+	/**
+     * Tests that the draw method will call wp_nonce_field() if given field of
+     * of type 'nonce'.
+     *
+     * @group stable
+     * @group nonce
+     */
+	function testDrawWithNonceFieldCallsWPNonceField() {
+		//arrange
+		$field = array(
+			'type' => 'nonce'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction('wp_nonce_field', array( 'times' => 1, ) );
+		\WP_Mock::wpPassthruFunction('plugin_basename', array( 'times' => 1, ) );
+
+		//act
+		$HTML->draw( $field );
+
+		//assert
+		// Passes when called for nonce type
+	}
+	/**
+     * Tests that the draw_formset() method will call get_post_custom().
+     *
+     * @group stable
+     * @group wp_function
+     */
+	function testDrawFormsetShouldCallGetPostCustom() {
+		//arrange
+		$field['fields'] = array();
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_post_custom', array( 'times' => 1 ) );
+		
+		//act
+		$HTML->draw_formset( $field );
+
+		//assert
+		// Passes if get_post_custom() is called once.
+	}
+	/**
+     * Tests that the draw_formset() method will call get_formset_id().
+     *
+     * @group stable
+     */
+	function testDrawFormsetShouldCallGetFormsetID() {
+		//arrange
+		$field = array(
+			'meta_key' => 'test_0',
+			'fields' => array(),
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'get_formset_id' )
+			 ->	will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_formset( $field );
+
+		//assert
+		// Passes if get_formset_id() is called once.
+	}
+	/**
+     * Tests that the draw_formset() method will call get_existing_data().
+     *
+     * @group stable
+     */
+	function testDrawFormsetShouldCallGetExistingData() {
+		//arrange
+		$field = array(
+			'meta_key' => 'test_0',
+			'fields' => array(),
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'get_existing_data' )
+			 ->	will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_formset( $field );
+
+		//assert
+		// Passes if get_existing_data() is called once.
+	}
+	/**
+     * Tests that the get_formset_id() method will return expected output.
+     * 
+     * get_formset_id() works by looking for a digit surrounded by underscores
+     * and then concatenates each digit by a '-' and returns it. This is used 
+     * for the front-end "Remove" button function to remove only a specific 
+     * formset.
+     *
+     * @group stable
+     * @group formset
+     */
+	function testGetFormsetIDReturnsExpectedOutput() {
+		// arrange
+		$form_meta_key = 'test_0_3';
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$expected = '0-3';
+
+		//act
+		$actual = $HTML->get_formset_id( $form_meta_key );
+
+		//assert
+		$this->assertEquals( $actual, $expected );
+	}
+	/**
+     * Tests that the get_existing_data() method will add existing data to an 
+     * array that is passed by reference. 
+     *
+     * @group stable
+     */
+	function testGetExistingDataWithNonFieldsetFieldAddsExistingDataToArray() {
+		//arrange
+		$field = array(
+			'fields' => array(
+				array( 'meta_key' => 'field'),
+			),
+		);
+		$existing = array();
+		$data = array( 'field' => 'data' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$expected = array( 0 => 'data' );
+
+		// act
+		$HTML->get_existing_data( $field, $existing, $data );
+
+		// assert
+		$this->assertEquals( $existing, $expected );
+	}
+	/**
+     * Tests that the pass_select() method will call select() for each select
+     * typed field given.
+     *
+     * @group stable
+     * @group select
+     */
+	function testPassSelectCallsSelectForSelectMultiselectAndTaxonomySelectTypes() {
+		//arrange
+		$selections = array(
+			array('type' => 'select'),
+			array('type' => 'multiselect'),
+			array('type' => 'taxonomyselect'),
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'select', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 3 ) )
+			 ->method( 'select' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		foreach ( $selections as $selection ) {
+			$HTML->pass_select( $selection );
+		}
+
+		//assert
+		// Passes when select() is called 3 times
+	}
+	/**
+     * Tests that the pass_select() method will call taxonomy_as_meta() if given 
+     * field of type 'tax_as_meta'.
+     *
+     * @group stable
+     * @group select
+     */
+	function testPassSelectCallsTaxonomyAsMetaForTaxAsMetaType() {		
+		//arrange
+		$field = array( 'type' => 'tax_as_meta' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'taxonomy_as_meta', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'taxonomy_as_meta' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->pass_select( $field );
+
+		//assert
+		// Passes when taxonomy_as_meta() is called once
+	}
+	/**
+     * Tests that the pass_select() method will call post_select() twice for 
+     * fields of types 'post_select' and 'post_multiselect'.
+     *
+     * @group stable
+     * @group select
+     */
+	function testPassSelectCallsSelectForPostSelectAndPostMultiselectTypes() {
+		//arrange
+		$selections = array(
+			array('type' => 'post_select'),
+			array('type' => 'post_multiselect'),
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'post_select', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 2 ) )
+			 ->method( 'post_select' )
+			 ->will( $this->returnValue( true ) );
+		\WP_Mock::wpPassthruFunction( 'get_posts' );
+		\WP_Mock::wpPassthruFunction( 'get_post_meta' );
+
+		//act
+		foreach ( $selections as $selection ) {
+			$HTML->pass_select( $selection );
+		}
+
+		//assert
+		// Passes when select() is called 2 times
+	}
+	/**
+     * Tests that the pass_select() method will call get_posts() once
+     *  if given field of type 'post_select'.
+     *
+     * @group stable
+     * @group select
+     */
+	function testPassSelectCallsGetPosts() {
+		//arrange
+		$field = array('type' => 'post_select');
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'post_select', ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'get_posts', array( 'times' => 1 ) );
+		\WP_Mock::wpPassthruFunction( 'get_post_meta' );
+
+		//act
+		$HTML->pass_select( $field );
+
+		//assert
+		// Passes when get_posts() is called once
+	}
+	/**
+     * Tests that the pass_select() method will call get_post_meta() once if 
+     * given field of type 'post_select'.
+     *
+     * @group stable
+     * @group select
+     */
+	function testPassSelectCallsGetPostMeta() {
+		//arrange
+		$field = array('type' => 'post_select');
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'post_select', ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'get_posts' );
+		\WP_Mock::wpPassthruFunction( 'get_post_meta', array( 'times' => 1 ) );
+
+		//act
+		$HTML->pass_select( $field );
+
+		//assert
+		// Passes when get_posts() is called once
+	}
+	/**
+     * Tests that the draw_input() method will call text_area() if given field of
+     * of type 'text_area'.
+     *
+     * @group stable
+     * @group draw_input
+     */
+	function testDrawInputCallsTextAreaForTextAreaType() {
+		//arrange
+		$field = array( 'type' => 'text_area' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'text_area', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'text_area' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_input( $field );
+
+		//assert
+		// Passes when text_area() is called once
+	}
+	/**
+     * Tests that the draw_input() method will call single_input() if given fields of
+     * of input types.
+     *
+     * @group stable
+     * @group draw_input
+     */
+	function testDrawInputCallsSingleInputForNumberTextEmailURLTypes() {
+		//arrange
+		$fields = array(
+			array( 'type' => 'number' ),
+			array( 'type' => 'text' ),
+			array( 'type' => 'email' ),
+			array( 'type' => 'url' ),
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'single_input', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 4 ) )
+			 ->method( 'single_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		foreach ( $fields as $field ) {
+			$HTML->draw_input( $field );
+		}
+
+		//assert
+		// Passes when single_input() is called 4 times
+	}
+	/**
+     * Tests that the draw_input() method will call date() for field type 'date'.
+     *
+     * @group stable
+     * @group draw_input
+     */
+	function testDrawInputCallsDateForDateType() {
+		//arrange
+		$field = array( 'type' => 'date' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'date', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'date' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_input( $field );
+
+		//assert
+		// Passes when date() is called once
+	}
+	/**
+     * Tests that the draw_input() method will call single_input() twice if 
+     * field of type 'radio'.
+     *
+     * @group stable
+     * @group draw_input
+     */
+	function testDrawInputCallsSingleInputForRadioTypeTwice() {
+		//arrange
+		$field = array( 'type' => 'radio' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'single_input', ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 2 ) )
+			 ->method( 'single_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_input( $field );
+
+		//assert
+		// Passes when single_input() is called twice
+	}
+	/**
+     * Tests that the draw_input() method will call boolean_input() if given field
+     * of type 'boolean'.
+     *
+     * @group stable
+     * @group draw_input
+     */
+	function testDrawInputCallsBooleanInputForBooleanType() {
+		//arrange
+		$field = array( 'type' => 'boolean' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'boolean_input', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'boolean_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_input( $field );
+
+		//assert
+		// Passes when boolean_input() is called once
+	}
+	/**
+     * Tests that the draw_input() method will call url_input() if given field
+     * of type 'link'.
+     *
+     * @group stable
+     * @group draw_input
+     */
+	function testDrawInputCallsURLInputForLinkType() {
+		//arrange
+		$field = array( 'type' => 'link' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'url_input', ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'url_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->draw_input( $field );
+
+		//assert
+		// Passes when url_input() is called once
+	}
+	/**
+     * Tests that the url_input() method will call single_input() twice if given 
+     * field of type 'single_input'.
+     *
+     * @group stable
+     * @group url_input
+     */
+	function testURLInputCallsSingleInputTwice() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'single_input' ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$HTML->expects( $this->exactly( 2 ) )
+			 ->method( 'single_input' )
+			 ->will( $this->returnValue( true ) );
+
+		//act
+		$HTML->url_input( 'field', 'title', null, null, null );
+
+		//assert
+		// Passes when single_input() is called only once
+	}
+	/**
+     * Tests that the select() method will call single_input() twice if given 
+     * field of type 'single_input'.
+     *
+     * @group stable
+     * @group url_input
+     */
+	function testSelectWithGivenTaxonomyCallsWPGetObjectTermsAndGetTheIDAndWPDropdownCategories() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_the_ID' );
+		\WP_Mock::wpFunction( 'wp_get_object_terms', array( 'times' => 1, 'return' => array() ) );
+		\WP_Mock::wpFunction( 'wp_dropdown_categories' );
+
+		//act
+		$HTML->select( null, null, 'tax', null, null, null, null, null, null, null );
+	}
+	/**
+     * Tests that the date() method taxonomy will draw select.
+     *
+     * @group unstable
+     * @group date
+     */
+	function testDateCallsGetMonth24Times() {
+		//arrange
+		global $wp_locale;
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$wp_locale->expects( $this->exactly( 24 ) )
+				  ->method( 'get_month' )
+				  ->will( $this->returnValue( 'month' ) );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+
+		//act
+		$HTML->date( 'tax', false ,false, '' );
+
+		//assert
+		// passes when get month is called 24 times
+	}
+	/**
+     * Tests that the date() method will call hidden() once.
+     *
+     * @group stable
+     * @group date
+     */
+	function testDateCallsHiddenOnce() {
+		//arrange
+		global $wp_locale;
+		$term = new \StdClass;
+		$term->name = '1 April, 1992';
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'hidden' ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'hidden' )
+			 ->will( $this->returnValue( true ) );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( $term ) ) );
+
+		//act
+		$HTML->date( 'tax', false, false, '' );
+
+		//assert
+		// Fails if date doesn't call hidden() once
+	}
+	/***************************
+	 * HTML output tests *
+	 ***************************/
+	/**
+     * Tests that the draw() method will output the a title if set and if not
+     * field type is not 'formset'.
+     *
+     * @group unstable
+     * @group draw
+     */
+	function testDrawNotFormsetWithTitleExpectsTitle() {
+		//arrange
+		$field = array(
+			'type' => 'text',
+			'title' => 'Test Title',
+			'meta_key' => 'field'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'draw_input', ) )
+					 ->getMock();
+		$needle = '<h4 id="field" >Test Title</h4>';
+
+		//act
+		ob_start();
+		$HTML->draw( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the draw() method will not output the a title if not set.
+     *
+     * @group unstable
+     * @group draw
+     */
+	function testDrawNotFormsetWithoutTitleExpectsNoTitle() {
+		//arrange
+		$field = array(
+			'type' => 'text',
+			'meta_key' => 'field'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'draw_input', ) )
+					 ->getMock();
+		$needle = '<h4 id="field" >Test Title</h4>';
+
+		//act
+		ob_start();
+		$HTML->draw( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertNotContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the draw() method will output the a title if set and if not
+     * field type is not 'formset'.
+     *
+     * @group unstable
+     * @group draw
+     */
+	function testDrawFormsetWithTitleExpectsNoTitle() {
+		//arrange
+		$field = array(
+			'type' => 'formset',
+			'title' => 'Test Title',
+			'meta_key' => 'field'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'draw_formset', ) )
+					 ->getMock();
+		$needle = '<h4 id="field" >Test Title</h4>';
+
+		//act
+		ob_start();
+		$HTML->draw( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertNotContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the draw() method will output the 'howto' if set.
+     *
+     * @group unstable
+     * @group draw
+     */
+	function testDrawFieldHasHowToGetsEchoed() {
+		//arrange
+		$field = array(
+			'howto' => 'Testing howto'
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<p class="howto">Testing howto</p>';
+
+		//act
+		ob_start();
+		$HTML->draw( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the draw() method will not output the 'howto' if not set.
+     *
+     * @group unstable
+     * @group draw
+     */
+	function testDrawFieldDoesNotHaveHowToSetDoesNotGetEchoed() {
+		//arrange
+		$field = array();
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<p class="howto">';
+
+		//act
+		ob_start();
+		$HTML->draw( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertNotContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the draw() method will not output the 'howto' if not set.
+     *
+     * @group unstable
+     * @group draw
+     */
+	function testDrawFieldWrapsWithCMSToolkitWrapperDiv() {
+		//arrange
+		$field = array( 'class' => 'test' );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
+		$needle = '<div class="cms-toolkit-wrapper test"></div>';
+
+		//act
+		ob_start();
+		$HTML->draw( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the draw_formset() method will output div with field meta_key
+     * as html attribute id and concatenates it with 'formset'.
+     *
+     * @group unstable
+     * @group draw_formset
+     */
+	function testDrawFormsetShowsNewInitialField() {
+		//arrange
+		$field = array( 
+			'init' => true,
+			'meta_key' => 'test',
+			'fields' => array(),
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_post_custom' );
+		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
+		$needle = '<div id="test_formset">';
+
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the draw_formset() method will output a hidden div because when
+     * it is not an initial field and data does not exist for it.
+     *
+     * @group unstable
+     * @group draw_formset
+     */
+	function testDrawFormsetHidesNonexistentNoninitialField() {
+		//arrange
+		$field = array( 'meta_key' => 'test', 'fields' => array() );
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_post_custom' );
+		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
+		$needle = '<div id="test_formset" class="hidden new" disabled>';
+
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the draw_formset() method will output a hidden div because when
+     * it is not an initial field and data does not exist for it.
+     *
+     * @group unstable
+     * @group draw_formset
+     */
+	function testDrawFormsetHidesHeaderForInvisibleField() {
+		//arrange
+		$field = array(
+			'title' => 'Test Title',
+			'fields' => array(
+				array(
+					'meta_key' => 'test_field',
+				),
+			),
+			'meta_key' => 'test' 
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'get_post_custom' );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<h4 id="test_header" class="formset-header hidden">';
+		
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the draw_formset() method will output a header.
+     *
+     * @group unstable
+     * @group draw_formset
+     */
+	function testDrawFormsetShowsHeaderForVisibleField() {
+		//arrange
+		$field = array(
+			'title' => 'Test Title',
+			'fields' => array(
+				array(
+					'meta_key' => 'test_field',
+				),
+			),
+			'meta_key' => 'test',
+			'init' => true
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'get_post_custom' );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<h4 id="test_header" class="formset-header">';
+		
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the draw_formset() method will show remove link and hide add
+     * link when field has data and/or is an initial field.
+     *
+     * @group unstable
+     * @group draw_formset
+     */
+	function testDrawFormsetShowsRemoveButtonAndHidesAddButtonForVisibleField() {
+		//arrange
+		$field = array(
+			'title' => 'Test Title',
+			'fields' => array(
+				array(
+					'meta_key' => 'test_field',
+				),
+			),
+			'meta_key' => 'test' 
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_formset_id' ) )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_post_custom', array( 'return' => array('test_field' => 'data' ) ) );
+		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
+		$needle = '<div id="test_formset">';
+		$remove_button = '<a class="toggle_form_manager test remove " href="#remove-formset_">Remove</a>';
+		$add_button = '<a class="toggle_form_manager test add  hidden" href="#add-formset_">Add Test Title</a>';
+		
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+		$this->assertContains( $remove_button, $haystack );
+		$this->assertContains( $add_button, $haystack );
+	}	
+	/**
+     * Tests that the draw_formset() method will hide remove link and show add
+     * link when field has no data and is not an initial field.
+     *
+     * @group unstable
+     * @group draw_formset
+     */
+	function testDrawFormsetHidesRemoveButtonAndShowsAddButtonForInvisibleField() {
+		//arrange
+		$field = array(
+			'title' => 'Test Title',
+			'fields' => array(
+				array(
+					'meta_key' => 'test_field',
+				),
+			),
+			'meta_key' => 'test' 
+		);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
+					 ->getMock();
+		$HTML->method( 'get_formset_id' )
+			 ->will( $this->returnValue( 1 ) );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<div id="test_formset" class="hidden new" disabled>';
+		$remove_button = '<a class="toggle_form_manager test remove 1 hidden" href="#remove-formset_1">Remove</a>';
+		$add_button = '<a class="toggle_form_manager test add 1" href="#add-formset_1">Add Test Title</a>';
+		
+		//act
+		ob_start();
+		$HTML->draw_formset( $field );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+		$this->assertContains( $remove_button, $haystack );
+		$this->assertContains( $add_button, $haystack );
+	}
+	/**
+     * Tests that the text_area() method will draw label.
+     *
+     * @group unstable
+     * @group text_area
+     */
+	function testTextAreaDrawsLabelForFieldMetaKey() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label block-label" for="field">';
+
+		//act
+		ob_start();
+		$HTML->text_area( 'field', null, null, null, null, 'label-text', null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the text_area() method will draw textarea element.
+     *
+     * @group unstable
+     * @group text_area
+     */
+	function testTextAreaDrawsTextareaElement() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<textarea id="field_key" class="cms-toolkit-textarea form-input_12" name="field_key" rows="10" cols="40" value="This is the text." placeholder="Placeholder text." required>This is the text.</textarea>';
+
+		//act
+		ob_start();
+		$HTML->text_area( 'field_key', 'This is the text.', true, 10, 40, '', 'Placeholder text.', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the single_input() method will draw label.
+     *
+     * @group unstable
+     * @group single_input
+     */
+	function testSingleInputDrawsLabel() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label block-label" for="field">label</label>';
+
+		//act
+		ob_start();
+		$HTML->single_input( 'field', null, 'text', false, null, 'label', null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the single_input() method will draw input of given type.
+     *
+     * @group unstable
+     * @group single_input
+     */
+	function testSingleInputDrawsGivenTypeInput() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<input id="field" class="cms-toolkit-input form-input_12" name="field" type="text" maxlength="30" value="The text." placeholder="placeholder" required />';
+
+		//act
+		ob_start();
+		$HTML->single_input( 'field', 'The text.', 'text', true, 30, 'label', 'placeholder', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the boolean_input() method will draw label.
+     *
+     * @group unstable
+     * @group boolean_input
+     */
+	function testBooleanInputPrintsLabel() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label" for="field">label</label>';
+
+		//act
+		ob_start();
+		$HTML->boolean_input( 'field', 'title', false, 'label', null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the boolean_input() method will draw checkbox.
+     *
+     * @group unstable
+     * @group boolean_input
+     */
+	function testBooleanInputPrintsCheckboxInput() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<input id="field" class="cms-toolkit-checkbox form-input_12" name="field" type="checkbox" checked required />';
+
+		//act
+		ob_start();
+		$HTML->boolean_input( 'field', 'on', true, 'label', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the url_input() method will draw div with class 'link-field'.
+     *
+     * @group unstable
+     * @group url_input
+     */
+	function testURLInputPrintsDiv() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<div class="link-field field_key">';
+
+		//act
+		ob_start();
+		$HTML->url_input( 'field_key', null, null, null, null, null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the hidden() method will draw hidden input field.
+     *
+     * @group unstable
+     * @group hidden
+     */
+	function testHiddenPrintsHiddenField() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<input class="cms-toolkit-input form-input_12" id="field_key" name="field_key" type="hidden" value="value" />';
+
+		//act
+		ob_start();
+		$HTML->hidden( 'field_key', 'value', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the select() method will draw label.
+     *
+     * @group unstable
+     * @group select
+     */
+	function testSelectWithoutTaxonomyPrintsLabel() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label block-label" for="field_key">label</label>';
+
+		//act
+		ob_start();
+		$HTML->select( 'field_key', array(), false, false, null, false, null, 'label', null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the select() method without taxonomy will draw select with 
+     * blank option and it selected.
+     *
+     * @group unstable
+     * @group select
+     */
+	function testSelectWithoutTaxonomyAndWithoutOptionsPrintsSelectFieldWithOnlyBlankOption() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<select id="field_key" name="field_key[]" class="form-input_12" multiple required>';
+		$needle .= '<option selected value="">--</option></select>';
+
+		//act
+		ob_start();
+		$HTML->select( 'field_key', array(), false, false, null, true, '--', null, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the select() method without taxonomy will draw select with 
+     * blank option selected and other options.
+     *
+     * @group unstable
+     * @group select
+     */
+	function testSelectWithoutTaxonomyAndWithOptionsPrintsSelectFieldWithBlankOptionSelected() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle  = '<option selected value="">--</option>';
+		$needle .= '<option value="option1">option1</option>';
+		$needle .= '<option value="option2">option2</option></select>';
+
+		//act
+		ob_start();
+		$HTML->select( 'field_key', array( 'option1', 'option2' ), false, true, null, false, '--', null, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the select() method without taxonomy will draw select with 
+     * blank option and selected option.
+     *
+     * @group unstable
+     * @group select
+     */
+	function testSelectWithoutTaxonomyAndWithOptionsPrintsSelectFieldWithValueSelected() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<option selected="selected" value="option1">option1</option>';
+		$needle .= '<option value="option2">option2</option></select>';
+
+		//act
+		ob_start();
+		$HTML->select( 'field_key', array( 'option1', 'option2' ), false, true, 'option1', '--', 'Title', null, true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the post_select() method without taxonomy will draw label.
+     *
+     * @group unstable
+     * @group post_select
+     */
+	function testPostSelectPrintsLabel() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<label class="cms-toolkit-label block-label" for="field_key">label</label>';
+
+		//act
+		ob_start();
+		$HTML->post_select( 'field_key', array(), null, false, false, 'label', null, null );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the post_select() method without taxonomy will draw select.
+     *
+     * @group unstable
+     * @group post_select
+     */
+	function testPostSelectPrintsSelect() {		
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<select class="form-input_12" id="field_key" name="field_key[]" multi required >';
+
+		//act
+		ob_start();
+		$HTML->post_select( 'field_key', array(), null, 'multi', true, '', '--', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the post_select() method without taxonomy will draw blank option
+     * selected.
+     *
+     * @group unstable
+     * @group post_select
+     */
+	function testPostSelectPrintsBlankOptionSelectedWithoutValue() {
+		//arrange
+		$posts = array();
+		$post = new \StdClass;
+		$post->post_name = 'name1';
+		$post->post_title = 'title1';
+		array_push($posts, $post);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<option selected value="">--</option>';
+
+		//act
+		ob_start();
+		$HTML->post_select( 'field_key', $posts, null, null, false, null, '--', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the post_select() method without will draw select.
+     *
+     * @group unstable
+     * @group post_select
+     */
+	function testPostSelectPrintsBlankOptionWithSelectedValue() {
+		//arrange
+		$posts = array();
+		$post = new \StdClass;
+		$post->post_name = 'name1';
+		$post->post_title = 'title1';
+		array_push($posts, $post);
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<option selected value="name1">title1</option>';
+
+		//act
+		ob_start();
+		$HTML->post_select( 'field_key', $posts, 'name1', null, 'Title', null, true, '--', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the taxonomy_as_meta() method will draw select.
+     *
+     * @group unstable
+     * @group taxonomy_as_meta
+     */
+	function testTaxonomyAsMetaPrintsSelect() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		$needle = '<select class="multi form-input_12" name="field_slug[]" multi required>';
+
+		//act
+		ob_start();
+		$HTML->taxonomy_as_meta( 'field_slug', array(), 'tax', null, 'multi', true, '', '--', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the taxonomy_as_meta() method will draw blank option
+     * selected when no value given.
+     *
+     * @group unstable
+     * @group taxonomy_as_meta
+     */
+	function testTaxonomyAsMetaPrintsBlankOptionSelectedWithoutValue() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$term = new \StdClass;
+		$term->slug = 'option1';
+		$term->name = 'Option 1';
+		$term->count = 2;
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'get_term_by', array( 'return' => $term ) );
+		$needle = '<option selected value="" id="no_field_slug" name="field_slug">--</option>';
+		$needle .= '<option value="option1">Option 1 (2)</option></select>';
+
+		//act
+		ob_start();
+		$HTML->taxonomy_as_meta( 'field_slug', array( 'option1' ), 'tax', null, 'multi', true, '', '--', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the taxonomy_as_meta() method will draw option with
+     * blank option and value option selected.
+     *
+     * @group unstable
+     * @group taxonomy_as_meta
+     */
+	function testTaxonomyAsMetaPrintsBlankOptionWithValueSelected() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$term = new \StdClass;
+		$term->slug = 'option2';
+		$term->name = 'Option 2';
+		$term->count = 1;
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'get_term_by', array( 'return' => $term ) );
+		$needle = '<option selected value="option1" id="field_slug" name="field_slug">option1</option>';
+		$needle .= '<option value="option2">Option 2 (1)</option></select>';
+
+		//act
+		ob_start();
+		$HTML->taxonomy_as_meta( 'field_slug', array( 'option2' ), 'tax', 'option1', 'multi', '--', true, 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the date() method will draw select with blank option
+     * selected.
+     *
+     * @group unstable
+     * @group date
+     */
+	function testDatePrintSelectElementWithGenericOptionSelected() {
+		//arrange
+		global $wp_locale;
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$wp_locale->expects( $this->exactly( 24 ) )
+				  ->method( 'get_month' )
+				  ->will( $this->returnValue( 'month' ) );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+		$needle = '<select id="tax_month" name="tax_month" class="form-input_12">';
+		$needle .= '<option selected="selected" value="" >Month</option>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', false ,false, '', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the date() method will draw 24 options
+     *
+     * @group unstable
+     * @group date
+     */
+	function testDatePrintsAll12Months() {
+		//arrange
+		global $wp_locale;
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		$wp_locale->expects( $this->exactly( 24 ) )
+				  ->method( 'get_month' )
+				  ->will( $this->returnValue( 'month' ) );
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+		$needle = '<option value="month">month</option><option value="month">month</option>';
+		$needle .= '<option value="month">month</option><option value="month">month</option>';
+		$needle .= '<option value="month">month</option><option value="month">month</option>';
+		$needle .= '<option value="month">month</option><option value="month">month</option>';
+		$needle .= '<option value="month">month</option><option value="month">month</option>';
+		$needle .= '<option value="month">month</option><option value="month">month</option></select>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', false ,false, '', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the date() method will draw 24 options
+     *
+     * @group unstable
+     * @group date
+     */
+	function testDatePrintsInputsForDayAndYear() {
+		//arrange
+		global $wp_locale;
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+		$needle = '<input id="tax_day" type="text" name="tax_day" class="form-input_12" value="" size="2" maxlength="2" placeholder="DD"/>';
+		$needle .= '<input id="tax_year" type="text" name="tax_year" class="form-input_12" value="" size="4" maxlength="4" placeholder="YYYY"/>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', false ,false, '', 12 );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the date() method will print unique message for single date
+     *
+     * @group unstable
+     * @group date
+     */
+	function testDatePrintsOutputMessageForSingleDate() {
+		//arrange
+		global $wp_locale;
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+		$needle = '<p class="howto">If one is set already, selecting a new month, day and year will override it.</p>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', false, false, '' );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the date() method will print unique message for a muli-date
+     * field.
+     *
+     * @group unstable
+     * @group date
+     */
+	function testDatePrintsMessageForMultipleDates() {
+		//arrange
+		global $wp_locale;
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( 'term' ) ) );
+		$needle = '<p class="howto">Select a month, day and year to add another.</p>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', true, false, '' );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the date() method will draw date tag when stored as numeric.
+     *
+     * @group unstable
+     * @group date
+     */
+	function testDatePrintsDateWhenStoredAsNumeric() {
+		//arrange
+		global $wp_locale;
+		$term = new \StdClass;
+		$term->name = '1420748634';
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( $term ) ) );
+		$needle = '<span><a id="tax-check-num-0" class="datedelbutton 1420748634">1420748634</a>&nbsp;8 January, 2015</span>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', true, false, '' );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
+	}
+	/**
+     * Tests that the date() method will draw date tag when stored as a string.
+     *
+     * @group unstable
+     * @group date
+     */
+	function testDatePrintsDateWhenStoredAsString() {
+		//arrange
+		global $wp_locale;
+		$term = new \StdClass;
+		$term->name = '1 April, 1992';
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( null )
+					 ->getMock();
+		\WP_Mock::wpPassthruFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( $term ) ) );
+		$needle = '<span><a id="tax-check-num-0" class="datedelbutton 1 April, 1992">1 April, 1992</a>&nbsp;1 April, 1992</span>';
+
+		//act
+		ob_start();
+		$HTML->date( 'tax', true, false, '' );
+		$haystack = ob_get_flush();
+
+		//assert
+		$this->assertContains( $needle, $haystack );
 	}
 }

--- a/tests/test-meta_box_html.php
+++ b/tests/test-meta_box_html.php
@@ -540,7 +540,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when boolean_input() is called once
 	}
 	/**
-     * Tests that the draw_input() method will call url_input() if given field
+     * Tests that the draw_input() method will call link_input() if given field
      * of type 'link'.
      *
      * @group stable
@@ -550,24 +550,24 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		//arrange
 		$field = array( 'type' => 'link' );
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'url_input', ) )
+					 ->setMethods( array( 'link_input', ) )
 					 ->getMock();
 		$HTML->expects( $this->once() )
-			 ->method( 'url_input' )
+			 ->method( 'link_input' )
 			 ->will( $this->returnValue( true ) );
 
 		//act
 		$HTML->draw_input( $field );
 
 		//assert
-		// Passes when url_input() is called once
+		// Passes when link_input() is called once
 	}
 	/**
-     * Tests that the url_input() method will call single_input() twice if given 
+     * Tests that the link_input() method will call single_input() twice if given 
      * field of type 'single_input'.
      *
      * @group stable
-     * @group url_input
+     * @group link_input
      */
 	function testURLInputCallsSingleInputTwice() {		
 		//arrange
@@ -580,7 +580,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 			 ->will( $this->returnValue( true ) );
 
 		//act
-		$HTML->url_input( 'field', 'title', null, null, null );
+		$HTML->link_input( 'field', 'title', null, null, null );
 
 		//assert
 		// Passes when single_input() is called only once
@@ -590,7 +590,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
      * field of type 'single_input'.
      *
      * @group stable
-     * @group url_input
+     * @group link_input
      */
 	function testSelectWithGivenTaxonomyCallsWPGetObjectTermsAndGetTheIDAndWPDropdownCategories() {
 		//arrange
@@ -1137,10 +1137,10 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the url_input() method will draw div with class 'link-field'.
+     * Tests that the link_input() method will draw div with class 'link-field'.
      *
      * @group unstable
-     * @group url_input
+     * @group link_input
      */
 	function testURLInputPrintsDiv() {		
 		//arrange
@@ -1152,7 +1152,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 
 		//act
 		ob_start();
-		$HTML->url_input( 'field_key', null, null, null, null, null, null );
+		$HTML->link_input( 'field_key', null, null, null, null, null, null );
 		$haystack = ob_get_flush();
 
 		//assert

--- a/tests/test-meta_box_models.php
+++ b/tests/test-meta_box_models.php
@@ -3,1311 +3,1694 @@ use CFPB\Utils\MetaBox\Models;
 use CFPB\Utils\MetaBox\Callbacks;
 
 class TestValidBox extends Models {
-	public $title = 'Meta Box';
-	public $slug = 'meta_box';
-	public $post_type = 'post';
-	public $context = 'side';
-	public $priority = 'default';
-	public $fields = array(
-		'field_one' => array(
-			'title' => 'This is a field',
-			'slug' => 'field_one',
-			'type' => 'text_area',
-			'params' => array(
-				'cols' => 27,
-			),
-			'placeholder' => 'Enter text',
-			'howto' => 'Type some text',
-			'meta_key' => 'field_one',
-		),
-		'field_two' => array(
-			'slug' => 'field_two',
-			'title' => 'This is another field',
-			'type' => 'number',
-			'params' => array(),
-			'placeholder' => '0-100',
-			'howto' => 'Type a number',
-			'meta_key' => 'field_two',
-		),
-	);
+    public $title = 'Meta Box';
+    public $slug = 'meta_box';
+    public $post_type = 'post';
+    public $context = 'side';
+    public $priority = 'default';
+    public $fields = array(
+        'field_one' => array(
+            'title' => 'This is a field',
+            'slug' => 'field_one',
+            'type' => 'text_area',
+            'params' => array(
+                'cols' => 27,
+            ),
+            'placeholder' => 'Enter text',
+            'howto' => 'Type some text',
+            'meta_key' => 'field_one',
+        ),
+        'field_two' => array(
+            'slug' => 'field_two',
+            'title' => 'This is another field',
+            'type' => 'number',
+            'params' => array(),
+            'placeholder' => '0-100',
+            'howto' => 'Type a number',
+            'meta_key' => 'field_two',
+        ),
+    );
 }
 
 class TestNumberField extends Models {
-	public $title = 'Meta Box';
-	public $slug = 'meta_box';
-	public $post_type = 'post';
-	public $context = 'side';
-	public $fields = array(
-		'field_one' => array(
-			'slug' => 'field_one',
-			'title' => 'This is another field',
-			'type' => 'number',
-			'params' => array(),
-			'placeholder' => '0-100',
-			'howto' => 'Type a number',
-			'meta_key' => 'field_one',
-		),
-	);
+    public $title = 'Meta Box';
+    public $slug = 'meta_box';
+    public $post_type = 'post';
+    public $context = 'side';
+    public $fields = array(
+        'field_one' => array(
+            'slug' => 'field_one',
+            'title' => 'This is another field',
+            'type' => 'number',
+            'params' => array(),
+            'placeholder' => '0-100',
+            'howto' => 'Type a number',
+            'meta_key' => 'field_one',
+        ),
+    );
 }
 
 class TestValidTextField extends Models {
-	public $post_type = 'post';
-	public $fields = array(
-		'one' => array(
-			'title' => 'Text Field',
-			'slug' => 'one',
-			'label' => 'Text Label',
-			'type' => 'text',
-			'params' => array('max_length' => 255),
-			'placeholder' => 'Type some text',
-			'howto' => 'Up to 255 characters',
-			'meta_key' => 'one',
-		),
-	);
+    public $post_type = 'post';
+    public $fields = array(
+        'one' => array(
+            'title' => 'Text Field',
+            'slug' => 'one',
+            'label' => 'Text Label',
+            'type' => 'text',
+            'params' => array('max_length' => 255),
+            'placeholder' => 'Type some text',
+            'howto' => 'Up to 255 characters',
+            'meta_key' => 'one',
+        ),
+    );
 }
 
 class TestValidTextAreaField extends Models {
-	public $post_type = 'post';
-	public $fields = array(
-		'one' => array(
-			'title' => 'Text Area Field',
-			'slug' => 'one',
-			'label' => 'Text Label',
-			'type' => 'text_area',
-			'params' => array('max_length' => 255),
-			'placeholder' => 'Type some text',
-			'howto' => 'Up to 255 characters',
-			'meta_key' => 'one',
-		),
-	);
+    public $post_type = 'post';
+    public $fields = array(
+        'one' => array(
+            'title' => 'Text Area Field',
+            'slug' => 'one',
+            'label' => 'Text Label',
+            'type' => 'text_area',
+            'params' => array('max_length' => 255),
+            'placeholder' => 'Type some text',
+            'howto' => 'Up to 255 characters',
+            'meta_key' => 'one',
+        ),
+    );
 }
 
 class TestValidEmailField extends Models {
-	public $post_type = 'post';
-	public $fields = array(
-		'one' => array(
-			'title' => 'Email Field',
-			'slug' => 'one',
-			'label' => 'Email Label',
-			'type' => 'email',
-			'params' => array(),
-			'placeholder' => 'Type some text',
-			'howto' => 'Up to 255 characters',
-			'meta_key' => 'one',
-		),
-	);
+    public $post_type = 'post';
+    public $fields = array(
+        'one' => array(
+            'title' => 'Email Field',
+            'slug' => 'one',
+            'label' => 'Email Label',
+            'type' => 'email',
+            'params' => array(),
+            'placeholder' => 'Type some text',
+            'howto' => 'Up to 255 characters',
+            'meta_key' => 'one',
+        ),
+    );
 }
 
 class TestValidDateField extends Models {
-	public $post_type = 'post';
-	public $fields = array(
-		'category' => array(
-			'title' => 'Issued date:',
-			'slug' => 'category',
-			'label' => '',
-			'type' => 'date',
-			'params' => array(),
-			'multiple' => false,
-			'placeholder' => '',
-			'howto' => '',
-			'taxonomy' => 'category',
-		),
-	);
+    public $post_type = 'post';
+    public $fields = array(
+        'category' => array(
+            'title' => 'Issued date:',
+            'slug' => 'category',
+            'label' => '',
+            'type' => 'date',
+            'params' => array(),
+            'multiple' => false,
+            'placeholder' => '',
+            'howto' => '',
+            'taxonomy' => 'category',
+        ),
+    );
+}
+
+class TestValidFieldsetField extends Models {
+    public $post_type = 'post';
+    public $fields = array(
+        'field' => array(
+            'type' => 'fieldset',
+            'fields' => array(
+                array(
+                    'type' => 'text',
+                    'meta_key' => 'num',
+                ),
+                array(
+                    'type' => 'text',
+                    'meta_key' => 'desc',
+                ),
+            ),
+            'params' => array(),
+            'meta_key' => 'field',
+        ),
+    );
+}
+
+class TestValidFormsetField extends Models {
+    public $post_type = 'post';
+    public $fields = array(
+        'field' => array(
+            'type' => 'formset',
+            'fields' => array(
+                array(
+                    'title' => 'Title',
+                    'type' => 'text',
+                    'meta_key' => 'title',
+                ),
+            ),
+            'params' => array(
+                'init_num_forms' => 1,
+                'max_num_forms' => 2,
+            ),
+            'meta_key' => 'field',
+        ),
+    );
 }
 
 class ValidationTest extends PHPUnit_Framework_TestCase {
-	function setUp() {
-		global $post;
-		$post = new \StdClass;
-		$post->ID = 1;
-		$post->post_type = 'post';
-		\WP_Mock::setUp();
-	}
+    function setUp() {
+        global $post;
+        $post = new \StdClass;
+        $post->ID = 1;
+        $post->post_type = 'post';
+        \WP_Mock::setUp();
+    }
 
-	function tearDown() {
-		\WP_Mock::tearDown();
-	}
+    function tearDown() {
+        \WP_Mock::tearDown();
+    }
 
+/***************************
+ * Error handling tests *
+ ***************************/
+    /**
+     * Tests whether the validate_and_save method will throw an error if there
+     * is an empty fields array.
+     *
+     *
+     * @group stable
+     * @group empty_data
+     * @group isolated
+     * @group validation
+     */
+    function testEmptyFieldsArrayExpectsError() {
+        // arrange
+        $TestValidTextField = new TestValidTextField();
+        $TestValidTextField->fields = array();
+        $stub = $this->getMockBuilder( '\WP_Error' )
+                     ->setMethods( array('get_error_message') )
+                     ->getMock();
+        $TestValidTextField->error_handler($stub);
+        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+        $TestValidTextField->error->expects( $this->once() )
+             ->method( 'get_error_message' )
+             ->will( $this->returnValue( true ) );
+
+        // act
+        $TestValidTextField->validate_and_save( $post->ID );
+        
+        // assert
+        // Passes when error is called
+    }
+    /**
+     * Tests if the validate method will throw an error if there
+     * is the type of the field is not set.
+     *
+     *
+     * @group stable
+     * @group empty_data
+     * @group isolated
+     * @group validation
+     */
+    function testFieldTypeIsNotSetExpectsError() {
+        // arrange
+        $TestValidTextField = new TestValidTextField();
+        $TestValidTextField->fields['one']['type'] = null;
+        $stub = $this->getMockBuilder( '\WP_Error' )
+                     ->setMethods( array('get_error_message') )
+                     ->getMock();
+        $TestValidTextField->error_handler($stub);
+        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+        $TestValidTextField->error->expects( $this->once() )
+             ->method( 'get_error_message' )
+             ->will( $this->returnValue( true ) );
+
+        // act
+        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
+        
+        // assert
+        // Passes when error is called
+    }
+    /**
+     * Tests if the validate method will throw an error if the field does not have
+     * the meta_key, slug, or taxonomy set.
+     *
+     *
+     * @group stable
+     * @group empty_data
+     * @group isolated
+     * @group validation
+     */
+    function testFieldMetakeySlugTaxonomyIsNotSetExpectsError() {
+        // arrange
+        $TestValidTextField = new TestValidTextField();
+        $TestValidTextField->fields['one']['meta_key'] = null;
+        $TestValidTextField->fields['one']['slug'] = null;
+        $TestValidTextField->fields['one']['taxonomy'] = null;
+        $stub = $this->getMockBuilder( '\WP_Error' )
+                     ->setMethods( array('get_error_message') )
+                     ->getMock();
+        $TestValidTextField->error_handler($stub);
+        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+        $TestValidTextField->error->expects( $this->once() )
+             ->method( 'get_error_message' )
+             ->will( $this->returnValue( true ) );
+
+        // act
+        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
+        
+        // assert
+        // Passes when error is called
+    }
+    /**
+     * Tests if the validate method will throw an error if the field does not have
+     * the taxonomy set when required for taxonomyselect field.
+     *
+     *
+     * @group stable
+     * @group empty_data
+     * @group isolated
+     * @group validation
+     */
+    function testFieldTypeTaxonomyselectWhereTaxonomyIsNotSetExpectsError() {
+        // arrange
+        $TestValidTextField = new TestValidTextField();
+        $TestValidTextField->fields['one']['taxonomy'] = null;
+        $TestValidTextField->fields['one']['type'] = 'taxonomyselect';
+        $stub = $this->getMockBuilder( '\WP_Error' )
+                     ->setMethods( array('get_error_message') )
+                     ->getMock();
+        $TestValidTextField->error_handler($stub);
+        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+        $TestValidTextField->error->expects( $this->once() )
+             ->method( 'get_error_message' )
+             ->will( $this->returnValue( true ) );
+
+        // act
+        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
+        
+        // assert
+        // Passes when error is called
+    }
+    /**
+     * Tests if the validate method will throw an error if the field does not have
+     * the taxonomy set when required for date field.
+     *
+     *
+     * @group stable
+     * @group empty_data
+     * @group isolated
+     * @group validation
+     */
+    function testFieldTypeDateWhereTaxonomyIsNotSetExpectsError() {
+        // arrange
+        $TestValidTextField = new TestValidTextField();
+        $TestValidTextField->fields['one']['taxonomy'] = null;
+        $TestValidTextField->fields['one']['type'] = 'date';
+        $stub = $this->getMockBuilder( '\WP_Error' )
+                     ->setMethods( array('get_error_message') )
+                     ->getMock();
+        $TestValidTextField->error_handler($stub);
+        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+        $TestValidTextField->error->expects( $this->once() )
+             ->method( 'get_error_message' )
+             ->will( $this->returnValue( true ) );
+
+        // act
+        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
+        
+        // assert
+        // Passes when error is called
+    }
+    /**
+     * Tests if the validate method will throw an error if the field does not have
+     * the meta_key set when required for select field(s). This will only test 
+     * one of the fields of the selects array.
+     *
+     * @group stable
+     * @group empty_data
+     * @group isolated
+     * @group validation
+     */
+    function testFieldTypeOfSelectsArrayWhereMetakeyIsNotSetExpectsError() {
+        // arrange
+        $TestValidTextField = new TestValidTextField();
+        $TestValidTextField->fields['one']['meta_key'] = null;
+        $TestValidTextField->fields['one']['type'] = 'select';
+        $stub = $this->getMockBuilder( '\WP_Error' )
+                     ->setMethods( array('get_error_message') )
+                     ->getMock();
+        $TestValidTextField->error_handler($stub);
+        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+        $TestValidTextField->error->expects( $this->once() )
+             ->method( 'get_error_message' )
+             ->will( $this->returnValue( true ) );
+
+        // act
+        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
+        
+        // assert
+        // Passes when error is called
+    }
+    /**
+     * Tests if the validate method will throw an error if the field of formset
+     * type does not have a params array set.
+     *
+     * @group stable
+     * @group empty_data
+     * @group isolated
+     * @group validation
+     */
+    function testFieldTypeFormsetWhereParamsArrayIsNotSetExpectsError() {
+        // arrange
+        $TestValidTextField = new TestValidFormsetField();
+        $TestValidTextField->fields['field']['params'] = null;
+        $stub = $this->getMockBuilder( '\WP_Error' )
+                     ->setMethods( array('get_error_message') )
+                     ->getMock();
+        $TestValidTextField->error_handler($stub);
+        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+        $TestValidTextField->error->expects( $this->once() )
+             ->method( 'get_error_message' )
+             ->will( $this->returnValue( true ) );
+
+        // act
+        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['field'] ), $actual );
+        
+        // assert
+        // Passes when error is called
+    }
+    /**
+     * Tests if the validate method will throw an error if the field of formset
+     * type does not have a max_num_forms set in the params array.
+     *
+     * @group stable
+     * @group empty_data
+     * @group isolated
+     * @group validation
+     */
+    function testFieldTypeFormsetWhereMaxNumFormsInParamsArrayIsNotSetExpectsError() {
+        // arrange
+        $TestValidTextField = new TestValidFormsetField();
+        $TestValidTextField->fields['field']['params']['max_num_forms'] = null;
+        $stub = $this->getMockBuilder( '\WP_Error' )
+                     ->setMethods( array('get_error_message') )
+                     ->getMock();
+        $TestValidTextField->error_handler($stub);
+        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+        $TestValidTextField->error->expects( $this->once() )
+             ->method( 'get_error_message' )
+             ->will( $this->returnValue( true ) );
+
+        // act
+        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['field'] ), $actual );
+        
+        // assert
+        // Passes when error is called
+    }
 /***************************
  * Validation method tests *
  ***************************/
-	/**
-	 * Tests whether the validate method will save a null value to the array if
-	 * data from $_POST is missing
-	 *
-	 * If a form is submitted with a field deleted, no key for that field is 
-	 * assigned in the $_POST superglobal. This is fine if the field is already 
-	 * empty but if the field is pre-populated it can make getting rid of the 
-	 * data impossible. This passes the key with a null value to make the data
-	 * more reliable for `save`.
-	 *
-	 * @group stable
-	 * @group empty_data
-	 * @group isolated
-	 * @group validation
-	 */
-	function testEmptyPOSTExpectsNullArrayForFieldKey() {
-		// arrange
-		$_POST = array();
-		global $post;
-		$TestValidTextField = new TestValidTextField();
-		$actual = array();
-		// act
-		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields ), $actual );
-		// assert
-		$this->assertTrue( empty( $actual ) );
-	}
-	/**
-	 * Tests whether the validate method when called on an email field calls
-	 * 'sanitize_email' from the WP API once
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group user_input
-	 * @group validation
-	 */
+    /**
+     * Tests whether the validate method will save a null value to the array if
+     * data from $_POST is missing
+     *
+     * If a form is submitted with a field deleted, no key for that field is 
+     * assigned in the $_POST superglobal. This is fine if the field is already 
+     * empty but if the field is pre-populated it can make getting rid of the 
+     * data impossible. This passes the key with a null value to make the data
+     * more reliable for `save`.
+     *
+     * @group stable
+     * @group empty_data
+     * @group isolated
+     * @group validation
+     */
+    function testEmptyPOSTExpectsNullArrayForFieldKey() {
+        // arrange
+        $_POST = array();
+        global $post;
+        $TestValidTextField = new TestValidTextField();
+        $actual = array();
+        // act
+        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields ), $actual );
+        // assert
+        $this->assertTrue( empty( $actual ) );
+    }
+    /**
+     * Tests whether the validate method when called on an email field calls
+     * 'sanitize_email' from the WP API once
+     *
+     * @group stable
+     * @group isolated
+     * @group user_input
+     * @group validation
+     */
 
-	function testEmailExpectsSanitizeMethodCalled() {
-		// arrange
-		global $post;
-		\WP_Mock::wpPassthruFunction('sanitize_email', array('times' => 1));
-		$TestValidEmailField = new TestValidEmailField();
-		$_POST = array(
-			'one' => 'foo@bar.baz',
-		);
-		$actual = array();
-		// act
-		$TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual);
-	}
+    function testEmailExpectsSanitizeMethodCalled() {
+        // arrange
+        global $post;
+        \WP_Mock::wpPassthruFunction('sanitize_email', array('times' => 1));
+        $TestValidEmailField = new TestValidEmailField();
+        $_POST = array(
+            'one' => 'foo@bar.baz',
+        );
+        $actual = array();
+        // act
+        $TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual);
+    }
 
-	// /**
-	//  * Tests whether WP_Error is returned if missing a piece of a date.
-	//  *
-	//  * @group stable
-	//  * @group isolated
-	//  * @group date
-	//  * @group user_input
-	//  * @group validation
-	//  */
-	// function testInvalidDateValidateExpectsDateCalledNone() {
-	// 	// arrange
-	// 	$stub = $this->getMockBuilder('Callbacks')
-	// 				 ->setMethods( array( 'validate_date' ) )
-	// 				 ->getMock();
+    /**
+     * Tests whether a number field has data replaced
+     *
+     * @group number
+     * @group stable
+     * @group isolated
+     * @group user_input
+     * @group validation
+     */
+    function testValidNumberFieldExpectsDataReturned() {
+        $TestNumberField = new TestNumberField();
+        $_POST = array(
+            'post_ID' => 1,
+            'field_one' => 2,
+        );
+        $actual = array();
 
-	// 	$form = new TestValidDateField();
-	// 	$form->set_callbacks($stub);
-	// 	$_POST =array('post_ID' => 1, 'category_year' => '1970');
-	// 	$actual = array();
-	// 	// act
-	// 	$form->validate($_POST['post_ID'], $form->fields['category'], $actual);
+        // act
+        $TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual);
 
-	// 	// assert
-	// 	$this->assertInstanceOf( 'WP_Error', $actual)
-	// }
+        // assert
+        $expected = 2;
+        $this->assertEquals(
+            $expected,
+            $actual['field_one'],
+            'Numeric strings should be accepted and converted to a number.');
+    }
 
-	/**
-	 * Tests whether a number field has data replaced
-	 *
-	 * @group number
-	 * @group stable
-	 * @group isolated
-	 * @group user_input
-	 * @group validation
-	 */
-	function testValidNumberFieldExpectsDataReturned() {
-		$TestNumberField = new TestNumberField();
-		$_POST = array(
-			'post_ID' => 1,
-			'field_one' => 2,
-		);
-		$actual = array();
+    /**
+     * Tests whether an invalid number is not accepted
+     *
+     * @group stable
+     * @group isolated
+     * @group number
+     * @group user_input
+     * @group validation
+     *
+     */
+    function testInvalidNumericFieldExpectsDataRemoved() {
 
-		// act
-		$TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual);
+        // arrange
+        
+        $TestNumberField = new TestNumberField();
+        $_POST = array(
+            'post_ID' => 1,
+            'field_one' => 'Two',
+        );
+        $actual = array();
 
-		// assert
-		$expected = 2;
-		$this->assertEquals(
-			$expected,
-			$actual['field_one'],
-			'Numeric strings should be accepted and converted to a number.');
-	}
+        // act
+        $TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual);
+        // assert
+        $expected = null;
+        $this->assertEquals(
+            $expected,
+            $actual['field_one'],
+            'Non-numeric strings should not be accepted for a number input type.'
+        );
+    }
 
-	/**
-	 * Tests whether an invalid number is not accepted
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group number
-	 * @group user_input
-	 * @group validation
-	 *
-	 */
-	function testInvalidNumericFieldExpectsDataRemoved() {
+    /**
+     * Tests whether a text field accepts and returns a textual string
+     *
+     * @group user_input
+     * @group stable
+     * @group isolated
+     * @group text
+     * @group validation
+     */
+    function testTextFieldExpectsStringReturned() {
 
-		// arrange
-		
-		$TestNumberField = new TestNumberField();
-		$_POST = array(
-			'post_ID' => 1,
-			'field_one' => 'Two',
-		);
-		$actual = array();
+        // arrange
+        $TestValidTextField = new TestValidTextField();
+        $TestValidTextField->fields['one']['type'] = 'text';
+        $_POST = array(
+            'post_ID' => 1,
+            'one' => 'Text field expects a string',
+        );
+        $actual = array();
 
-		// act
-		$TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual);
-		// assert
-		$expected = null;
-		$this->assertEquals(
-			$expected,
-			$actual['field_one'],
-			'Non-numeric strings should not be accepted for a number input type.'
-		);
-	}
+        // act
+        $TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['one'], $actual);
 
-	/**
-	 * Tests whether a text field accepts and returns a textual string
-	 *
-	 * @group user_input
-	 * @group stable
-	 * @group isolated
-	 * @group text
-	 * @group validation
-	 */
-	function testTextFieldExpectsStringReturned() {
+        // assert
+        $this->assertEquals(
+            'Text field expects a string',
+            $actual['one']
+        );
+    }
 
-		// arrange
-		$TestValidTextField = new TestValidTextField();
-		$TestValidTextField->fields['one']['type'] = 'text';
-		$_POST = array(
-			'post_ID' => 1,
-			'one' => 'Text field expects a string',
-		);
-		$actual = array();
+    /**
+     * Tests wheter an integer is converted to a string if field == text
+     *
+     * @group text
+     * @group user_input
+     * @group stable
+     * @group isolated
+     * @group validation
+     */
+    function testTextFieldGivenNumberExpectsNumericStringValueReturned() {
 
-		// act
-		$TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['one'], $actual);
+        // arrange
+        global $post;
+        $TestValidTextField = new TestValidTextField();
+        $TestValidTextField->fields['one']['type'] = 'text';
+        $_POST = array(
+            'post_ID' => 1,
+            'one' => 1,
+        );
+        $actual = array();
 
-		// assert
-		$this->assertEquals(
-			'Text field expects a string',
-			$actual['one']
-		);
-	}
+        // act
+        $TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['one'], $actual);
 
-	/**
-	 * Tests wheter an integer is converted to a string if field == text
-	 *
-	 * @group text
-	 * @group user_input
-	 * @group stable
-	 * @group isolated
-	 * @group validation
-	 */
-	function testTextFieldGivenNumberExpectsNumericStringValueReturned() {
+        // assert
+        $this->assertEquals('1', $actual['one']);
+    }
 
-		// arrange
-		global $post;
-		$TestValidTextField = new TestValidTextField();
-		$TestValidTextField->fields['one']['type'] = 'text';
-		$_POST = array(
-			'post_ID' => 1,
-			'one' => 1,
-		);
-		$actual = array();
+    /**
+     * Tests whether a text area field accepts and returns a string.
+     *
+     * @group textarea
+     * @group isolated
+     * @group stable
+     * @group validation
+     *
+     */
+    function testTextAreaFieldExpectsStringReturned() {
+        // arrange
+        global $post;
+        $post = new \StdClass();
+        $post->ID = 1;
+        $post->post_type = 'post';
+        $TestValidTextAreaField = new TestValidTextAreaField();
+        // \WP_Mock::wpFunction(
+        //  'get_post',
+        //  array('times' => 1, 'returns' => $post)
+        // );
+        $_POST = array(
+            'post_ID' => 1,
+            'one' => 'Foo',
+        );
+        $actual = array();
 
-		// act
-		$TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['one'], $actual);
+        // act
+        $TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
 
-		// assert
-		$this->assertEquals('1', $actual['one']);
-	}
+        //assert
+        $this->assertEquals('Foo', $actual['one']);
+    }
 
-	/**
-	 * Tests whether a text area field accepts and returns a string.
-	 *
-	 * @group textarea
-	 * @group isolated
-	 * @group stable
-	 * @group validation
-	 *
-	 */
-	function testTextAreaFieldExpectsStringReturned() {
-		// arrange
-		global $post;
-		$post = new \StdClass();
-		$post->ID = 1;
-		$post->post_type = 'post';
-		$TestValidTextAreaField = new TestValidTextAreaField();
-		// \WP_Mock::wpFunction(
-		// 	'get_post',
-		// 	array('times' => 1, 'returns' => $post)
-		// );
-		$_POST = array(
-			'post_ID' => 1,
-			'one' => 'Foo',
-		);
-		$actual = array();
+    /**
+     * tests whether an array is not accepted and an error is returned.
+     * @group strings
+     * @group isolated
+     * @group user_input
+     * @group stable
+     * @group returns_null
+     * @group validation
+     */
+    function testTextAreaFieldNonStringExpectsNullReturned() {
+        // arrange
+        global $post; 
+        // $post = new StdClass;
+        // $post->post_type = 'post';
+        // $post->ID = 1;
+        $stub = $this->getMock('\WP_Error', array('get_error_message'));
+        // \WP_Mock::wpFunction(
+        //  'get_post',
+        //  array('times' => 1, 'return' => $post));
+        $TestValidTextAreaField = new TestValidTextAreaField();
+        $TestValidTextAreaField->error_handler($stub);
+        $_POST = array(
+            'post_ID' => 1,
+            'one' => null,
+        );
+        $actual = array();
 
-		// act
-		$TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
+        // act
+        $TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
 
-		//assert
-		$this->assertEquals('Foo', $actual['one']);
-	}
+        // assert
+        $this->assertTrue( is_null($actual['one']) );
+    }
 
-	/**
-	 * tests whether an array is not accepted and an error is returned.
-	 * @group strings
-	 * @group isolated
-	 * @group user_input
-	 * @group stable
-	 * @group returns_null
-	 * @group validation
-	 */
-	function testTextAreaFieldNonStringExpectsNullReturned() {
-		// arrange
-		global $post; 
-		// $post = new StdClass;
-		// $post->post_type = 'post';
-		// $post->ID = 1;
-		$stub = $this->getMock('\WP_Error', array('get_error_message'));
-		// \WP_Mock::wpFunction(
-		// 	'get_post',
-		// 	array('times' => 1, 'return' => $post));
-		$TestValidTextAreaField = new TestValidTextAreaField();
-		$TestValidTextAreaField->error_handler($stub);
-		$_POST = array(
-			'post_ID' => 1,
-			'one' => null,
-		);
-		$actual = array();
+    /**
+     * Tests whether url field data will be sent to WordPress and sanitized
+     *
+     * @group urls
+     * @group user_input
+     * @group stable
+     * @group isolated
+     * @group validation
+     */
+    function testURLFieldExpectsEscRawURLCall() {
+        // arrange
+        global $post;
+        \WP_Mock::wpPassthruFunction(
+            'esc_url_raw',
+            array('times' => 1, 'return' => 'http://google.com')
+        );
+        // \WP_Mock::wpFunction(
+        //  'get_post',
+        //  array('times' => 1,'return' => $post,)
+        // );
+        $TestValidEmailField = new TestValidEmailField();
+        $TestValidEmailField->fields['one']['type'] = 'url';
+        $_POST = array(
+            'one' => 'http://google.com',
+        );
+        $actual = array();
 
-		// act
-		$TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
+        // act
+        $TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual );
 
-		// assert
-		$this->assertTrue( is_null($actual['one']) );
-	}
+        // assert
+        $this->assertEquals($actual['one'], 'http://google.com');
+    }
 
-	/**
-	 * Tests whether url field data will be sent to WordPress and sanitized
-	 *
-	 * @group urls
-	 * @group user_input
-	 * @group stable
-	 * @group isolated
-	 * @group validation
-	 */
-	function testURLFieldExpectsEscRawURLCall() {
-		// arrange
-		global $post;
-		\WP_Mock::wpPassthruFunction(
-			'esc_url_raw',
-			array('times' => 1, 'return' => 'http://google.com')
-		);
-		// \WP_Mock::wpFunction(
-		// 	'get_post',
-		// 	array('times' => 1,'return' => $post,)
-		// );
-		$TestValidEmailField = new TestValidEmailField();
-		$TestValidEmailField->fields['one']['type'] = 'url';
-		$_POST = array(
-			'one' => 'http://google.com',
-		);
-		$actual = array();
+    /**
+     * Tests whether validate will call the appropriate special validator for 
+     * a taxonomy select field.
+     *
+     * @group stable
+     * @group isolated
+     * @group taxonomy_select
+     * @group validation
+     */
+    function testTaxonomySelectFieldExpectsTaxonomySelectValidatorCalled() {
+        // arrange
+        global $post;
+        $factory = $this->getMockBuilder('TestValidDateField')
+                        ->setMethods(array('validate_taxonomyselect',))
+                        ->getMock();
+        $factory->fields['category']['type'] = 'taxonomyselect';
 
-		// act
-		$TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual );
+        $factory->expects($this->once())
+                ->method('validate_taxonomyselect')
+                ->will($this->returnValue(true));
+        $actual = array();
 
-		// assert
-		$this->assertEquals($actual['one'], 'http://google.com');
-	}
+        // act
+        $factory->validate($post->ID, $factory->fields['category'], $actual);
 
-	/**
-	 * Tests whether validate will call the appropriate special validator for 
-	 * a taxonomy select field.
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group taxonomy_select
-	 * @group validation
-	 */
-	function testTaxonomySelectFieldExpectsTaxonomySelectValidatorCalled() {
-		// arrange
-		global $post;
-		$factory = $this->getMockBuilder('TestNumberField')
-						->setMethods(array('validate_taxonomyselect',))
-						->getMock();
+        // assert
+        // Test will fail if validate_taxonomyselect called more than once
+    }
 
-		$factory->expects($this->once())
-				->method('validate_taxonomyselect')
-				->will($this->returnValue(true));
-		$factory->fields['field_one']['type'] = 'taxonomyselect';
-		$actual = array();
+    /**
+     * Tests whether validate will call the appropriate special validator for 
+     * a select field.
+     *
+     * @group stable
+     * @group isolated
+     * @group taxonomy_select
+     * @group validation
+     */
+    function testSelectFieldExpectsTaxonomySelectValidatorCalled() {
+        // arrange
+        global $post;
+        $factory = $this->getMockBuilder('TestNumberField')
+                        ->setMethods(array('validate_select',))
+                        ->getMock();
 
-		// act
-		$factory->validate($post->ID, $factory->fields['field_one'], $actual);
+        $factory->expects($this->once())
+                ->method('validate_select')
+                ->will($this->returnValue(true));
+        $factory->fields['field_one']['type'] = 'select';
+        $actual = array();
 
-		// assert
-		// Test will fail if validate_taxonomyselect called more than once
-	}
+        // act
+        $factory->validate($post->ID, $factory->fields['field_one'], $actual);
 
-	/**
-	 * Tests whether validate will call the appropriate special validator for 
-	 * a select field.
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group taxonomy_select
-	 * @group validation
-	 */
-	function testSelectFieldExpectsTaxonomySelectValidatorCalled() {
-		// arrange
-		global $post;
-		$factory = $this->getMockBuilder('TestNumberField')
-						->setMethods(array('validate_select',))
-						->getMock();
+        // assert
+        // Test will fail if validate_taxonomyselect called more than once
+    }
 
-		$factory->expects($this->once())
-				->method('validate_select')
-				->will($this->returnValue(true));
-		$factory->fields['field_one']['type'] = 'select';
-		$actual = array();
+    /**
+     * Tests whether validate will call the appropriate special validator for 
+     * a link field.
+     *
+     * @group stable
+     * @group isolated
+     * @group taxonomy_select
+     * @group validation
+     */
+    function testLinkFieldExpectsTaxonomySelectValidatorCalled() {
+        // arrange
+        global $post;
+        $factory = $this->getMockBuilder('TestNumberField')
+                        ->setMethods(array('validate_link',))
+                        ->getMock();
 
-		// act
-		$factory->validate($post->ID, $factory->fields['field_one'], $actual);
+        $factory->expects($this->once())
+                ->method('validate_link')
+                ->will($this->returnValue(true));
+        $factory->fields['field_one']['type'] = 'link';
+        $actual = array();
 
-		// assert
-		// Test will fail if validate_taxonomyselect called more than once
-	}
+        // act
+        $factory->validate($post->ID, $factory->fields['field_one'], $actual);
 
-	/**
-	 * Tests whether validate will call the appropriate special validator for 
-	 * a link field.
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group taxonomy_select
-	 * @group validation
-	 */
-	function testLinkFieldExpectsTaxonomySelectValidatorCalled() {
-		// arrange
-		global $post;
-		$factory = $this->getMockBuilder('TestNumberField')
-						->setMethods(array('validate_link',))
-						->getMock();
+        // assert
+        // Test will fail if validate_taxonomyselect called more than once
+    }
 
-		$factory->expects($this->once())
-				->method('validate_link')
-				->will($this->returnValue(true));
-		$factory->fields['field_one']['type'] = 'link';
-		$actual = array();
+    /**
+     * Tests whether a field with do_not_validate in the key will continue to 
+     * validate. Expects `validate` to return.
+     *
+     * @group stable
+     * @group isolated
+     * @group negative
+     * @group validation
+     * 
+     */
+    
+    function testDoNotValidateReturnsInsteadOfValidates() {
+        $TestNumberField = new TestNumberField();
+        $_POST = array(
+            'post_ID' => 1,
+            'field_one' => 2,
+        );
+        $actual = array();
 
-		// act
-		$factory->validate($post->ID, $factory->fields['field_one'], $actual);
+        // act
+        $TestNumberField->fields['field_one']['do_not_validate'] = true;
+        $TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual );
 
-		// assert
-		// Test will fail if validate_taxonomyselect called more than once
-	}
+        // assert
+        $this->assertTrue(empty($actual));
+    }
+    /**
+     * Tests whether the validate_fieldset method is called when validating a 
+     * field of type 'fieldset'
+     *
+     * @group stable
+     * @group fieldset
+     * @group isolated
+     * @group validate_fieldset
+     */
+    function testValidFieldsetExpectsValidateToBeCalled() {
+        // arrange
+        global $post;
+        $factory = $this->getMockBuilder('TestValidFieldsetField')
+                        ->setMethods( array( 'validate_fieldset', ) )
+                        ->getMock();
+        $factory->expects($this->once())
+                ->method('validate_fieldset')
+                ->will($this->returnValue(true));
+        $validate = array();
 
-	/**
-	 * Tests whether a field with do_not_validate in the key will continue to 
-	 * validate. Expects `validate` to return.
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group negative
-	 * @group validation
-	 * 
-	 */
-	
-	function testDoNotValidateReturnsInsteadOfValidates() {
-		$TestNumberField = new TestNumberField();
-		$_POST = array(
-			'post_ID' => 1,
-			'field_one' => 2,
-		);
-		$actual = array();
+        // act
+        $factory->validate( $post->ID, $factory->fields['field'], $validate );
 
-		// act
-		$TestNumberField->fields['field_one']['do_not_validate'] = true;
-		$TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual );
+        // assert
+        // Test will fail if validate_fieldset isn't executed once and only once
+    }
+    /**
+     * Tests whether the validate_formset method is called when validating a 
+     * field of type 'formset'
+     *
+     * @group stable
+     * @group formset
+     * @group isolated
+     * @group validate_formset
+     */
+    function testValidFormsetExpectsValidateToBeCalled() {
+        // arrange
+        global $post;
+        $factory = $this->getMockBuilder('TestValidFormsetField')
+                        ->setMethods( array( 'validate_formset', ) )
+                        ->getMock();
+        $factory->expects($this->once())
+                ->method('validate_formset')
+                ->will($this->returnValue(true));
+        $validate = array();
 
-		// assert
-		$this->assertTrue(empty($actual));
-	}
+        // act
+        $factory->validate( $post->ID, $factory->fields['field'], $validate );
+
+        // assert
+        // Test will fail if validate_formset isn't executed once and only once
+    }
+
 
 /***************
  * Save method *
  ***************/
 
-	/**
-	 * Tests whether save will call update_post_meta
-	 *
-	 * @group isolated
-	 * @group stable
-	 * @group save
-	 */
-	function testSaveExpectsUpdatePostMetaCalledOnce() {
+    /**
+     * Tests whether save will call update_post_meta
+     *
+     * @group isolated
+     * @group stable
+     * @group save
+     */
+    function testSaveExpectsUpdatePostMetaCalledOnce() {
 
-		// arrange
-		$post_id = 100;
-		$postvalues = array(
-			'one' => 'Some text',
-		);
-		\WP_Mock::wpFunction( 'get_post_meta', array(
-			'times' => 1,
-			'return' => false,
-			)
-		);
-		\WP_Mock::wpFunction( 'update_post_meta', array(
-			'times' => 1,
-			'return' => true,
-			'with' => array(
-				$post_id,
-				'one',
-				'Some text',
-			),
-			)
-		);
+        // arrange
+        $post_id = 100;
+        $postvalues = array(
+            'one' => 'Some text',
+        );
+        \WP_Mock::wpFunction( 'get_post_meta', array(
+            'times' => 1,
+            'return' => false,
+            )
+        );
+        \WP_Mock::wpFunction( 'update_post_meta', array(
+            'times' => 1,
+            'return' => true,
+            'with' => array(
+                $post_id,
+                'one',
+                'Some text',
+            ),
+            )
+        );
 
-		$form = new TestValidTextField();
-		$form->post_type = 'post';
+        $form = new TestValidTextField();
+        $form->post_type = 'post';
 
-		// act
-		$form->save($post_id, $postvalues);
+        // act
+        $form->save($post_id, $postvalues);
 
-		// assert
+        // assert
 
-	}
+    }
 
-	/**
-	 * Tests whether save() will call update_post_meta if $_POST is empty, expects
-	 * it not to.
-	 * @group stable
-	 * @group isolated
-	 * @group negative
-	 * @group save
-	 */
-	function testEmptyPostDataSaveExpectsNothing() {
+    /**
+     * Tests whether save() will call update_post_meta if $_POST is empty, expects
+     * it not to.
+     * @group stable
+     * @group isolated
+     * @group negative
+     * @group save
+     */
+    function testEmptyPostDataSaveExpectsNothing() {
 
-		// arrange
-		$post_id = 100;
-		$postvalues = null;
+        // arrange
+        $post_id = 100;
+        $postvalues = null;
 
-		\WP_Mock::wpFunction( 'update_post_meta', array(
-			'times' => 0,)
-		);
+        \WP_Mock::wpFunction( 'update_post_meta', array(
+            'times' => 0,)
+        );
 
-		$form = new TestValidTextField();
+        $form = new TestValidTextField();
 
-		// act
-		$form->save( $post_id, $postvalues );
-	}
+        // act
+        $form->save( $post_id, $postvalues );
+    }
 
-	/**
-	 * Tests whether save() will call update_post_meta if $_POST is empty, expects
-	 * it not to.
-	 * @group stable
-	 * @group isolated
-	 * @group negative
-	 * @group save
-	 */
-	function testEmptyPostKeySaveExpectsReturn() {
+    /**
+     * Tests whether save() will call update_post_meta if $_POST is empty, expects
+     * it not to.
+     * @group stable
+     * @group isolated
+     * @group negative
+     * @group save
+     */
+    function testEmptyPostKeySaveExpectsReturn() {
 
-		// arrange
-		$post_id = 100;
-		$postvalues = array('one' => null);
-		\WP_Mock::wpFunction( 'get_post_meta', array(
-			'times' => 1,
-			'return' => false,
-			'with' => array( $post_id, 'one')
-			)
-		);
-		\WP_Mock::wpFunction( 'delete_post_meta', array(
-			'times' => 1)
-		);
-		\WP_Mock::wpFunction( 'update_post_meta', array(
-			'times' => 0,)
-		);
+        // arrange
+        $post_id = 100;
+        $postvalues = array('one' => null);
+        \WP_Mock::wpFunction( 'get_post_meta', array(
+            'times' => 1,
+            'return' => false,
+            'with' => array( $post_id, 'one')
+            )
+        );
+        \WP_Mock::wpFunction( 'delete_post_meta', array(
+            'times' => 1)
+        );
+        \WP_Mock::wpFunction( 'update_post_meta', array(
+            'times' => 0,)
+        );
 
-		$form = new TestValidTextField();
+        $form = new TestValidTextField();
 
-		// act
-		$form->save( $post_id, $postvalues );
-	}
-	/**
-	 * Tests whether an empty key will call delete_post_meta()
-	 *
-	 * @group stable
-	 * @group save
-	 * @group isolated
-	 */
-	function testEmptyKeyValueExpectsDeletePostMeta() {
-		// arrange
-		$post_id = 1;
-		$postvalues = array('one' => null);
-		$existing = 'exists';
-		\WP_Mock::wpFunction( 
-			'get_post_meta', 
-			array(
-				'times' => 1,
-				'return' => $existing,
-			)
-		);
-		\WP_Mock::wpFunction(
-			'delete_post_meta',
-			array(
-				'times' => 1,
-				'return' => true,
-				'with' => array('post_ID' => 1, 'meta_key' => 'one'),	
-			)
-		);
-		$form = new TestValidTextField();
-		// act
-		$form->save( $post_id, $postvalues);
-		// assert
-	}
+        // act
+        $form->save( $post_id, $postvalues );
+    }
+    /**
+     * Tests whether an empty key will call delete_post_meta()
+     *
+     * @group stable
+     * @group save
+     * @group isolated
+     */
+    function testEmptyKeyValueExpectsDeletePostMeta() {
+        // arrange
+        $post_id = 1;
+        $postvalues = array('one' => null);
+        $existing = 'exists';
+        \WP_Mock::wpFunction( 
+            'get_post_meta', 
+            array(
+                'times' => 1,
+                'return' => $existing,
+            )
+        );
+        \WP_Mock::wpFunction(
+            'delete_post_meta',
+            array(
+                'times' => 1,
+                'return' => true,
+                'with' => array('post_ID' => 1, 'meta_key' => 'one'),   
+            )
+        );
+        $form = new TestValidTextField();
+        // act
+        $form->save( $post_id, $postvalues);
+        // assert
+    }
 
-	/**
-	 * Tests whether validate() and save() can be called in succession.
-	 *
-	 * @group isolated
-	 * @group stable
-	 * @group save
-	 */
-	function testVerifyAndSaveExpectsSuccess() {
-		// arrange
-		$_POST = array('post_ID' => 1, 'field_one' => 'value');
-		$actual = array();
-		$factory = $this->getMockBuilder('TestNumberField')
-						->setMethods( array( 'validate', 'save' ) )
-						->getMock();
+    /**
+     * Tests whether validate() and save() can be called in succession.
+     *
+     * @group isolated
+     * @group stable
+     * @group save
+     */
+    function testVerifyAndSaveExpectsSuccess() {
+        // arrange
+        $_POST = array('post_ID' => 1, 'field_one' => 'value');
+        $actual = array();
+        $factory = $this->getMockBuilder('TestNumberField')
+                        ->setMethods( array( 'validate', 'save' ) )
+                        ->getMock();
 
-		$factory->expects($this->once())
-				->method('validate')
-				->will($this->returnValue(true))
-				->with(1, $factory->fields['field_one'], $actual);
-		$factory->expects($this->once())
-				->method('save')
-				->with(1, $actual);
+        $factory->expects($this->once())
+                ->method('validate')
+                ->will($this->returnValue(true))
+                ->with(1, $factory->fields['field_one'], $actual);
+        $factory->expects($this->once())
+                ->method('save')
+                ->with(1, $actual);
 
-		// act
-		$factory->validate_and_save( 1 );
-	}
+        // act
+        $factory->validate_and_save( 1 );
+    }
 
 /**************************
  * Specialized validators *
  **************************/
 
-	/**
-	 * Tests whether the validate method when called on a date field calls the
-	 * date method from the Callbacks class.
-	 *
-	 * @group stable
-	 * @group date
-	 * @group isolated
-	 * @group user_input
-	 */
-	function testValidDateFieldExpectsCallbackCalledOnce() {
-		// arrange
-		$stub = $this->getMockBuilder('Callbacks')
-					->setMethods(array('date'))
-					->getMock();
+    /**
+     * Tests whether the validate method when called on a date field calls the
+     * date method from the Callbacks class.
+     *
+     * @group stable
+     * @group date
+     * @group isolated
+     * @group user_input
+     */
+    function testValidDateFieldExpectsCallbackCalledOnce() {
+        // arrange
+        $stub = $this->getMockBuilder('Callbacks')
+                    ->setMethods(array('date'))
+                    ->getMock();
 
-		$stub->expects( $this->once() )
-			 ->method( 'date' )
-			 ->with( $this->anything(), $this->anything(), $this->anything() );
+        $stub->expects( $this->once() )
+             ->method( 'date' )
+             ->with( $this->anything(), $this->anything(), $this->anything() );
 
-		// $stub->expects( $this->once() )
-		// 	->method( 'method' );
+        // $stub->expects( $this->once() )
+        //  ->method( 'method' );
 
-		$form = new TestValidDateField();
-		$form->set_callbacks($stub);
-		$term = \WP_Mock::wpFunction( 'wp_get_post_terms' ); 
-		$_POST = array(
-			'post_ID' => 1,
-			'category_year' => '1970' ,
-			'category_month' => 'January',
-			'category_day' => '01');
+        $form = new TestValidDateField();
+        $form->set_callbacks($stub);
+        $term = \WP_Mock::wpFunction( 'wp_get_post_terms' ); 
+        $_POST = array(
+            'post_ID' => 1,
+            'category_year' => '1970' ,
+            'category_month' => 'January',
+            'category_day' => '01');
 
-		// act
-		$form->validate_date( $form->fields['category'], $_POST['post_ID']);
-		// $stub->method();
-	}
+        // act
+        $form->validate_date( $form->fields['category'], $_POST['post_ID']);
+        // $stub->method();
+    }
 
-	/**
-	 * Tests whether taxonomyselect will use a string if the given term does not exist.
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group taxonomyselect
-	 */
-	function testTermDoesNotExistExpectsStringUsed() {
-		// Arrange
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'taxonomyselect';
-		$form->fields['field_one']['taxonomy'] = 'category';
-		$form->fields['field_one']['multiple'] = false;
-		$field = $form->fields['field_one'];
-		$_POST = array('post_ID' => 1, 'field_one' => 'term');
-		$term = \WP_Mock::wpFunction(
-			'sanitize_text_field',
-			array(
-				'times' => 1,
-				'args' => array( $_POST['field_one'] ),
-				'return' => 'term',
-			)
-		);
-		\WP_Mock::wpFunction('get_term_by', array('times' => 1, 'return' => false));
-		\WP_Mock::wpFunction(
-			'wp_set_object_terms',
-			array(
-				'times' => 1,
-			)
-		);
+    /**
+     * Tests whether taxonomyselect will use a string if the given term does not exist.
+     *
+     * @group stable
+     * @group isolated
+     * @group taxonomyselect
+     */
+    function testTermDoesNotExistExpectsStringUsed() {
+        // Arrange
+        $form = new TestNumberField();
+        $form->fields['field_one']['type'] = 'taxonomyselect';
+        $form->fields['field_one']['taxonomy'] = 'category';
+        $form->fields['field_one']['multiple'] = false;
+        $field = $form->fields['field_one'];
+        $_POST = array('post_ID' => 1, 'field_one' => 'term');
+        $term = \WP_Mock::wpFunction(
+            'sanitize_text_field',
+            array(
+                'times' => 1,
+                'args' => array( $_POST['field_one'] ),
+                'return' => 'term',
+            )
+        );
+        \WP_Mock::wpFunction('get_term_by', array('times' => 1, 'return' => false));
+        \WP_Mock::wpFunction(
+            'wp_set_object_terms',
+            array(
+                'times' => 1,
+            )
+        );
 
-		// act
-		$form->validate_taxonomyselect($form->fields['field_one'], $_POST['post_ID']);
+        // act
+        $form->validate_taxonomyselect($form->fields['field_one'], $_POST['post_ID']);
 
-		// Assert: test will fail if wp_set_object_terms, get_term_by or
-		// sanitize_text_field do not fire or fire more than once
-	}
+        // Assert: test will fail if wp_set_object_terms, get_term_by or
+        // sanitize_text_field do not fire or fire more than once
+    }
 
-	/**
-	 * Tests whether validate_link will call add post meta with the correct values
-	 *
-	 * @group isolated
-	 * @group stable
-	 * @group validate_link
-	**/
-	function testValidateLinkExpectsAddPostMetaTwice() {
-		$_POST = array(
-			'link_url' => 'http://example.com',
-			'link_text' => 'example.com',
-		);
-		$field = array(
+    /**
+     * Tests whether validate_link will call add post meta with the correct values
+     *
+     * @group isolated
+     * @group stable
+     * @group validate_link
+    **/
+    function testValidateLinkExpectsAddPostMetaTwice() {
+        $_POST = array(
+            'link_url' => 'http://example.com',
+            'link_text' => 'example.com',
+        );
+        $field = array(
             'slug' => 'link',
             'type' => 'link',
             'params' => array(),
             'meta_key' => 'link',
             'howto' => "Some howto text",
-		);
-		$form = new TestNumberField();
-		global $post;
-		$post = new StdClass();
-		$post_id = 1;
-		$form->fields = $field;
-		\WP_Mock::wpFunction(
-			'add_post_meta',
-			array( 'times' => 2, 'return' => true )
-		);
-		$post = new \StdClass;
-		\WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
-		\WP_Mock::wpFunction('delete_post_meta', array('times' => 0));
-		$form->validate_link( $field, $post_id);
-	}
+        );
+        $form = new TestNumberField();
+        global $post;
+        $post = new StdClass();
+        $post_id = 1;
+        $form->fields = $field;
+        \WP_Mock::wpFunction(
+            'add_post_meta',
+            array( 'times' => 2, 'return' => true )
+        );
+        $post = new \StdClass;
+        \WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
+        \WP_Mock::wpFunction('delete_post_meta', array('times' => 0));
+        $form->validate_link( $field, $post_id);
+    }
 
-	/**
-	* Tests whether count will default to 1 if none is passed in the model
-	*
-	* @group stable
-	* @group isolated
-	* @group validate_link
-	**/
-	function testValidateLinkCountNotGivenExpectsUpdatePostMetaCalledOnce() {
-		// arrange
-		$_POST = array(
-			'link_url' => 'http://example.com',
-			'link_text' => 'example.com',
-		);
-		$field = array(
+    /**
+    * Tests whether count will default to 1 if none is passed in the model
+    *
+    * @group stable
+    * @group isolated
+    * @group validate_link
+    **/
+    function testValidateLinkCountNotGivenExpectsUpdatePostMetaCalledOnce() {
+        // arrange
+        $_POST = array(
+            'link_url' => 'http://example.com',
+            'link_text' => 'example.com',
+        );
+        $field = array(
             'slug' => 'link',
             'type' => 'link',
             'params' => array(),
             'meta_key' => 'link',
             'howto' => "Some howto text",
-		);
-		$form = new TestNumberField();
-		$post_id = 1;
-		$form->fields = $field;
-		\WP_Mock::wpFunction(
-			'add_post_meta',
-			array( 'times' => 2, 'return' => true )
-		);
-		$post = new \StdClass;
-		\WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
+        );
+        $form = new TestNumberField();
+        $post_id = 1;
+        $form->fields = $field;
+        \WP_Mock::wpFunction(
+            'add_post_meta',
+            array( 'times' => 2, 'return' => true )
+        );
+        $post = new \StdClass;
+        \WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
 
-		// act
-		$form->validate_link( $field, $post_id);
+        // act
+        $form->validate_link( $field, $post_id);
 
-		// assert: Test will fail if get_ or update_post_meta called more than once.
-	}
-	/**
-	 * Tests whether validate_link will use the $existing variable if it is set
-	 *
-	**/
-	function testValidateLinkWithExistingDataExpectsDataDeletedAndReplaced() {
-		// arrange
-		$_POST = array(
-			'link_url' => 'http://example.com',
-			'link_text' => 'example.com',
-		);
-		$field = array(
+        // assert: Test will fail if get_ or update_post_meta called more than once.
+    }
+    /**
+     * Tests whether validate_link will use the $existing variable if it is set
+     *
+    **/
+    function testValidateLinkWithExistingDataExpectsDataDeletedAndReplaced() {
+        // arrange
+        $_POST = array(
+            'link_url' => 'http://example.com',
+            'link_text' => 'example.com',
+        );
+        $field = array(
             'slug' => 'link',
             'type' => 'link',
             'params' => array(),
             'meta_key' => 'link',
             'howto' => "Some howto text",
-		);
-		$existing = array( 'http://google.com', 'Google');
-		$form = new TestNumberField();
-		$post_id = 1;
-		$form->fields = $field;
-		// \WP_Mock::wpFunction(
-		// 	'delete_post_meta',
-		// 	array( 'times' => 1, 'return' => true)
-		// );
-		// \WP_Mock::wpFunction(
-		// 	'add_post_meta',
-		// 	array( 'times' => 2, 'return' => true)
-		// );
-		\WP_Mock::wpFunction(
-			'update_post_meta',
-			array( 'times' => 2, 'return' => true)
-		);
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array( 'times' => 1, 'return' => $existing )
-		);
+        );
+        $existing = array( 'http://google.com', 'Google');
+        $form = new TestNumberField();
+        $post_id = 1;
+        $form->fields = $field;
+        // \WP_Mock::wpFunction(
+        //  'delete_post_meta',
+        //  array( 'times' => 1, 'return' => true)
+        // );
+        // \WP_Mock::wpFunction(
+        //  'add_post_meta',
+        //  array( 'times' => 2, 'return' => true)
+        // );
+        \WP_Mock::wpFunction(
+            'update_post_meta',
+            array( 'times' => 2, 'return' => true)
+        );
+        \WP_Mock::wpFunction(
+            'get_post_meta',
+            array( 'times' => 1, 'return' => $existing )
+        );
 
 
-		// act
-		$form->validate_link( $field, $post_id );
+        // act
+        $form->validate_link( $field, $post_id );
 
-		// assert
-		// Test will fail if add_post_meta is called more than twice, and if
-		// get_post_meta or delete_post_meta are called more than once.
-	}
+        // assert
+        // Test will fail if add_post_meta is called more than twice, and if
+        // get_post_meta or delete_post_meta are called more than once.
+    }
 
-	/**
-	* Tests whether validate_link will return rather than re-save existing data
-	*
-	* @group stable
-	* @group link_validate
-	*
-	**/
-	function testValidateLinkWithExistingDataMatchingSubmittedExpectsNoaction() {
-		// arrange
-		$_POST = array(
-			'link_url' => 'http://example.com',
-			'link_text' => 'example.com',
-		);
-		$field = array(
+    /**
+    * Tests whether validate_link will return rather than re-save existing data
+    *
+    * @group stable
+    * @group link_validate
+    *
+    **/
+    function testValidateLinkWithExistingDataMatchingSubmittedExpectsNoaction() {
+        // arrange
+        $_POST = array(
+            'link_url' => 'http://example.com',
+            'link_text' => 'example.com',
+        );
+        $field = array(
             'slug' => 'link',
             'type' => 'link',
             'params' => array(),
             'meta_key' => 'link',
             'howto' => "Some howto text",
-		);
-		$existing = array( 'http://example.com', 'example.com');
-		$form = new TestNumberField();
-		$post_id = 1;
-		$form->fields = $field;
-		\WP_Mock::wpFunction(
-			'add_post_meta',
-			array( 'times' => 0 )
-		);
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array( 'times' => 1, 'return' => $existing )
-		);
-		\WP_Mock::wpFunction(
-			'update_post_meta',
-			array( 'times' => 0)
-		);
-		// act
-		$form->validate_link( $field, $post_id );
-		// assert
-		// Test will fail if add_post_meta or delete_post_meta is called and if
-		// get_post_meta is called more than once.
-	}
-	/**
-	 * Tests whether taxonomyselect will use the term object when a term exists
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group taxonomyselect
-	 */
-	function testTermExistsExpectsStringUsed() {
-		// Arrange
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'taxonomyselect';
-		$form->fields['field_one']['taxonomy'] = 'category';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array( 'field_one' => 'term' );
-		$existing = new \StdClass;
-		$existing->name = 'Sluggo';
-		\WP_Mock::wpFunction('sanitize_text_field', array('times' => 1));
-		\WP_Mock::wpFunction(
-			'get_term_by', 
-			array('times' => 1, 'return' => $existing));
-		\WP_Mock::wpFunction('wp_set_object_terms', array( 'times' => 1 ) );
+        );
+        $existing = array( 'http://example.com', 'example.com');
+        $form = new TestNumberField();
+        $post_id = 1;
+        $form->fields = $field;
+        \WP_Mock::wpFunction(
+            'add_post_meta',
+            array( 'times' => 0 )
+        );
+        \WP_Mock::wpFunction(
+            'get_post_meta',
+            array( 'times' => 1, 'return' => $existing )
+        );
+        \WP_Mock::wpFunction(
+            'update_post_meta',
+            array( 'times' => 0)
+        );
+        // act
+        $form->validate_link( $field, $post_id );
+        // assert
+        // Test will fail if add_post_meta or delete_post_meta is called and if
+        // get_post_meta is called more than once.
+    }
+    /**
+     * Tests whether taxonomyselect will use the term object when a term exists
+     *
+     * @group stable
+     * @group isolated
+     * @group taxonomyselect
+     */
+    function testTermExistsExpectsStringUsed() {
+        // Arrange
+        global $post;
+        $form = new TestNumberField();
+        $form->fields['field_one']['type'] = 'taxonomyselect';
+        $form->fields['field_one']['taxonomy'] = 'category';
+        $form->fields['field_one']['multiple'] = false;
+        $_POST = array( 'field_one' => 'term' );
+        $existing = new \StdClass;
+        $existing->name = 'Sluggo';
+        \WP_Mock::wpFunction('sanitize_text_field', array('times' => 1));
+        \WP_Mock::wpFunction(
+            'get_term_by', 
+            array('times' => 1, 'return' => $existing));
+        \WP_Mock::wpFunction('wp_set_object_terms', array( 'times' => 1 ) );
 
-		// act
-		$form->validate_taxonomyselect($form->fields['field_one'], $post->ID);
+        // act
+        $form->validate_taxonomyselect($form->fields['field_one'], $post->ID);
 
-		// Assert: test will fail if wp_set_object_terms, get_term_by or
-		// sanitize_text_field do not fire or fire more than once
-	}
+        // Assert: test will fail if wp_set_object_terms, get_term_by or
+        // sanitize_text_field do not fire or fire more than once
+    }
 
-	/**
-	 * Tests whether if no existing metadata, add_post_meta is called by validate_select
-	 *
-	 * @group stable
-	 * @group select
-	 * @group isolated
-	**/
-	function testNoExistingDataValidateSelectExpectsAddPostMetaFiredOnce() {
-		// Arrange
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'select';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array( 'field_one' => 'metadata');
-		\WP_Mock::wpFunction('sanitize_text_field', array('times' => 1));
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 1, 'return' => array() )
-		);
-		\WP_Mock::wpFunction('add_post_meta', array( 'times' => 1 ) );
+    /**
+     * Tests whether if no existing metadata, add_post_meta is called by validate_select
+     *
+     * @group stable
+     * @group select
+     * @group isolated
+    **/
+    function testNoExistingDataValidateSelectExpectsAddPostMetaFiredOnce() {
+        // Arrange
+        global $post;
+        $form = new TestNumberField();
+        $form->fields['field_one']['type'] = 'select';
+        $form->fields['field_one']['multiple'] = false;
+        $_POST = array( 'field_one' => 'metadata');
+        \WP_Mock::wpFunction('sanitize_text_field', array('times' => 1));
+        \WP_Mock::wpFunction(
+            'get_post_meta',
+            array('times' => 1, 'return' => array() )
+        );
+        \WP_Mock::wpFunction('add_post_meta', array( 'times' => 1 ) );
 
-		// act
-		$form->validate_select($form->fields['field_one'],$post->ID);
-	}
+        // act
+        $form->validate_select($form->fields['field_one'],$post->ID);
+    }
 
-	/**
-	 * Tests whether if no existing metadata, add_post_meta will be called twice by 
-	 * validate_select if multiple values are in $_POST
-	 *
-	 * A multi select field will pass an array of values to the $_POST array, we 
-	 * expect cms-toolkit to iterate over that array adding new post data for each
-	 * entry.
-	 *
-	 * @group stable
-	 * @group select
-	 * @group isolated
-	 */
-	function testNoExistingDataValidateSelectExpectsAddPostMetaTwice() {
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'select';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array( 'field_one' => array( 'metadata', 'otherdata' ) );
-		\WP_Mock::wpFunction('sanitize_text_field', array('times' => 2));
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 1, 'return' => array() )
-		);
-		\WP_Mock::wpFunction('add_post_meta', array( 'times' => 2 ) );
+    /**
+     * Tests whether if no existing metadata, add_post_meta will be called twice by 
+     * validate_select if multiple values are in $_POST
+     *
+     * A multi select field will pass an array of values to the $_POST array, we 
+     * expect cms-toolkit to iterate over that array adding new post data for each
+     * entry.
+     *
+     * @group stable
+     * @group select
+     * @group isolated
+     */
+    function testNoExistingDataValidateSelectExpectsAddPostMetaTwice() {
+        global $post;
+        $form = new TestNumberField();
+        $form->fields['field_one']['type'] = 'select';
+        $form->fields['field_one']['multiple'] = false;
+        $_POST = array( 'field_one' => array( 'metadata', 'otherdata' ) );
+        \WP_Mock::wpFunction('sanitize_text_field', array('times' => 2));
+        \WP_Mock::wpFunction(
+            'get_post_meta',
+            array('times' => 1, 'return' => array() )
+        );
+        \WP_Mock::wpFunction('add_post_meta', array( 'times' => 2 ) );
 
-		// act
-		$form->validate_select($form->fields['field_one'],$post->ID);
+        // act
+        $form->validate_select($form->fields['field_one'],$post->ID);
 
-	}
+    }
 
-	/**
-	 * Tests whether, if post has existing custom data but those data are
-	 * not in the $_POST array, delete_post_meta will be called on each
-	 * existing value.
-	 *
-	 * When a select field is submitted it will may contian values that 
-	 * exist already for this post in addition to new ones the user wants
-	 * to add. If a term is in both arrays ($existing and $_POST), we 
-	 * should keep it. If the term is in $existing but not $_POST, then a
-	 * user has removed it or chosen a different value and we should 
-	 * delete the previously stored metadata. This test verifies the latter
-	 * condition specifically where there is no _POST data set at all (a user
-	 * has set the <select> to a null value indicating they wish to delete 
-	 * the value and not replace it.
-	 *
-	 * @group stable
-	 * @group select
-	 * @group isolated
-	 */
-	function testExistingDataButEmptyPostValidateSelectExpectsDeletePostMetaOnce() {
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'select';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array( 'field_one' => array( ) );
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 1, 'return' => array('existing') )
-		);
-		\WP_Mock::wpFunction('delete_post_meta', array( 'times' => 1 ) );
+    /**
+     * Tests whether, if post has existing custom data but those data are
+     * not in the $_POST array, delete_post_meta will be called on each
+     * existing value.
+     *
+     * When a select field is submitted it will may contian values that 
+     * exist already for this post in addition to new ones the user wants
+     * to add. If a term is in both arrays ($existing and $_POST), we 
+     * should keep it. If the term is in $existing but not $_POST, then a
+     * user has removed it or chosen a different value and we should 
+     * delete the previously stored metadata. This test verifies the latter
+     * condition specifically where there is no _POST data set at all (a user
+     * has set the <select> to a null value indicating they wish to delete 
+     * the value and not replace it.
+     *
+     * @group stable
+     * @group select
+     * @group isolated
+     */
+    function testExistingDataButEmptyPostValidateSelectExpectsDeletePostMetaOnce() {
+        global $post;
+        $form = new TestNumberField();
+        $form->fields['field_one']['type'] = 'select';
+        $form->fields['field_one']['multiple'] = false;
+        $_POST = array( 'field_one' => array( ) );
+        \WP_Mock::wpFunction(
+            'get_post_meta',
+            array('times' => 1, 'return' => array('existing') )
+        );
+        \WP_Mock::wpFunction('delete_post_meta', array( 'times' => 1 ) );
 
-		// act
-		$form->validate_select($form->fields['field_one'],$post->ID);
+        // act
+        $form->validate_select($form->fields['field_one'],$post->ID);
 
-	}
+    }
 
-	/**
-	 * Tests whether, if $_POST contains non-identical values to $existing delete_post_meta
-	 * will be called on each existing value. Similar to L978 _supra_
-	 *
-	 * @group stable
-	 * @group select
-	 * @group isolated
-	 */
-	function testExistingDataMismatchPostValidateSelectExpectsDeletePostMetaAndAddPostMetaOnceEach() {
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'select';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array( 'field_one' => array( 'non-existent' ) );
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 1, 'return' => array('existing') )
-		);
-		\WP_Mock::wpFunction( 'sanitize_text_field', array( 'times' => 1 ) );
-		\WP_Mock::wpFunction( 'delete_post_meta', array( 'times' => 1 ) );
-		\WP_Mock::wpFunction( 'add_post_meta', array( 'times' => 1 ) );
+    /**
+     * Tests whether, if $_POST contains non-identical values to $existing delete_post_meta
+     * will be called on each existing value. Similar to L978 _supra_
+     *
+     * @group stable
+     * @group select
+     * @group isolated
+     */
+    function testExistingDataMismatchPostValidateSelectExpectsDeletePostMetaAndAddPostMetaOnceEach() {
+        global $post;
+        $form = new TestNumberField();
+        $form->fields['field_one']['type'] = 'select';
+        $form->fields['field_one']['multiple'] = false;
+        $_POST = array( 'field_one' => array( 'non-existent' ) );
+        \WP_Mock::wpFunction(
+            'get_post_meta',
+            array('times' => 1, 'return' => array('existing') )
+        );
+        \WP_Mock::wpFunction( 'sanitize_text_field', array( 'times' => 1 ) );
+        \WP_Mock::wpFunction( 'delete_post_meta', array( 'times' => 1 ) );
+        \WP_Mock::wpFunction( 'add_post_meta', array( 'times' => 1 ) );
 
-		// act
-		$form->validate_select($form->fields['field_one'],$post->ID);
+        // act
+        $form->validate_select($form->fields['field_one'],$post->ID);
 
-	}
+    }
 
-	/**
-	 * Tests whether, if $_POST is completley empty delete_post_meta will be called
-	 * on each existing value. Similar to L978 _supra_
-	 *
-	 * @group stable
-	 * @group select
-	 * @group isolated
-	 */
-	function testExistingDataEmptyPostValidateSelectExpectsDeletePostMetaAndAddPostMetaOnceEach() {
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'select';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array();
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 0, 'return' => array('existing') )
-		);
-		\WP_Mock::wpFunction( 'sanitize_text_field', array( 'times' => 0 ) );
-		\WP_Mock::wpFunction( 'delete_post_meta', array( 'times' => 1 ) );
-		\WP_Mock::wpFunction( 'add_post_meta', array( 'times' => 0 ) );
+    /**
+     * Tests whether, if $_POST is completley empty delete_post_meta will be called
+     * on each existing value. Similar to L978 _supra_
+     *
+     * @group stable
+     * @group select
+     * @group isolated
+     */
+    function testExistingDataEmptyPostValidateSelectExpectsDeletePostMetaAndAddPostMetaOnceEach() {
+        global $post;
+        $form = new TestNumberField();
+        $form->fields['field_one']['type'] = 'select';
+        $form->fields['field_one']['multiple'] = false;
+        $_POST = array();
+        \WP_Mock::wpFunction(
+            'get_post_meta',
+            array('times' => 0, 'return' => array('existing') )
+        );
+        \WP_Mock::wpFunction( 'sanitize_text_field', array( 'times' => 0 ) );
+        \WP_Mock::wpFunction( 'delete_post_meta', array( 'times' => 1 ) );
+        \WP_Mock::wpFunction( 'add_post_meta', array( 'times' => 0 ) );
 
-		// act
-		$form->validate_select($form->fields['field_one'],$post->ID);
+        // act
+        $form->validate_select($form->fields['field_one'],$post->ID);
 
-	}
+    }
+    /**
+    * Tests a fieldset to make sure that validate is called for each of the 
+    * fieldset's fields.
+    *
+     * @group stable
+     * @group validate
+     * @group fieldset
+     * @group validate_fieldset
+     * @group isolated
+    */
+    function testValidFieldsetOfTwoFieldsCallsValidateTwice() {
+        //arrange
+        global $post;
+        $factory = $this->getMockBuilder('TestValidFieldsetField')
+                        ->setMethods( array( 'validate',) )
+                        ->getMock();
+        $factory->expects( $this->exactly( 2 ) )
+                ->method( 'validate' )
+                ->will( $this->returnValue( true ) );
+        $expected = array();
+
+        //act
+        $factory->validate_fieldset( $factory->fields['field'], $expected, $post->ID );
+
+        //assert
+        // Test will fail if only each of the fields in the fieldset are validated
+    }
+    /**
+    * Tests a fieldset to make sure that validate adds validated values to the 
+    * array that was passed in by reference.
+    *
+     * @group stable
+     * @group validate
+     * @group fieldset
+     * @group validate_fieldset
+     * @group isolated
+    */
+    function testValidateAddsValidatedValuesToPassedInArrayByValidateFieldset() {
+        // arrange
+        global $post;
+        $_POST = array( 'field_num' => '0123456789', 'field_desc' => 'description' );
+        $testValidFieldsetField = new TestValidFieldsetField();
+        $actual = array();
+        $expected = array( 'field_num' => '0123456789', 'field_desc' => 'description' );
+
+        //act
+        $testValidFieldsetField->validate_fieldset( $testValidFieldsetField->fields['field'], $actual, $post->ID );
+
+        //assert
+        $this->assertEquals( $expected, $actual );
+    }
+    /**
+    * Tests a formset to make sure that validate is called for each of the 
+    * formset's fields.
+    *
+     * @group stable
+     * @group validate
+     * @group fieldset
+     * @group validate_formset
+     * @group isolated
+    */
+    function testValidFormsetOfTwoFieldsCallsValidateTwice() {
+        //arrange
+        global $post;
+        $factory = $this->getMockBuilder('TestValidFormsetField')
+                        ->setMethods( array( 'validate', ) )
+                        ->getMock();
+        $factory->expects( $this->exactly( 2 ) )
+                ->method( 'validate' )
+                ->will( $this->returnValue( true ) );
+        $actual = array();
+
+        //act
+        $factory->validate_formset( $factory->fields['field'], $actual, $post->ID );
+
+        //assert
+    }
+    /**
+    * Tests a formset to make sure that validate adds validated values to the 
+    * array that was passed in by reference.
+    *
+     * @group stable
+     * @group validate
+     * @group formset
+     * @group validate_fieldset
+     * @group isolated
+    */
+    function testValidateAddsValidatedValuesToPassedInArrayByValidateFormset() {
+        // arrange
+        global $post;
+        $_POST = array( 'field_0_title' => 'Title 1', 'field_1_title' => 'Title 2' );
+        $testValidFormsetField = new TestValidFormsetField();
+        $actual = array();
+        $expected = array( 'field_0_title' => 'Title 1', 'field_1_title' => 'Title 2' );
+
+        //act
+        $testValidFormsetField->validate_formset( $testValidFormsetField->fields['field'], $actual, $post->ID );
+
+        //assert
+        $this->assertEquals( $expected, $actual );
+    }
 /**************
  * Generators *
 /**************/
-	/**
-	 * Tests whether calling date_meta_box from this class results in an error
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group wp_error
-	 * @group doing_it_wrong
-	 *
-	 **/
-	function testDateMetaBoxExpectsWP_Error() {
-		//arrange
-		$taxonomy = 'category';
-		$tax_nice_name = 'Category';
-		$multiples = false;
-		$stub = $this->getMock('\WP_Error', array('get_error_message'));
-		$form = new TestValidEmailField();
-		$form->error_handler($stub);
+    /**
+     * Tests that a meta box is generated if the given post type exists.
+     *
+     * @group isolated
+     * @group stable
+     * @group meta_boxes
+     * @group generate
+     */
+    function testPostTypeExistsGenerateExpectsMetaBoxAdded() {
+        // Arrange
+        $form = new TestValidBox();
+        \WP_Mock::wpFunction('post_type_exists', array(
+            'times' => 1,
+            'args' => $form->post_type,
+            'return' => true,
+            )
+        );
+        \WP_Mock::wpPassthruFunction('sanitize_key');
+        \WP_Mock::wpFunction('add_meta_box', array(
+            'times' => 1,
+            'return' => true,
+            )
+        );
 
-		// act
-		$form->date_meta_box($taxonomy, $tax_nice_name, $multiples);
+        // act
+        $form->generate();
 
-		// Assert
-		// $this->assertInstanceOf('WP_Error', $actual);
-	}
+        // Assert: test will fail if add_meta_box is not called, or called more than once
+    }
 
-	/**
-	 * Tests that a meta box is generated if the given post type exists.
-	 *
-	 * @group isolated
-	 * @group stable
-	 * @group meta_boxes
-	 * @group generate
-	 */
-	function testPostTypeExistsGenerateExpectsMetaBoxAdded() {
-		// Arrange
-		$form = new TestValidBox();
-		\WP_Mock::wpFunction('post_type_exists', array(
-			'times' => 1,
-			'args' => $form->post_type,
-			'return' => true,
-			)
-		);
-		\WP_Mock::wpPassthruFunction('sanitize_key');
-		\WP_Mock::wpFunction('add_meta_box', array(
-			'times' => 1,
-			'return' => true,
-			)
-		);
+    /**
+     * Tests whether post_type exists is called once
+     *
+     * @group stable
+     * @group generate
+     **/
+    function testPostTypeExistsCheckPostTypeExpectsPostTypeNameReturned() {
+        // Arrange
+        \WP_Mock::wpFunction('sanitize_key', array(
+            'times' => 1,
+            'return' => 'post'
+            )
+        );
+        \WP_Mock::wpFunction('post_type_exists', array(
+            'times' => 1,
+            'arg' => array( \WP_Mock\Functions::type('string') ),
+            'return' => true
+            )
+        );
+        $form = new TestValidBox();
+        $expected = 'post';
+        // act
+        $actual = $form->check_post_type($form->post_type);
+        // Assert
+        $this->assertEquals($expected, $actual, 'Post type did not verify correctly');
+    }
+    /**
+     * Tests whether check_post_type returns false if post type doesn't exist
+     *
+     * @group stable
+     * @group isolated
+     * @group meta_boxes
+     * @group generate
+     */
+    function testPostTypeNotExistsCheckPostTypeExpectsPostTypeNameReturned() {
+        // Arrange
+        \WP_Mock::wpFunction('sanitize_key', array(
+            'times' => 0,
+            )
+        );
+        \WP_Mock::wpFunction('post_type_exists', array(
+            'times' => 1,
+            'return' => false
+            )
+        );
+        $form = new TestValidBox();
+        $expected = false;
+        // act
+        $actual = $form->check_post_type($form->post_type);
+        // Assert
+        $this->assertEquals($expected, $actual, 'Post type did not verify correctly');
+    }
+    /**
+     * Tests whether a meta box can be attached to more than one post type
+     *
+     * @group stable
+     * @group meta_boxes
+     * @group generate
+     *
+     */
+    function testArrayinPostTypeExpectsBoxesGenerated() {
+        // arrange
+        $Box = new TestValidBox();
+        $Box->post_type = array('post', 'page');
+        \WP_Mock::wpFunction('post_type_exists', array(
+            'times' => 2,
+            'return' => true,)
+        );
+        \WP_Mock::wpPassthruFunction('sanitize_key');
+        \WP_Mock::wpFunction('add_meta_box', array(
+            'times' => 2,
+            'return' => true,
+            )
+        );
+        // act
+        $Box->generate();
+        // assert
+    }
+    /**
+     * Tests whether generate will make a meta box if the post type does not exist
+     *
+     * @group wp_error
+     * @group isolated
+     * @group stable
+     * @group generate
+     */
+    function testPostTypeNotExistsGenerateExpectsWPError() {
+        // Arrange
+        $stub = $this->getMockBuilder('TestValidBox')
+            ->setMethods(array('check_post_type'))
+            ->getMock();
+        $stub->expects($this->once())
+            ->method('check_post_type')
+            ->with($stub->post_type[0])
+            ->will($this->returnValue(false));
+        $error = $this->getMock('\WP_Error', array('get_error_message'));
+        $stub->error_handler(get_class($error));
+        // act
+        $actual = $stub->generate();
 
-		// act
-		$form->generate();
+        // Assert
+    }
 
-		// Assert: test will fail if add_meta_box is not called, or called more than once
-	}
+    /**
+     * Tests whether generate will make a meta box if the post type does not exist
+     *
+     * @group wp_error
+     * @group isolated
+     * @group stable
+     * @group generate
+     */
+    function testInvalidContextGenerateExpectsWPError() {
+        // Arrange
+        $stub = $this->getMock('\WP_Error', array('get_error_message'));
+        $form = new TestValidDateField();
+        $form->error_handler(($stub));
+        $form->context = 'context';
+        // act
+        $actual = $form->generate();
 
-	/**
-	 * Tests whether post_type exists is called once
-	 *
-	 * @group stable
-	 * @group generate
-	 **/
-	function testPostTypeExistsCheckPostTypeExpectsPostTypeNameReturned() {
-		// Arrange
-		\WP_Mock::wpFunction('sanitize_key', array(
-			'times' => 1,
-			'return' => 'post'
-			)
-		);
-		\WP_Mock::wpFunction('post_type_exists', array(
-			'times' => 1,
-			'arg' => array( \WP_Mock\Functions::type('string') ),
-			'return' => true
-			)
-		);
-		$form = new TestValidBox();
-		$expected = 'post';
-		// act
-		$actual = $form->check_post_type($form->post_type);
-		// Assert
-		$this->assertEquals($expected, $actual, 'Post type did not verify correctly');
-	}
-	/**
-	 * Tests whether check_post_type returns false if post type doesn't exist
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group meta_boxes
-	 * @group generate
-	 */
-	function testPostTypeNotExistsCheckPostTypeExpectsPostTypeNameReturned() {
-		// Arrange
-		\WP_Mock::wpFunction('sanitize_key', array(
-			'times' => 0,
-			)
-		);
-		\WP_Mock::wpFunction('post_type_exists', array(
-			'times' => 1,
-			'return' => false
-			)
-		);
-		$form = new TestValidBox();
-		$expected = false;
-		// act
-		$actual = $form->check_post_type($form->post_type);
-		// Assert
-		$this->assertEquals($expected, $actual, 'Post type did not verify correctly');
-	}
-	/**
-	 * Tests whether a meta box can be attached to more than one post type
-	 *
-	 * @group stable
-	 * @group meta_boxes
-	 * @group generate
-	 *
-	 */
-	function testArrayinPostTypeExpectsBoxesGenerated() {
-		// arrange
-		$Box = new TestValidBox();
-		$Box->post_type = array('post', 'page');
-		\WP_Mock::wpFunction('post_type_exists', array(
-			'times' => 2,
-			'return' => true,)
-		);
-		\WP_Mock::wpPassthruFunction('sanitize_key');
-		\WP_Mock::wpFunction('add_meta_box', array(
-			'times' => 2,
-			'return' => true,
-			)
-		);
-		// act
-		$Box->generate();
-		// assert
-	}
-	/**
-	 * Tests whether generate will make a meta box if the post type does not exist
-	 *
-	 * @group wp_error
-	 * @group isolated
-	 * @group stable
-	 * @group generate
-	 */
-	function testPostTypeNotExistsGenerateExpectsWPError() {
-		// Arrange
-		$stub = $this->getMockBuilder('TestValidBox')
-			->setMethods(array('check_post_type'))
-			->getMock();
-		$stub->expects($this->once())
-			->method('check_post_type')
-			->with($stub->post_type[0])
-			->will($this->returnValue(false));
-		$error = $this->getMock('\WP_Error', array('get_error_message'));
-		$stub->error_handler(get_class($error));
-		// act
-		$actual = $stub->generate();
-
-		// Assert
-	}
-
-	/**
-	 * Tests whether generate will make a meta box if the post type does not exist
-	 *
-	 * @group wp_error
-	 * @group isolated
-	 * @group stable
-	 * @group generate
-	 */
-	function testInvalidContextGenerateExpectsWPError() {
-		// Arrange
-		$stub = $this->getMock('\WP_Error', array('get_error_message'));
-		$form = new TestValidDateField();
-		$form->error_handler(($stub));
-		$form->context = 'context';
-		// act
-		$actual = $form->generate();
-
-		// Assert
-	}
+        // Assert
+    }
 /************************
  * Dependency injection *
  ************************/
-	/**
-	 * Tests the ability replace the internal View class
-	 *
-	 * @group stable
-	 * @group set_view
-	 * @group isolated
-	 * @group dependency_injection
-	 */
-	function testSetViewExpectsViewReplaced() {
-		// Arrange
-		$newView = new \StdClass;
-		$form = new TestNumberField();
+    /**
+     * Tests the ability replace the internal View class
+     *
+     * @group stable
+     * @group set_view
+     * @group isolated
+     * @group dependency_injection
+     */
+    function testSetViewExpectsViewReplaced() {
+        // Arrange
+        $newView = new \StdClass;
+        $form = new TestNumberField();
 
-		// act
-		$form->set_view($newView);
+        // act
+        $form->set_view($newView);
 
-		// Assert
-		$this->assertInstanceOf('StdClass', $form->View, 'Not working.');
-	}
+        // Assert
+        $this->assertInstanceOf('StdClass', $form->View, 'Not working.');
+    }
 }

--- a/tests/test-meta_box_view.php
+++ b/tests/test-meta_box_view.php
@@ -529,7 +529,6 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 			array('times' => 1, 'return' => 1));
 		// Act
 		$actual = $stub->process_defaults($fields);
-		echo print_r($actual);
 
 		// Assert
 		$this->assertEquals($expected, $actual);

--- a/tests/test-meta_box_view.php
+++ b/tests/test-meta_box_view.php
@@ -418,6 +418,31 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests whether no meta_key or slug returns error
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group defaults
+	 */
+	function testNoMetakeyOrSlugExpectsWPError() {
+		$fields= array(
+			0 => array(
+				'type' => 'text',
+				'taxonomy' => 'tax',
+			)
+		);
+
+		$mock = $this->getMock('WP_Error');
+		$HTML = $this->getMock('HTML');
+		$View = new View();
+		$View->replace_HTML($HTML);
+
+		$cleaned = $View->process_defaults($fields);
+
+		$this->assertInstanceOf('WP_Error', $cleaned);
+	}
+
+	/**
 	 * Tests whether ready_and_print calls \HTML->Draw();
 	 *
 	 * @group stable

--- a/tests/test-meta_box_view.php
+++ b/tests/test-meta_box_view.php
@@ -305,6 +305,27 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests whether a field passed to default_formset_params will set params if
+	 * none are given.
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group defaults
+	 */
+	function testDefaultFormsetParamsWillSetParamsArrayWhenNotSet() {
+		// arrange
+		$View = new View();
+		$field['params'] = null;
+		$expected = array( 'init_num_forms' => 1, 'max_num_forms' => 1 );
+
+		// Act
+		$actual = $View->default_formset_params( $field );
+
+		// Assert
+		$this->assertEquals($expected, $actual['params'], 'The params array should have been set');
+	}
+
+	/**
 	 * Tests whether when more than one field is passed and one is hidden if both
 	 * fields are generated with the correct values.
 	 * @group maybe_delete
@@ -477,10 +498,11 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 				'taxonomy' => 'category',
 				'slug' => 'field',
 				'max_length' => 255,
+				'value' => 'term',
 				'label' => '',
 				'placeholder' => '',
-				'value' => 'term',
 				'multiselect' => false,
+				'meta_key' => 'field',
 			),
 		);
 		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
@@ -507,11 +529,250 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 			array('times' => 1, 'return' => 1));
 		// Act
 		$actual = $stub->process_defaults($fields);
+		echo print_r($actual);
 
 		// Assert
 		$this->assertEquals($expected, $actual);
 	}
 
+	function testFormsetFieldExpectsProcessFormsetDefaultsCalled() {
+		// arrange
+		$fields = array(
+			'field' => array(
+	            'type' => 'formset',
+	            'fields' => array(
+	                array(
+	                    'title' => 'Title',
+	                    'type' => 'text',
+	                    'meta_key' => 'title',
+	                ),
+	            ),
+	            'params' => array(
+	                'init_num_forms' => 1,
+	                'max_num_forms' => 2,
+	            ),
+	            'meta_key' => 'field',
+	        ),
+		);
+		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
+					 ->setMethods( array( 'process_formset_defaults', 'default_value' ) )
+					 ->getMock();
+		$stub->expects( $this->once() )
+			 ->method( 'process_formset_defaults' )
+			 ->will( $this->returnValue( true ) );
+		$stub->expects( $this->once() )
+			 ->method( 'default_value' )
+			 ->will( $this->returnValue( array() ) );
+
+		// act
+		$stub->process_defaults( $fields );
+
+		// assert
+		// Passes when process_formset_defaults and default_value are called
+	}
+
+	function testFieldsetFieldCallsAssignDefaultsAndDefaultValuePerField() {
+		// arrange
+		$fields = array(
+			'field' => array(
+		        'type' => 'fieldset',
+		        'fields' => array(
+		            array(
+		                'type' => 'text',
+		                'meta_key' => 'num',
+		            ),
+		            array(
+		                'type' => 'text',
+		                'meta_key' => 'desc',
+		            ),
+		        ),
+		        'params' => array(),
+		        'meta_key' => 'field',
+		    ),
+		);
+		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
+					 ->setMethods( array( 'assign_defaults', 'default_value' ) )
+					 ->getMock();
+		$stub->expects( $this->exactly( 2 ) )
+			 ->method( 'assign_defaults' )
+			 ->will( $this->returnValue( array() ) );
+		$stub->expects( $this->exactly( 3 ) )
+			 ->method( 'default_value' )
+			 ->will( $this->returnValue( array() ) );
+
+		// act
+		$stub->process_defaults( $fields );
+
+		// assert
+		// Passes when each field (including the fieldset field) gets a call to assign_defaults and default_value
+	}
+
+	function testOtherFieldTypesWithMetakeySetToCallAssignDefaults() {
+		$fields = array(
+			'field' => array(
+				'slug' => 'field',
+				'title' => 'This is another field',
+				'type' => 'number',
+				'params' => array(),
+				'placeholder' => '0-100',
+				'howto' => 'Type a number',
+				'meta_key' => 'field',
+			),
+		);
+		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
+					 ->setMethods( array( 'assign_defaults', ) )
+					 ->getMock();
+		$stub->expects( $this->once() )
+			 ->method( 'assign_defaults' )
+			 ->will( $this->returnValue( true ) );
+		\WP_Mock::wpFunction('get_post_meta', array('times' => 1, 'return' => array()));
+
+		//act
+		$stub->process_defaults( $fields );
+
+		//assert
+		// Passes when process_defaults is called on field
+	}
+
+	function testOtherFieldTypesWithoutMetakeySetAndSlugSetToCallAssignDefaults() {
+		$fields = array(
+			'field' => array(
+				'meta_key' => 'field',
+				'title' => 'This is another field',
+				'type' => 'number',
+				'params' => array(),
+				'placeholder' => '0-100',
+				'howto' => 'Type a number',
+			),
+		);
+		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
+					 ->setMethods( array( 'assign_defaults', 'default_value' ) )
+					 ->getMock();
+		$stub->expects( $this->once() )
+			 ->method( 'assign_defaults' )
+			 ->will( $this->returnValue( true ) );
+		// \WP_Mock::wpFunction('get_post_meta', array('times' => 0, 'return' => array()));
+
+		//act
+		$stub->process_defaults( $fields );
+
+		//assert
+		// Passes when process_defaults is called on field
+	}
+
+	function testProcessDefaultsIsCalledForEachFieldInProcessFormsetDefaults() {
+		// arrange
+		$fields = array(
+			'field' => array(
+	            'type' => 'formset',
+	            'fields' => array(
+	                array(
+	                    'title' => 'Title',
+	                    'type' => 'text',
+	                    'meta_key' => 'title',
+	                ),
+	            ),
+	            'params' => array(
+	                'init_num_forms' => 1,
+	                'max_num_forms' => 2,
+	            ),
+	            'meta_key' => 'field',
+	        ),
+		);
+		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
+					 ->setMethods( array( 'process_defaults', ) )
+					 ->getMock();
+		$stub->expects( $this->exactly( 2 ) )
+			 ->method( 'process_defaults' )
+			 ->will( $this->returnValue( true ) );
+		$ready = array();
+
+		// act
+		$stub->process_formset_defaults( $fields['field'], $ready );
+
+		//assert
+		// Passes when each field of each formset calls process_defaults
+	}
+
+	function testProcessFormsetDefaultsAssignsCorrectValuesToEachField() {
+		//arrange
+		$fields = array(
+			'field' => array(
+	            'type' => 'formset',
+	            'fields' => array(
+	                array(
+	                    'title' => 'Title',
+	                    'type' => 'text',
+	                    'meta_key' => 'title',
+	                ),
+	            ),
+	            'params' => array(
+	                'init_num_forms' => 1,
+	                'max_num_forms' => 2,
+	            ),
+	            'meta_key' => 'field',
+	        ),
+		);
+		$View = new View();
+		\WP_Mock::wpFunction('get_post_meta', array('times' => 2, 'return' => array()));
+		$actual = array();
+		$expected = array(
+			'field_0' => array(
+	            'type' => 'formset',
+	            'fields' => array(
+	                'field_0_title' => array(
+	                    'title' => 'Title',
+	                    'type' => 'text',
+	                    'meta_key' => 'field_0_title',
+	                    'slug' => 'field_0_title',
+	                    'value' => '',
+	                    'label' => '',
+	                    'max_length' => 255,
+	                    'placeholder' => '',
+	                    'multiselect' => false,
+	                    'taxonomy' => false,
+	                ),
+	            ),
+		        'params' => array(
+		                'init_num_forms' => 1,
+		                'max_num_forms' => 2,
+		        ),
+		        'meta_key' => 'field_0',
+		        'init' => true,
+		        'slug' => '_0',
+		        'title' => '',
+	        ),
+			'field_1' => array(
+	            'type' => 'formset',
+	            'fields' => array(
+	                'field_1_title' => array(
+	                    'title' => 'Title',
+	                    'type' => 'text',
+	                    'meta_key' => 'field_1_title',
+	                    'slug' => 'field_1_title',
+	                    'value' => '',
+	                    'label' => '',
+	                    'max_length' => 255,
+	                    'placeholder' => '',
+	                    'multiselect' => false,
+	                    'taxonomy' => false,
+	                ),
+	            ),
+		        'params' => array(
+		                'init_num_forms' => 1,
+		                'max_num_forms' => 2,
+	            ),
+		        'meta_key' => 'field_1',
+		        'slug' => '_1',
+		        'title' => '',
+	        ),
+	    );
+		//act
+		$View->process_formset_defaults( $fields['field'], $actual );
+
+		//assert
+		$this->assertEquals( $expected, $actual );
+	}
 	/**
 	 * Tests that a text_area field calls for default_rows and default_cols
 	 *


### PR DESCRIPTION
# This is a huge pull request
**Please contact me if you're trying this out and want guidance. It _will_ make the process less painful.**
*Because of the size I will be adding comments to lines that I feel like should be explained to expedite the review process.*
#### I have intentionally not submitted this as separate PR's because the code included is necessary for proper execution and testing.
It is intended to make cms-toolkit more robust on it's handling of bad metabox data while improving the HTML output and covering the code more fully with tests.

## [inc/meta-box-models.php](https://github.com/kurtw/cms-toolkit/blob/testandrefactor/inc/meta-box-models.php)
In this file, the diff is enormous mostly due to the fact that about half of the file was misaligned so adding the extra tab (4 spaces) to it made it seem huge. However, there are a lot of changes made to this file. **Note**: The error handling in this isn't perfect. There are better ways of doing it, such as returning the `WP_Error` object that should be explored.

1. In the `validate_and_save` method, there is now checking for an empty fields array and and echoing an error if it's empty.
2. The `validate` method now checks for the required fields for each field type. When a required field is not set, an error is echoed and the function returns. It may seem confusing to look at it and see that when these fields are being validated they sometimes check for a field key that could have already been checked. This is because there are cases where the required key is not necessarily checked and therefore needs more validation, but I digress (only slightly).
3. The `validate_fieldset` method now makes sure each key is set and also now assigns values to both 'meta_key' and 'slug' keys.
4. The `validate_formset` method now validates its required keys in the `validate` method but still checks for their existence before assigning them. Like `validate_fieldset`, it too now assigns values to both keys.

## [inc/meta-box-view.php](https://github.com/kurtw/cms-toolkit/blob/testandrefactor/inc/meta-box-view.php)
This file does some of the same thing the models.php file does in that it checks for necessary files before using them.

1. Create a `WP_Error` member and dependency injection function to set it. This is for throwing errors and testing.
2. The method `process_defaults` now throws an error if 'meta_key' or 'taxonomy' keys are not set. It will set 'slug' to 'meta_key' if that is not set and 'meta_key' is.
3. It also throws an error there is a 'taxonomy' key but no 'meta_key' or 'slug' key because those are required to save some field types.

## [inc/meta-box-html.php](https://github.com/kurtw/cms-toolkit/blob/testandrefactor/inc/meta-box-html.php)
Last, but most certainly not least. This file has a big overhaul but in general there actually isn't a lot to it.

1. Format php so there aren't as many spaces in the HTML output.
2. Removed the `pass_fieldset` function because it wasn't doing much.
3. **Made most of everything `public`**. This was due to 
  * Not being able to test the functions
  * The functions were unnecessarily made private/protected
4. Moved some parameters around in the HTML element functions because they didn't make sense and optional fields were put in front of some required fields.


## Tests
**The amount of tests in the code is 73 total. With this PR, it goes up to 157!** Phew, that's a lot of tests. When you run the tests, You'll see 80%. That metric is attained by doing `(number of assertions ) / (number of tests)`. There are a lot of "assertions" that it doesn't count because they are WP_Mock assertions. That's okay. The big overhaul in testing goes to the inc/meta-box-html.php file. This went virtually untested and is now almost completely tested, as is with the other two aforementioned files. You can run these tests normally by doing `./vendor/bin/phpunit` in the base directory of the repo.

I've done my very best to make this code review as easy as possible because it is a lot to go over and most of you that might look at it are probably looking at it for the first time. I hope I've shed some light on what's going on in it and **PLEASE** do not hesitate to pull me into the review for however long you need me for to get it done. Good luck.