### PR TITLE
Add wysiwyg type field to available metaboxes

### DIFF
--- a/inc/README.md
+++ b/inc/README.md
@@ -208,6 +208,11 @@ correspond to IDs and classes used in the WordPress admin. Changing the value of
 below. Check the unit tests for examples of how to use each type.
 
 * `text_area` generates a text area meta box.
+* `wysiwyg` calls `wp_editor` to generate a text editor. Defaults to TinyMCE with
+Quicktags enabled. A `params` array is directly related to the `settings` array
+seen [here](http://codex.wordpress.org/Function_Reference/wp_editor) so use it
+the same way.
+that is used as the settings for the 
 * `number` generates an input field with the number type, optionally add a 
 'max_num' key to the params array to limit the length of input. For example:
 `'param' => array( 'max_length' => 2),` 

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -5,7 +5,7 @@ class HTML {
 
 	public $elements = array(
 		'selects' => array( 'select', 'multiselect', 'taxonomyselect', 'tax_as_meta', 'post_select', 'post_multiselect' ),
-		'inputs' => array( 'text_area', 'number', 'text', 'boolean', 'email', 'url', 'date', 'radio', 'link', ),
+		'inputs' => array( 'text_area', 'number', 'text', 'boolean', 'email', 'url', 'date', 'radio', 'link', 'wysiwyg', ),
 		'hidden' => array( 'nonce', 'hidden', 'separator', 'fieldset' ),
 		);
 
@@ -178,6 +178,10 @@ class HTML {
 			HTML::text_area( $field['rows'], $field['cols'], $field['meta_key'], $value, $title, $label, $field['placeholder'], $required, $form_id );
 		}
 
+		if ( $field['type'] == 'wysiwyg' ) {
+			$this->wysiwyg( $value, $field['meta_key'], $field['params'], $label, $form_id );
+		}
+
 		if ( in_array( $field['type'], array( 'number', 'text', 'email', 'url' ) ) ) {
 			HTML::single_input( $field['meta_key'], $field['type'], $field['max_length'], $value, $title, $label, $field['placeholder'], $required, $form_id );
 		}
@@ -228,6 +232,26 @@ class HTML {
 				  placeholder="<?php echo esc_attr( $placeholder ) ?>"
 				  <?php if ( $required ): echo 'required'; endif; ?>><?php echo esc_html( $value ) ?></textarea>
 		<?php
+	}
+
+	/**
+	 * Generate a wysiwyg field
+	 *
+	 * Uses the built in Wordpress function wp_editor to generate the field.
+	 *
+	 * @param str $value is the text within the editor that has been saved
+	 * @param str $meta_key the id associated with the HTML tag and data
+	 * @param str $params are the settings for the wp_editor function
+	 * @param str $form_id the numeric id for a formset that the field could be in
+	 *
+	**/
+	public function wysiwyg( $value, $meta_key, $params, $label, $form_id = NULL ) {
+		if ( isset( $form_id ) ) {
+			$params['editor_class'] .= " form-input_{$form_id}";
+		}
+		?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php echo esc_attr( $label ) ?></label><?php
+		wp_editor( $value, $meta_key, $params );
+
 	}
 
 	/**

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -40,6 +40,7 @@ class Models {
         'date',
         'radio',
         'link',
+        'wysiwyg',
     );
     private $other   = array( 'nonce', 'hidden', 'separator', 'fieldset', 'formset' );
     

--- a/inc/meta-box-view.php
+++ b/inc/meta-box-view.php
@@ -125,6 +125,13 @@ class View {
 		if ( ! in_array($field['type'], array( 'taxonomyselect', 'tax_as_meta', 'date' ) ) ) {
 			$field['taxonomy'] = false;
 		}
+		if ( $field['type'] == 'wysiwyg' ) {
+			if ( ! isset( $field['params'] ) or empty( $field['params'] ) ) {
+				$field['params'] = array( 'textarea_rows' => 5, 'editor_class' => "cms-toolkit-wysiwyg" );
+			} else {
+				$field['params']['editor_class'] .= " cms-toolkit-wysiwyg";
+			}
+		}
 		return $field;
 	}
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -4,6 +4,18 @@ function delete_form_data(slug, form_id) {
     // Clear text fields
     jQuery(selectorBase).each( function(index) {
         jQuery(this).val("");
+        var iframe = "iframe[id=" + this.id + "_ifr";
+        var contents = jQuery(iframe).contents();
+        var wysiwyg = contents.find("body");
+        wysiwyg.html("");
+        // var wysiwyg = 
+
+        // console.log(wysiwyg);
+        // Clear WYSIWYG
+        // jQuery(wysiwyg).each( function(index) {
+        //     console.log(this);
+            // jQuery(this).html("");
+        // });
     });
     // Clear checkboxes & radio buttons
     jQuery(selectorBase + ':checked').each( function(index) {

--- a/tests/test-meta_box_html.php
+++ b/tests/test-meta_box_html.php
@@ -33,4 +33,13 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Act
 		$HTML->draw($fields);
 	}
+
+	function testWYSIWYGFieldCallsWPEditor() {
+		//arrange
+		$HTML = new HTML();
+		\WP_Mock::wpFunction( 'wp_editor', array( 'times' => 1 ) );
+
+		//act
+		$HTML->wysiwyg( 'content', 'meta_key', array(), null, null);
+	}
 }

--- a/tests/test-meta_box_view.php
+++ b/tests/test-meta_box_view.php
@@ -649,4 +649,28 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		// Assert
 		$this->assertTrue($expected == $actual);
 	}
+
+	function testAssignDefaultsSetsParamArrayIfNotSet() {
+		//arrange
+		$View = new View();
+		$field = array( 'type' => 'wysiwyg', 'params' => null );
+
+		//act
+		$field = $View->assign_defaults( $field );
+
+		// assert
+		$this->assertTrue( isset( $field['params'] ) );
+	}
+
+	function testAssignDefaultsAddsClassToEditorClassParam() {
+		//arrange
+		$View = new View();
+		$field = array( 'type' => 'wysiwyg', 'params' => array( 'editor_class' => 'class') );
+
+		//act
+		$field = $View->assign_defaults( $field );
+
+		// assert
+		$this->assertEquals( $field['params']['editor_class'], "class cms-toolkit-wysiwyg" );
+	}
 }


### PR DESCRIPTION
This will add a wysiwyg text editor to the available field types in the cms-toolkit's field type repertoire. Use of this field is documented in the [README.md](https://github.com/kurtw/cms-toolkit/tree/wysiwyg/inc/README.md) and there are tests for it. Run them using `./vendor/bin/phpunit`. 

This is part of a set of 3 (or 4) fields to be added in the current sprint.