### PR TITLE
Fix select field that was not displaying saved data

### DIFF
--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -129,6 +129,7 @@ class HTML {
 				$field['params'], 
 				$field['taxonomy'], 
 				$multi, 
+				$field['value'],
 				$field['placeholder'],
 				$title,
 				$label,


### PR DESCRIPTION
This is a simple fix for select fields not displaying the saved field in the select input.