### PR TITLE
Add time and datetime field types with tests

### DIFF
--- a/inc/meta-box-callbacks.php
+++ b/inc/meta-box-callbacks.php
@@ -41,7 +41,9 @@ class Callbacks {
 		$rmTerm     = 'rm_' . $taxonomy . '_' . $term_num;
 		if ( isset( $_POST[$rmTerm] ) ) {
 			$tounset = get_term_by( 'name', $_POST[$rmTerm], $taxonomy );
-			$this->Taxonomy->remove_post_term( $post_id, $tounset->term_id, $taxonomy );
+			if ( $tounset ) {
+				$this->Taxonomy->remove_post_term( $post_id, $tounset->term_id, $taxonomy );
+			}
 		}
 		
 		if ( isset($data[$taxonomy] ) ) {

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -5,7 +5,7 @@ class HTML {
 
 	public $elements = array(
 		'selects' => array( 'select', 'multiselect', 'taxonomyselect', 'tax_as_meta', 'post_select', 'post_multiselect' ),
-		'inputs' => array( 'text_area', 'number', 'text', 'boolean', 'email', 'url', 'date', 'radio', 'link', 'wysiwyg', ),
+		'inputs' => array( 'text_area', 'number', 'text', 'boolean', 'email', 'url', 'date', 'time', 'datetime', 'radio', 'link', 'wysiwyg' ),
 		'hidden' => array( 'nonce', 'hidden', 'separator', 'fieldset' ),
 		);
 
@@ -189,6 +189,13 @@ class HTML {
 
 		if ( $field['type'] == 'date' ) {
 			HTML::date( $taxonomy = $field['taxonomy'], $tax_nice_name, $multiples = $field['multiple'], $required, $form_id );
+			$this->displayTags( $field['taxonomy'], $field['type'] );
+		} elseif ( $field['type'] == 'time' ) {
+			$this->time( $field['slug'], $field['taxonomy'], $required, $label, $form_id );
+			$this->displayTags( $field['taxonomy'], $field['type'] );
+		} elseif ( $field['type'] == 'datetime' ) {
+			$this->datetime( $field['slug'], $field['taxonomy'], $required, $label, $form_id );
+			$this->displayTags( $field['taxonomy'], $field['type'] );
 		}
 
 		if ( $field['type'] == 'radio' ) {
@@ -472,31 +479,69 @@ class HTML {
 		  <p class="howto">If one is set already, selecting a new month, day and year will override it.</p>
 		<?php } else { ?>
 		  <p class='howto'>Select a month, day and year to add another.</p>
-		<?php } ?>
+		<?php }
+	}
+	
+	public function time( $slug, $taxonomy, $required, $label = NULL, $form_id = NULL ) {
+		if ( $label ) { 
+			?><label for="<?php echo esc_attr( $slug ) ?>" class="cms-toolkit-label block-label"><?php 
+				echo esc_attr( $label ); 
+			?></label><?php
+		}
+		$this->select( $slug . "_hour", array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ), false, null, null, "Hour", null, null, $required, $form_id );
+		?> : <?php
+		$this->select( $slug . "_minute", array( "00", "15", "30", "45" ), false, null, null, "Minute", null, null, $required, $form_id );
+		$this->select( $slug . "_ampm", array( "am", "pm" ), false, null, null, "am/pm", null, null, $required, $form_id );
+	}
 
-		<div class='tagchecklist'>
-		<?php
+	public function datetime( $slug, $taxonomy, $required, $label = NULL, $form_id = NULL ) {
+		?><div id="<?php echo esc_attr( $slug) ?>" name="<?php echo esc_attr( $slug) ?>" class="cms-toolkit-datetime" ><?php
+			if ( $label ) { 
+				?><label for="<?php echo esc_attr( $slug ) ?>" class="cms-toolkit-label block-label"><?php 
+					echo esc_attr( $label ); 
+				?></label><?php
+			}
+			$this->date( $taxonomy, null, false, $required, $form_id );
+			?> @ <?php
+			$this->time( $slug, $taxonomy, $required, null, $form_id );
+		?></div><?php
+	}
+
+	public function displayTags( $taxonomy, $type ) {
+		global $post;
+		?><div class='tagchecklist'><?php
 			if ( has_term( '', $taxonomy, $post->id ) ) {
-				$terms = get_the_terms( $post->id, $tax_name );
-				$i     = 0;
+				$terms = get_the_terms( $post->id, $taxonomy );
+				$i = 0;
 				foreach ( $terms as $term ) {
 					// Checks if the current set term is wholly numeric (in this case a timestamp)
 					if ( is_numeric( $term->name ) ) {
-						$natdate = date( 'j F, Y', intval( $term->name ) );
-	?>
-			  <span><a id='<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>' class='datedelbutton <?php echo esc_attr( $term->name ) ?>'><?php echo esc_attr( $term->name ) ?></a>&nbsp;<?php echo esc_attr( $natdate ) ?></span>
-			<?php
+						if ( $type == 'date' ) {
+							$natdate = date( 'j F, Y', intval( $term->name ) );
+						} elseif ( $type == 'time' ) {							
+							$natdate = date( 'h:ia', intval( $term->name ) );
+						} elseif ( $type == 'datetime' ) {
+							$natdate = date( 'h:ia F j, Y', intval( $term->name ) );
+						}
+						?><span><a id="<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>"
+								  class="tagdelbutton <?php echo esc_attr( $term->name ) ?>"><?php
+									echo esc_attr( $term->name );
+								?></a><?php
+							?>&nbsp;<?php echo esc_attr( $natdate );
+						?></span><?php
 					} else {
-						$date = strtotime( $term->name ); // If it isn't, convert it to a timestamp -- why? ?>
-			<span><a id='<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>' class='datedelbutton <?php echo esc_attr( $date ) ?>'><?php echo esc_attr( $term->name ) ?></a>&nbsp;<?php echo esc_attr( $term->name ) ?></span>
-			<?php
+						$date = strtotime( $term->name );
+						?><span><a id="<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>"
+								  class="tagdelbutton <?php echo esc_attr( $date ) ?>"><?php
+									echo esc_attr( $term->name );
+								?></a><?php
+							?>&nbsp;<?php echo esc_attr( $term->name );
+						?></span><?php
 					}
-					HTML::hidden( 'rm_' . $tax_name . '_' . $i, null, null );
+					$this->hidden( 'rm_' . $taxonomy . '_' . $i, null, null );
 					$i++;
 				}
 			}
-			?>
-		</div>
-	<?php
+		?></div><?php
 	}
 }

--- a/inc/meta-box-view.php
+++ b/inc/meta-box-view.php
@@ -122,7 +122,7 @@ class View {
 		} else {
 			$field['multiselect'] = false;
 		}
-		if ( ! in_array($field['type'], array( 'taxonomyselect', 'tax_as_meta', 'date' ) ) ) {
+		if ( ! in_array($field['type'], array( 'taxonomyselect', 'tax_as_meta', 'date', 'time', 'datetime' ) ) ) {
 			$field['taxonomy'] = false;
 		}
 		if ( $field['type'] == 'wysiwyg' ) {
@@ -136,7 +136,7 @@ class View {
 	}
 
 	public function default_value( $ID, $field, $index = 0 ) {
-		if ( $field['type'] == 'link' ) {
+		if ( $field['type'] == 'link' or $field['type'] == 'time' or $field['type'] == 'datetime' or $field['type'] == 'date' ) {
 			$default = null;
 		} else {
 			$existing = get_post_meta( $ID, $field['meta_key'], false );

--- a/js/functions.js
+++ b/js/functions.js
@@ -85,7 +85,7 @@ jQuery(document).ready(function($){
     });
 } );
 
-jQuery('.datedelbutton').click( function() {
+jQuery('.tagdelbutton').click( function() {
     var taxAndTagNum = jQuery(this).attr('id').split('-');
     var taxonomy = taxAndTagNum[0];
     var tagNum = taxAndTagNum[3];

--- a/tests/test-meta_box_html.php
+++ b/tests/test-meta_box_html.php
@@ -42,4 +42,69 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		//act
 		$HTML->wysiwyg( 'content', 'meta_key', array(), null, null);
 	}
+
+	function testTimeCallsSelect3Times() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'select' ) )
+					 ->getMock();
+		$HTML->expects( $this->exactly( 3 ) )
+			 ->method( 'select' );
+
+		//act
+		$HTML->time( 'slug', 'taxonomy', false, 'label', 1 );
+	}
+
+	function testDatetimeCallsDateAndTime() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'time', 'date' ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'date' );
+		$HTML->expects( $this->once() )
+			 ->method( 'time' );
+
+		//act
+		$HTML->datetime( 'slug', 'taxonomy', false, 'label', 1 );
+	}
+
+	function testDisplayTagsCallsHasTermToSeeIfTagsExistToBeShown() {
+		//arrange
+		$HTML = new HTML();
+		\WP_Mock::wpFunction( 'has_term', array( 'times' => 1, 'return' => false ) );
+
+		//act
+		$HTML->displayTags( 'tax', 'type' );
+	}
+
+	function testDisplayTagsCallsGetTheTerms() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'hidden' ) )
+					 ->getMock();
+		$term = new \StdClass;
+		$term->name = strtotime( 'now' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'times' => 1, 'return' => array( $term ) ) );
+
+		//act
+		$HTML->displayTags( 'tax', 'time' );
+	}
+
+	function testDisplayTagsCallsHiddenForEachTag() {
+		//arrange
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'hidden' ) )
+					 ->getMock();
+		$HTML->expects( $this->once() )
+			 ->method( 'hidden' );
+		$term = new \StdClass;
+		$term->name = strtotime( 'now' );
+		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
+		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( $term ) ) );
+
+		//act
+		$HTML->displayTags( 'tax', 'time' );
+	}
 }

--- a/tests/test-meta_box_models.php
+++ b/tests/test-meta_box_models.php
@@ -180,32 +180,6 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		$TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual);
 	}
 
-	// /**
-	//  * Tests whether WP_Error is returned if missing a piece of a date.
-	//  *
-	//  * @group stable
-	//  * @group isolated
-	//  * @group date
-	//  * @group user_input
-	//  * @group validation
-	//  */
-	// function testInvalidDateValidateExpectsDateCalledNone() {
-	// 	// arrange
-	// 	$stub = $this->getMockBuilder('Callbacks')
-	// 				 ->setMethods( array( 'validate_date' ) )
-	// 				 ->getMock();
-
-	// 	$form = new TestValidDateField();
-	// 	$form->set_callbacks($stub);
-	// 	$_POST =array('post_ID' => 1, 'category_year' => '1970');
-	// 	$actual = array();
-	// 	// act
-	// 	$form->validate($_POST['post_ID'], $form->fields['category'], $actual);
-
-	// 	// assert
-	// 	$this->assertInstanceOf( 'WP_Error', $actual)
-	// }
-
 	/**
 	 * Tests whether a number field has data replaced
 	 *
@@ -734,8 +708,187 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_day' => '01');
 
 		// act
-		$form->validate_date( $form->fields['category'], $_POST['post_ID']);
-		// $stub->method();
+		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+	}
+	/**
+	 * Tests whether the validate_datetime method when called on an invalid field
+	 * does not call the callback method.
+	 *
+	 * @group stable
+	 * @group date
+	 * @group isolated
+	 * @group user_input
+	 */
+	function testInvalidDateFieldExpectsCallbackNotCalled() {
+		// arrange
+		$stub = $this->getMockBuilder('Callbacks')
+					->setMethods(array('date'))
+					->getMock();
+
+		$stub->expects( $this->exactly( 0 ) )
+			 ->method( 'date' )
+			 ->with( $this->anything(), $this->anything(), $this->anything() );
+
+		// $stub->expects( $this->once() )
+		// 	->method( 'method' );
+
+		$form = new TestValidDateField();
+		$form->set_callbacks($stub);
+		$term = \WP_Mock::wpFunction( 'wp_get_post_terms' ); 
+		$_POST = array(
+			'post_ID' => 1,
+			'category_year' => '' ,
+			'category_month' => 'January',
+			'category_day' => '01');
+
+		// act
+		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+	}
+	/**
+	 * Tests whether the validate_datetime method when called on a time field calls the
+	 * date method from the Callbacks class.
+	 *
+	 * @group stable
+	 * @group date
+	 * @group isolated
+	 * @group user_input
+	 */
+	function testValidTimeFieldExpectsCallbackCalledOnce() {
+		// arrange
+		$stub = $this->getMockBuilder('Callbacks')
+					->setMethods(array('date'))
+					->getMock();
+
+		$stub->expects( $this->once() )
+			 ->method( 'date' )
+			 ->with( $this->anything(), $this->anything(), $this->anything() );
+
+		// $stub->expects( $this->once() )
+		// 	->method( 'method' );
+
+		$form = new TestValidDateField();
+		$form->fields['category']['type'] = 'time';
+		$form->set_callbacks($stub);
+		$term = \WP_Mock::wpFunction( 'wp_get_post_terms' ); 
+		$_POST = array(
+			'post_ID' => 1,
+			'category_hour' => array('9') ,
+			'category_minute' => array('30'),
+			'category_ampm' => array('am'));
+
+		// act
+		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+	}
+	/**
+	 * Tests whether the validate_datetime method when called on an invalid time 
+	 * does not call the date callback method.
+	 *
+	 * @group stable
+	 * @group date
+	 * @group isolated
+	 * @group user_input
+	 */
+	function testInvalidTimeFieldExpectsCallbackNotCalled() {
+		// arrange
+		$stub = $this->getMockBuilder('Callbacks')
+					->setMethods(array('date'))
+					->getMock();
+
+		$stub->expects( $this->exactly( 0 ) )
+			 ->method( 'date' )
+			 ->with( $this->anything(), $this->anything(), $this->anything() );
+
+		// $stub->expects( $this->once() )
+		// 	->method( 'method' );
+
+		$form = new TestValidDateField();
+		$form->fields['category']['type'] = 'time';
+		$form->set_callbacks($stub);
+		$term = \WP_Mock::wpFunction( 'wp_get_post_terms' ); 
+		$_POST = array(
+			'post_ID' => 1,
+			'category_hour' => array('9') ,
+			'category_minute' => array('30'),
+			'category_ampm' => array(''));
+
+		// act
+		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+	}
+	/**
+	 * Tests whether the validate_datetime method when called on a datetime field calls the
+	 * date method from the Callbacks class.
+	 *
+	 * @group stable
+	 * @group date
+	 * @group isolated
+	 * @group user_input
+	 */
+	function testValidDatetimeFieldExpectsCallbackCalledOnce() {
+		// arrange
+		$stub = $this->getMockBuilder('Callbacks')
+					->setMethods(array('date'))
+					->getMock();
+
+		$stub->expects( $this->once() )
+			 ->method( 'date' )
+			 ->with( $this->anything(), $this->anything(), $this->anything() );
+
+		// $stub->expects( $this->once() )
+		// 	->method( 'method' );
+
+		$form = new TestValidDateField();
+		$form->fields['category']['type'] = 'datetime';
+		$form->set_callbacks($stub);
+		$term = \WP_Mock::wpFunction( 'wp_get_post_terms' ); 
+		$_POST = array(
+			'post_ID' => 1,
+			'category_hour' => array('9') ,
+			'category_minute' => array('30'),
+			'category_ampm' => array('am'),
+			'category_year' => '2014' ,
+			'category_month' => 'January',
+			'category_day' => '01');
+
+		// act
+		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+	}
+	/**
+	 * Tests whether the validate_datetime method when called on an invalid datetime 
+	 * does not call the date callback method.
+	 *
+	 * @group stable
+	 * @group date
+	 * @group isolated
+	 * @group user_input
+	 */
+	function testInvalidDatetimeFieldExpectsCallbackNotCalled() {
+		// arrange
+		$stub = $this->getMockBuilder('Callbacks')
+					->setMethods(array('date'))
+					->getMock();
+
+		$stub->expects( $this->exactly( 0 ) )
+			 ->method( 'date' )
+			 ->with( $this->anything(), $this->anything(), $this->anything() );
+
+		// $stub->expects( $this->once() )
+		// 	->method( 'method' );
+
+		$form = new TestValidDateField();
+		$form->fields['category']['type'] = 'datetime';
+		$form->set_callbacks($stub);
+		$term = \WP_Mock::wpFunction( 'wp_get_post_terms' ); 
+		$_POST = array(
+			'post_ID' => 1,
+			'category_hour' => array('9') ,
+			'category_minute' => array('30'),
+			'category_ampm' => array(''),
+			'category_year' => '' ,
+			'category_month' => 'January',
+			'category_day' => '01');
+
+		// act
+		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
 	}
 
 	/**

--- a/tests/test-meta_box_view.php
+++ b/tests/test-meta_box_view.php
@@ -673,4 +673,35 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		// assert
 		$this->assertEquals( $field['params']['editor_class'], "class cms-toolkit-wysiwyg" );
 	}
+
+	function testAssignDefaultsDoesNotSetTaxonomyToFalseForGivenFields() {
+		// arrange
+		$View = new View();
+		$field = array( 'type' => '', 'taxonomy' => true );
+		$types = array( 'taxonomyselect', 'tax_as_meta', 'date', 'time', 'datetime' );
+
+		//act
+		foreach ( $types as $type ) {
+			$field['type'] = $type;		
+			$default = $View->assign_defaults( $field );
+			// assert
+			$this->assertEquals( $field['taxonomy'], true );
+		}
+	}
+
+	function testDefaultValueDoesNotSetValueForGivenFields() {
+		// arrange
+		global $post;
+		$View = new View();
+		$field = array( 'type' => '' );
+		$types = array( 'link', 'date', 'time', 'datetime' );
+
+		foreach ( $types as $type ) {
+			$field['type'] = $type;		
+			// act
+			$default = $View->default_value( $post->ID, $field );
+			// assert
+			$this->assertEquals( isset( $field['value'] ), false );
+		}
+	}
 }


### PR DESCRIPTION
This adds the `time` and `datetime` field types to the cms-toolkit with tests for the added features. These fields act just like the `date` field and are dependent on a taxonomy for saving. This PR also pulls the tags for showing the data saved by the fields and deletion by clicking the "X" button on the tags into a new function for use in all 3 fields.