### PR TITLE
Fix failing tests from PR #40

### DIFF
--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -43,8 +43,7 @@ class HTML {
 	}
 
 	public function draw_formset( $field ) {
-		global $post;
-		$post_id = $post->ID;	
+		$post_id = get_the_ID();	
 		$post_data = get_post_custom( $post_id );
 		$form_id = $this->get_formset_id( $field['meta_key'] );
 		$init = isset( $field['init'] ) ? true : false;
@@ -134,10 +133,10 @@ class HTML {
 				$form_id
 			);
 		} elseif ( $field['type'] == 'post_select' || $field['type'] == 'post_multiselect' ) {
-			global $post;
+			$post_id = get_the_ID();
 			$args = $field['params'];
 			$posts = get_posts($args);
-			$value = get_post_meta( $post->ID, $field['meta_key'], $single = false );
+			$value = get_post_meta( $post_id, $field['meta_key'], $single = false );
 			$multi = $field['type'] == 'post_multiselect' ? 'multiple' : null;
 			$this->post_select(
 				$field['meta_key'],
@@ -289,8 +288,7 @@ class HTML {
 	}
 
 	public function link_input( $meta_key, $value, $required, $label, $form_id = NULL ) {
-		global $post;
-		$post_id = $post->ID;
+		$post_id = get_the_ID();
 		$existing = get_post_meta( $post_id, $meta_key, false);
 		?><div class="link-field <?php echo "{$meta_key}" ?>"><?php
 		if ( ! isset( $existing[0] ) || ! isset( $existing[1] ) ) { 
@@ -432,8 +430,9 @@ class HTML {
 	 * @param bool $multiples     whether the term shoud append (true) or replace (false) existing terms
 	 **/
 	public function date( $taxonomy, $multiple, $required, $label, $form_id = NULL ) {
+		global $wp_locale;
+		$post_id = get_the_ID();
 		$tax_name = stripslashes( $taxonomy );
-		global $post, $wp_locale;
 		$month = NULL;
 		$day   = NULL;
 		$year  = NULL;
@@ -454,8 +453,8 @@ class HTML {
 			?><p class="howto">If one is set already, selecting a new month, day and year will override it.</p><?php
 		} 
 		?><div class="tagchecklist"><?php
-			if ( has_term( '', $taxonomy, $post->id ) ) {
-				$terms = get_the_terms( $post->id, $tax_name );
+			if ( has_term( '', $taxonomy, $post_id ) ) {
+				$terms = get_the_terms( $post_id, $tax_name );
 				$i     = 0;
 				foreach ( $terms as $term ) {
 					// Checks if the current set term is wholly numeric (in this case a timestamp)

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -13,483 +13,483 @@ use \WP_Error as WP_Error;
 use \DateTime;
 
 class Models {
-    public $title;
-    public $slug;
-    public $post_type;
-    public $context;
-    public $fields;
-    public $priority;
-    public $Callbacks; // obj A class containing other validation methods
-    public $View; // obj A class containing template patterns
-    public $error;
-    private $selects = array(
-        'select',
-        'multiselect',
-        'taxonomyselect',
-        'tax_as_meta',
-        'post_select',
-        'post_multiselect'
-    );
-    private $inputs  = array(
-        'text_area',
-        'number',
-        'text',
-        'boolean',
-        'email',
-        'url',
-        'date',
-        'radio',
-        'link',
-        'wysiwyg',
-    );
-    private $other   = array( 'nonce', 'hidden', 'separator', 'fieldset', 'formset' );
-    
-    public function __construct() {
-        $this->Callbacks = new Callbacks();
-        $this->View      = new View();
-        $this->priority  = 'default';
-        if ( ! is_array($this->post_type) ) {
-            $this->post_type = array($this->post_type);
-        }
-        $this->error = '\WP_Error';
-    }
+	public $title;
+	public $slug;
+	public $post_type;
+	public $context;
+	public $fields;
+	public $priority;
+	public $Callbacks; // obj A class containing other validation methods
+	public $View; // obj A class containing template patterns
+	public $error;
+	private $selects = array(
+		'select',
+		'multiselect',
+		'taxonomyselect',
+		'tax_as_meta',
+		'post_select',
+		'post_multiselect'
+	);
+	private $inputs  = array(
+		'text_area',
+		'number',
+		'text',
+		'boolean',
+		'email',
+		'url',
+		'date',
+		'radio',
+		'link',
+		'wysiwyg',
+	);
+	private $other   = array( 'nonce', 'hidden', 'separator', 'fieldset', 'formset' );
 
-    /**
-     * The following three methods are dependency injection methods. They can be used
-     * to replace Utils\MetaBox\Callbacks and Utils\MetaBox\View with your own callback
-     * or view class. This is useful for unit testing purposes and for when you decide
-     * you don't like the methods we've given you and need to replace them for some 
-     * reason. Maybe you need different templates for something but don't think they
-     * should be contributed back, use these methods to replace our templates with your
-     * own.
-     * 
-     * @param obj $Class The class you want to inject into this plugin
-     */
-    public function set_callbacks( $Class ) {
-        $this->Callbacks = $Class;
-    }
+	public function __construct() {
+		$this->Callbacks = new Callbacks();
+		$this->View      = new View();
+		$this->priority  = 'default';
+		if ( ! is_array($this->post_type) ) {
+			$this->post_type = array($this->post_type);
+		}
+		$this->error = '\WP_Error';
+	}
 
-    public function set_view( $Class ) {
-        $this->View = $Class;
-    }
+	/**
+	 * The following three methods are dependency injection methods. They can be used
+	 * to replace Utils\MetaBox\Callbacks and Utils\MetaBox\View with your own callback
+	 * or view class. This is useful for unit testing purposes and for when you decide
+	 * you don't like the methods we've given you and need to replace them for some 
+	 * reason. Maybe you need different templates for something but don't think they
+	 * should be contributed back, use these methods to replace our templates with your
+	 * own.
+	 *
+	 * @param obj $Class The class you want to inject into this plugin
+	 */
+	public function set_callbacks( $Class ) {
+		$this->Callbacks = $Class;
+	}
 
-    public function error_handler( $Class ) {
-        $this->error = $Class;
-    }
+	public function set_view( $Class ) {
+		$this->View = $Class;
+	}
 
-    public function check_post_type( $post_type ) {
-        if ( post_type_exists( $post_type ) ) {
-            $post_type = sanitize_key( $post_type );
-        } else {
-            $post_type = false;
-        }
-        return $post_type;
-    }
+	public function error_handler( $Class ) {
+		$this->error = $Class;
+	}
 
-    /**
-    *
-    * generate: Create a meta box based on a few parameters.
-    *
-    * This function allows developers with this plugin installed to easily
-    * instantiate meta boxes into different edit screens of their WordPress
-    * install. Inspired by Django forms. The generate() method parses parameters
-    * into an objeect, the last property of which is passed to the build()
-    * callback. Generating metaboxes is as simple as hooking this method into
-    * the `add_meta_boxes` action hook.
-    *
-    * @since 1.0
-    *
-    * @uses wp_parse_args To determine the desired differences from defaults
-    * @uses add_meta_box WordPress API To generate the metabox
-    * @uses \CFPB\Utils\MetaBox\Template\HTML(); For generating form fields
-    * @uses add_meta_box (WP Core) To instantiate the meta box
-    * @uses $this->check_post_type To check whether the post type given in
-    *       $this->post_type exists
-    * @uses \WP_Error Error handling is done with WordPress if invalid contexts or 
-    *        post types are supplied
-    **/
-    public function generate( ) {
-        $parts = array( 'normal', 'advanced', 'side', );
-        if ( ! in_array( $this->context, $parts ) ) {
-            $error = new $this->error( 'context', __( 'Invalid context: ' . $this->context ) );
-            echo $error->get_error_message('context');
-            return;
-        }
+	public function check_post_type( $post_type ) {
+		if ( post_type_exists( $post_type ) ) {
+			$post_type = sanitize_key( $post_type );
+		} else {
+			$post_type = false;
+		}
+		return $post_type;
+	}
 
-        $fields = $this->fields;
-        $post_types = $this->post_type;
-        foreach ( $post_types as $p ) {
-            $exists = $this->check_post_type($p);
-            if ( $exists != false ) {
-                add_meta_box(
-                    $id = $this->slug,
-                    $title = $this->title,
-                    $callback = array( $this->View, 'ready_and_print_html' ),
-                    $post_type = $p,
-                    $context = $this->context,
-                    $priority = $this->priority,
-                    $callback_args = $fields
-                );
-            } else {
-                $error = new $this->error( 'post_type', 'Invalid post type: ' . $p);
-                echo $error->get_error_message('post_type');
-            }
-        }
-    }
+	/**
+	*
+	* generate: Create a meta box based on a few parameters.
+	*
+	* This function allows developers with this plugin installed to easily
+	* instantiate meta boxes into different edit screens of their WordPress
+	* install. Inspired by Django forms. The generate() method parses parameters
+	* into an objeect, the last property of which is passed to the build()
+	* callback. Generating metaboxes is as simple as hooking this method into
+	* the `add_meta_boxes` action hook.
+	*
+	* @since 1.0
+	*
+	* @uses wp_parse_args To determine the desired differences from defaults
+	* @uses add_meta_box WordPress API To generate the metabox
+	* @uses \CFPB\Utils\MetaBox\Template\HTML(); For generating form fields
+	* @uses add_meta_box (WP Core) To instantiate the meta box
+	* @uses $this->check_post_type To check whether the post type given in
+	*       $this->post_type exists
+	* @uses \WP_Error Error handling is done with WordPress if invalid contexts or
+	*        post types are supplied
+	**/
+	public function generate( ) {
+		$parts = array( 'normal', 'advanced', 'side', );
+		if ( ! in_array( $this->context, $parts ) ) {
+			$error = new $this->error( 'context', __( 'Invalid context: ' . $this->context ) );
+			echo $error->get_error_message('context');
+			return;
+		}
 
-    /**
-    * validate_formset validates a formset
-    *
-    * @param  arr  $field     The formset to validate. 
-    * @param  arr  $validate  The array that holds all the data to save in an
-    *                         associative array that is passed by reference.
-    * @param  arr  $post_ID   The post's ID
-    *
-    * @return  void           No return value. The validate array is passed by reference
-    *                         so data is saved through that array.
-    */
+		$fields = $this->fields;
+		$post_types = $this->post_type;
+		foreach ( $post_types as $p ) {
+			$exists = $this->check_post_type($p);
+			if ( $exists != false ) {
+				add_meta_box(
+					$id = $this->slug,
+					$title = $this->title,
+					$callback = array( $this->View, 'ready_and_print_html' ),
+					$post_type = $p,
+					$context = $this->context,
+					$priority = $this->priority,
+					$callback_args = $fields
+				);
+			} else {
+				$error = new $this->error( 'post_type', 'Invalid post type: ' . $p);
+				echo $error->get_error_message('post_type');
+			}
+		}
+	}
 
-    public function validate_formset( $field, &$validate, $post_ID ) {
-        for ( $i = 0; $i < $field['params']['max_num_forms']; $i++ ) {
-            $processed[$i] = $field;
-            if ( isset( $processed[$i]['meta_key'] ) ) {
-                $processed[$i]['meta_key'] .= '_' . $i;
-            }
-            if ( isset( $processed[$i]['slug'] ) ) {
-                $processed[$i]['slug'] .= '_' . $i;
-            }
-            foreach ( $processed[$i]['fields'] as $f ) {
-                if ( isset( $processed[$i]['meta_key'] ) and isset( $f['meta_key'] ) ) {
-                    $f['meta_key'] = "{$processed[$i]['meta_key']}_{$f['meta_key']}";
-                }
-                if ( isset( $processed[$i]['slug'] ) and isset( $f['slug'] ) ) {
-                    $f['slug'] = "{$processed[$i]['slug']}_{$f['slug']}";
-                }
-                $this->validate( $post_ID, $f, $validate );
-            }
-        }
-    }
+	/**
+	* validate_formset validates a formset
+	*
+	* @param  arr  $field     The formset to validate.
+	* @param  arr  $validate  The array that holds all the data to save in an
+	*                         associative array that is passed by reference.
+	* @param  arr  $post_ID   The post's ID
+	*
+	* @return  void           No return value. The validate array is passed by reference
+	*                         so data is saved through that array.
+	*/
 
-    /**
-    * validate_fieldset validates a fieldset
-    *
-    * @param  arr  $field     The formset to validate. 
-    * @param  arr  $validate  The array that holds all the data to save in an
-    *                         associative array that is passed by reference.
-    * @param  arr  $post_ID   The post's ID
-    *
-    * @return  void           No return value. The validate array is passed by reference
-    *                         so data is saved through that array.
-    */
+	public function validate_formset( $field, &$validate, $post_ID ) {
+		for ( $i = 0; $i < $field['params']['max_num_forms']; $i++ ) {
+			$processed[$i] = $field;
+			if ( isset( $processed[$i]['meta_key'] ) ) {
+				$processed[$i]['meta_key'] .= '_' . $i;
+			}
+			if ( isset( $processed[$i]['slug'] ) ) {
+				$processed[$i]['slug'] .= '_' . $i;
+			}
+			foreach ( $processed[$i]['fields'] as $f ) {
+				if ( isset( $processed[$i]['meta_key'] ) and isset( $f['meta_key'] ) ) {
+					$f['meta_key'] = "{$processed[$i]['meta_key']}_{$f['meta_key']}";
+				}
+				if ( isset( $processed[$i]['slug'] ) and isset( $f['slug'] ) ) {
+					$f['slug'] = "{$processed[$i]['slug']}_{$f['slug']}";
+				}
+				$this->validate( $post_ID, $f, $validate );
+			}
+		}
+	}
 
-    public function validate_fieldset( $field, &$validate, $post_ID ) {
-        foreach ( $field['fields'] as $f ) {
-            if ( isset( $field['meta_key'] ) and isset( $f['meta_key'] ) ) {
-                $f['meta_key'] = "{$field['meta_key']}_{$f['meta_key']}";
-            }
-            if ( isset( $field['slug'] ) and isset( $f['slug'] ) ) {
-                $f['slug'] = "{$field['slug']}_{$f['slug']}";
-            }
-            $this->validate( $post_ID, $f, $validate );
-        }
-    }
+	/**
+	* validate_fieldset validates a fieldset
+	*
+	* @param  arr  $field     The formset to validate.
+	* @param  arr  $validate  The array that holds all the data to save in an
+	*                         associative array that is passed by reference.
+	* @param  arr  $post_ID   The post's ID
+	*
+	* @return  void           No return value. The validate array is passed by reference
+	*                         so data is saved through that array.
+	*/
 
-    /**
-     * validate_link validates a field with type = 'link'
-     * 
-     * @param  arr $field   The field to validate, normally passed by looping through 
-     *                      $this->fields
-     * @param  int $post_ID The post ID to have post values saved to
-     * @return void         No return value, updates or adds post meta if successful. New
-     *                      metadata are saved to the post as an array of the form
-     *                      array(0 => 'url', 1 => 'text')
-     */
-    public function validate_link( $field, $post_ID ) {
-        if ( isset( $_POST["{$field['meta_key']}_url"] ) 
-         and isset( $_POST["{$field['meta_key']}_text"] ) ) {
-            $url = $_POST["{$field['meta_key']}_url"];
-            $text = $_POST["{$field['meta_key']}_text"];
-            $full_link = array( 0 => $url, 1 => $text );
-            $existing = get_post_meta( $post_ID, $field['meta_key'], $single = false );
-            
-            if ( empty( $_POST["{$field['meta_key']}_url"] ) 
-              or empty( $_POST["{$field['meta_key']}_text"] ) ) {
-                delete_post_meta( $post_ID, $field['meta_key']);
-            } elseif ( empty($existing) ) {
-                add_post_meta( $post_ID, $field['meta_key'], $url, false );
-                add_post_meta( $post_ID, $field['meta_key'], $text, false );
-            } elseif ( $existing != $full_link ) {
-                update_post_meta( $post_ID, $field['meta_key'], $url, $existing[0] );
-                update_post_meta( $post_ID, $field['meta_key'], $text, $existing[1] );
-            }
-        }
-    }
+	public function validate_fieldset( $field, &$validate, $post_ID ) {
+		foreach ( $field['fields'] as $f ) {
+			if ( isset( $field['meta_key'] ) and isset( $f['meta_key'] ) ) {
+				$f['meta_key'] = "{$field['meta_key']}_{$f['meta_key']}";
+			}
+			if ( isset( $field['slug'] ) and isset( $f['slug'] ) ) {
+				$f['slug'] = "{$field['slug']}_{$f['slug']}";
+			}
+			$this->validate( $post_ID, $f, $validate );
+		}
+	}
 
-    /**
-     * validate_select validates a <select> field
-     * 
-     * @param  arr $field   The field to validate, normally passed by looping through 
-     *                      $this->fields
-     * @param  int $post_ID The post ID to have post values saved to
-     * @return void         No return value, adds or deletes post meta if successful. New
-     *                      data are saved to the post as new values in an array or 
-     *                      deleted.
-     */
+	/**
+	 * validate_link validates a field with type = 'link'
+	 *
+	 * @param  arr $field   The field to validate, normally passed by looping through
+	 *                      $this->fields
+	 * @param  int $post_ID The post ID to have post values saved to
+	 * @return void         No return value, updates or adds post meta if successful. New
+	 *                      metadata are saved to the post as an array of the form
+	 *                      array(0 => 'url', 1 => 'text')
+	 */
+	public function validate_link( $field, $post_ID ) {
+		if ( isset( $_POST["{$field['meta_key']}_url"] )
+		 and isset( $_POST["{$field['meta_key']}_text"] ) ) {
+			$url = $_POST["{$field['meta_key']}_url"];
+			$text = $_POST["{$field['meta_key']}_text"];
+			$full_link = array( 0 => $url, 1 => $text );
+			$existing = get_post_meta( $post_ID, $field['meta_key'], $single = false );
 
-    public function validate_select( $field, $post_ID ) {
-        if ( !isset( $_POST[$field['meta_key']] ) ) {
-            delete_post_meta( $post_ID, $field['meta_key']);
-            return;
-        }
-        if ( array_key_exists($field['meta_key'], $_POST) ) {
-            $existing = get_post_meta( $post_ID, $field['meta_key'], false );
-            $data = $_POST[$field['meta_key']];
-            foreach ( (array)$data as $d ) {
-                // Adding or updating terms
-                $term = sanitize_text_field( $d );
-                $e_key = array_search($term, $existing);
-                if ( ! in_array($d, (array)$existing) ) {
-                    // if the term is not in $existing, it's a new term, add it
-                    // we use add_post_meta instead of update so we can have more
-                    // than one value on the array
-                    add_post_meta( $post_ID, $field['meta_key'], $term );
-                }
-            }
-            // delete terms if they're not in the $_POST data
-            foreach ( (array)$existing as $e ) {
-                if ( ! in_array($e, (array)$data) ) {
-                    delete_post_meta( $post_ID, $field['meta_key'], $meta_value = $e );
-                }
-            }
-        }
-    }
+			if ( empty( $_POST["{$field['meta_key']}_url"] )
+			  or empty( $_POST["{$field['meta_key']}_text"] ) ) {
+				delete_post_meta( $post_ID, $field['meta_key']);
+			} elseif ( empty($existing) ) {
+				add_post_meta( $post_ID, $field['meta_key'], $url, false );
+				add_post_meta( $post_ID, $field['meta_key'], $text, false );
+			} elseif ( $existing != $full_link ) {
+				update_post_meta( $post_ID, $field['meta_key'], $url, $existing[0] );
+				update_post_meta( $post_ID, $field['meta_key'], $text, $existing[1] );
+			}
+		}
+	}
 
-    public function validate_taxonomyselect($field, $post_ID) {
-        $field['multiple'] = isset( $field['multiple'] ) ? $field['multiple'] : false;
-        if ( isset($_POST[$field['slug']] )) {
-            $term = sanitize_text_field( $_POST[$field['slug']] );
-            $term_exists = get_term_by('id', $term, $field['taxonomy']);
-            if ( $term_exists ){
-                wp_set_object_terms(
-                    $post_ID,
-                    $term_exists->name,
-                    $field['taxonomy'],
-                    $append = $field['multiple']
-                );
-            } else {
-                wp_set_object_terms(
-                    $post_ID,
-                    $term,
-                    $field['taxonomy'],
-                    $append = $field['multiple']
-                );
-            }
-        }
-    }
+	/**
+	 * validate_select validates a <select> field
+	 *
+	 * @param  arr $field   The field to validate, normally passed by looping through
+	 *                      $this->fields
+	 * @param  int $post_ID The post ID to have post values saved to
+	 * @return void         No return value, adds or deletes post meta if successful. New
+	 *                      data are saved to the post as new values in an array or
+	 *                      deleted.
+	 */
 
-    /** 
-     * Validates a date field by converting $_POST keys into date strings before passing
-     * to a date method in $this->Callbacks->date()
-     * 
-     * @param  array $field    The field to be processed
-     * @param  [type] $post_ID The ID of the object to be manipulated
-     * @return void
-     */
+	public function validate_select( $field, $post_ID ) {
+		if ( !isset( $_POST[$field['meta_key']] ) ) {
+			delete_post_meta( $post_ID, $field['meta_key']);
+			return;
+		}
+		if ( array_key_exists($field['meta_key'], $_POST) ) {
+			$existing = get_post_meta( $post_ID, $field['meta_key'], false );
+			$data = $_POST[$field['meta_key']];
+			foreach ( (array)$data as $d ) {
+				// Adding or updating terms
+				$term = sanitize_text_field( $d );
+				$e_key = array_search($term, $existing);
+				if ( ! in_array($d, (array)$existing) ) {
+					// if the term is not in $existing, it's a new term, add it
+					// we use add_post_meta instead of update so we can have more
+					// than one value on the array
+					add_post_meta( $post_ID, $field['meta_key'], $term );
+				}
+			}
+			// delete terms if they're not in the $_POST data
+			foreach ( (array)$existing as $e ) {
+				if ( ! in_array($e, (array)$data) ) {
+					delete_post_meta( $post_ID, $field['meta_key'], $meta_value = $e );
+				}
+			}
+		}
+	}
 
-    public function validate_date($field, $post_ID) {
-        $terms = wp_get_post_terms( $post_ID, $field['taxonomy'], array( 'fields' => 'ids' ) );
-        $terms_to_remove = array();
-        $field['multiple'] = isset( $field['multiple'] ) ? $field['multiple'] : false;
-        for ( $i = 0; $i < count( $terms ); $i++ ) {
-            if ( isset( $_POST['rm_' . $field['taxonomy'] . '_' . $i ] ) ) {
-                array_push( $terms_to_remove, $i );
-            }
-        }
-        foreach ( $terms_to_remove as $t ) {
-            $this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], null, $t );
-        }
-        $year = $field['taxonomy'] . '_year';
-        $month = $field['taxonomy'] . '_month';
-        $day = $field['taxonomy'] . '_day';
-        $data = array($field['taxonomy'] => '');
-        if ( isset($_POST[$month]) ) {
-            $data[$field['taxonomy']] = $_POST[$month];
-        }
-        if ( isset( $_POST[$day] ) ) {
-            $data[$field['taxonomy']] .= ' ' . $_POST[$day];
-        }
-        if ( isset( $_POST[$year] ) ) {
-            $data[$field['taxonomy']] .= ' ' . $_POST[$year];
-        }
-        $date = DateTime::createFromFormat('F j Y', $data[$field['taxonomy']]);
-        if ( $date ) {
-            $this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $data, null );
-        }
-    }
+	public function validate_taxonomyselect($field, $post_ID) {
+		$field['multiple'] = isset( $field['multiple'] ) ? $field['multiple'] : false;
+		if ( isset($_POST[$field['slug']] )) {
+			$term = sanitize_text_field( $_POST[$field['slug']] );
+			$term_exists = get_term_by('id', $term, $field['taxonomy']);
+			if ( $term_exists ){
+				wp_set_object_terms(
+					$post_ID,
+					$term_exists->name,
+					$field['taxonomy'],
+					$append = $field['multiple']
+				);
+			} else {
+				wp_set_object_terms(
+					$post_ID,
+					$term,
+					$field['taxonomy'],
+					$append = $field['multiple']
+				);
+			}
+		}
+	}
 
-    /**
-     * Checks that data is coming through in the types we expect or ferries out form 
-     * data to the appropriate validator. Run before save to ensure you're saving
-     * correct data. Essentially this takes in $_POST and pushes all the good stuff from
-     * $_POST into a separate, cleaned array and returns the cleaned data.
-     *
-     * @param int $post_ID The post targeted for custom data
-     * 
-     * @return array A version of $_POST with cleaned data ready to be sent to a save method
-     *               like $this->save()
-     */
+	/**
+	 * Validates a date field by converting $_POST keys into date strings before passing
+	 * to a date method in $this->Callbacks->date()
+	 *
+	 * @param  array $field    The field to be processed
+	 * @param  [type] $post_ID The ID of the object to be manipulated
+	 * @return void
+	 */
 
-    public function validate( $post_ID, $field, &$validate ) {
-        if ( isset( $field['do_not_validate'] ) ) {
-            return;
-        } elseif ( ! isset( $field['type'] ) ) {
-            $error = new $this->error( 'no_type', __( 'No field type set.' ) );
-            echo $error->get_error_message('no_type');
-            return;
-        }
-        if ( isset( $field['meta_key'] ) ) {
-            $key = $field['meta_key'];
-        } elseif ( isset( $field['slug'] ) ) {
-            $key = $field['slug'];
-        } elseif ( isset( $field['taxonomy'] ) ) {
-            $key = $field['taxonomy'];
-        } else {
-            $error = new $this->error( 'no_slug', __( 'No meta_key/slug/taxonomy is set.' ) );
-            echo $error->get_error_message('no_slug');
-            return;
-        }
-        /* if this field is a formset, fieldset, taxonomy select, date, link or 
-           select field, we send it out to another validator
-        */
-        if ( $field['type'] == 'formset' ) {
-           if ( isset( $field['params'] ) ) {
-                if ( isset( $field['params']['max_num_forms'] ) ) {
-                    if ( ! is_numeric( $field['params']['max_num_forms'] ) ) {
-                        $error = new $this->error( 'formset_params_max_num',
-                                    __( "The 'max_num_forms' in params array for the"
-                                        . "formset field needs to be an integer." ) );
-                        return $error->get_error_message('formset_params_max_num');
-                    }
-                } else {
-                    $field['params']['max_num_forms'] = 1;
-                }            
-            } else {
-                $error = new $this->error( 'formset_params',
-                                    __( "There must be a params array set in the field"
-                                         . "for a formset." ) );
-                return $error->get_error_message('formset_params');
-            }
-            $this->validate_formset( $field, $validate, $post_ID );
-            return;
-        } elseif ( $field['type'] == 'fieldset' ) {
-            $this->validate_fieldset( $field, $validate, $post_ID );
-            return;
-        } elseif ( $field['type'] == 'taxonomyselect') {
-            if ( ! isset( $field['taxonomy'] ) ) {
-                $error = new $this->error( 'no_taxonomy', __( 'No taxonomy set'
-                                           . ' for field that requires it.' ) );
-                echo $error->get_error_message('no_taxonomy');
-                return;
-            }
-            $this->validate_taxonomyselect( $field, $post_ID );
-            return;
-        } elseif ( in_array( $field['type'], $this->selects ) ) {
-            if ( ! isset( $field['meta_key'] ) ) {
-                $error = new $this->error( 'no_meta_key', __( 'No meta_key is set.' ) );
-                echo $error->get_error_message('no_meta_key');
-                return;
-            }
-            $this->validate_select( $field, $post_ID );
-            return;
-        } elseif ( $field['type'] == 'date' ) {
-            if ( ! isset( $field['taxonomy'] ) ) {
-                $error = new $this->error( 'no_taxonomy', __( 'No taxonomy set'
-                                           . ' for field that requires it.' ) );
-                echo $error->get_error_message('no_taxonomy');
-                return;
-            }
-            $this->validate_date( $field, $post_ID );
-            return;
-        } elseif ( $field['type'] == 'link' ) {
-            $this->validate_link($field, $post_ID);
-            return;
-        } else {
-            /* 
-                For most field types we just need to make sure we have the data
-                we expect from the form and sanitize them before sending them to
-                save
-            */
-            if ( ! isset( $_POST[$key] ) ) {
-                return;
-            }
-            $value = $_POST[$key];
-            if ( $field['type'] == 'number' ) {
-                if ( is_numeric( $value ) ) {
-                    // if we're expecting a number, make sure we get a number
-                    $value = intval( $value ); 
-                } else {
-                    $value = null;
-                }
-            } elseif ( $field['type'] == 'url' && isset( $value ) ) {
-                // if we're expecting a url, make sure we get a url
-                $value = esc_url_raw( $value ); 
-            } elseif ( $field['type'] == 'email' ) {
-                // if we're expecting an email, make sure we get an email
-                $value = sanitize_email( $value ); 
-            } elseif ( ! empty( $value ) && ! is_array($value ) ) {
-                // make sure whatever we get for anything else is a string
-                $value = (string)$value;
-            }
-        }
-        $validate[$key] = $value;
-    }
+	public function validate_date($field, $post_ID) {
+		$terms = wp_get_post_terms( $post_ID, $field['taxonomy'], array( 'fields' => 'ids' ) );
+		$terms_to_remove = array();
+		$field['multiple'] = isset( $field['multiple'] ) ? $field['multiple'] : false;
+		for ( $i = 0; $i < count( $terms ); $i++ ) {
+			if ( isset( $_POST['rm_' . $field['taxonomy'] . '_' . $i ] ) ) {
+				array_push( $terms_to_remove, $i );
+			}
+		}
+		foreach ( $terms_to_remove as $t ) {
+			$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], null, $t );
+		}
+		$year = $field['taxonomy'] . '_year';
+		$month = $field['taxonomy'] . '_month';
+		$day = $field['taxonomy'] . '_day';
+		$data = array($field['taxonomy'] => '');
+		if ( isset($_POST[$month]) ) {
+			$data[$field['taxonomy']] = $_POST[$month];
+		}
+		if ( isset( $_POST[$day] ) ) {
+			$data[$field['taxonomy']] .= ' ' . $_POST[$day];
+		}
+		if ( isset( $_POST[$year] ) ) {
+			$data[$field['taxonomy']] .= ' ' . $_POST[$year];
+		}
+		$date = DateTime::createFromFormat('F j Y', $data[$field['taxonomy']]);
+		if ( $date ) {
+			$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $data, null );
+		}
+	}
 
-    /**
-     * Takes cleaned $_POST data and save it as custom post meta
-     * 
-     * @param  int $post_ID      The post we save data to
-     * @param  array $postvalues Cleaned version of $_POST or some other array of trusted 
-     *                           data to be saved
-     * @return nothing           Either deletes or updates post meta or returns empty
-     */
-    public function save( $post_ID, $postvalues ) {
-        // Do nothing if we're auto saving
-        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) 
-        return;
+	/**
+	 * Checks that data is coming through in the types we expect or ferries out form
+	 * data to the appropriate validator. Run before save to ensure you're saving
+	 * correct data. Essentially this takes in $_POST and pushes all the good stuff from
+	 * $_POST into a separate, cleaned array and returns the cleaned data.
+	 *
+	 * @param int $post_ID The post targeted for custom data
+	 *
+	 * @return array A version of $_POST with cleaned data ready to be sent to a save method
+	 *               like $this->save()
+	 */
 
-        if ( empty( $postvalues ) ) {
-            // if we're passed an empty array, don't do anything
-            return;
-        }
+	public function validate( $post_ID, $field, &$validate ) {
+		if ( isset( $field['do_not_validate'] ) ) {
+			return;
+		} elseif ( ! isset( $field['type'] ) ) {
+			$error = new $this->error( 'no_type', __( 'No field type set.' ) );
+			echo $error->get_error_message('no_type');
+			return;
+		}
+		if ( isset( $field['meta_key'] ) ) {
+			$key = $field['meta_key'];
+		} elseif ( isset( $field['slug'] ) ) {
+			$key = $field['slug'];
+		} elseif ( isset( $field['taxonomy'] ) ) {
+			$key = $field['taxonomy'];
+		} else {
+			$error = new $this->error( 'no_slug', __( 'No meta_key/slug/taxonomy is set.' ) );
+			echo $error->get_error_message('no_slug');
+			return;
+		}
+		/* if this field is a formset, fieldset, taxonomy select, date, link or
+		   select field, we send it out to another validator
+		*/
+		if ( $field['type'] == 'formset' ) {
+		   if ( isset( $field['params'] ) ) {
+				if ( isset( $field['params']['max_num_forms'] ) ) {
+					if ( ! is_numeric( $field['params']['max_num_forms'] ) ) {
+						$error = new $this->error( 'formset_params_max_num',
+									__( "The 'max_num_forms' in params array for the"
+										. "formset field needs to be an integer." ) );
+						return $error->get_error_message('formset_params_max_num');
+					}
+				} else {
+					$field['params']['max_num_forms'] = 1;
+				}
+			} else {
+				$error = new $this->error( 'formset_params',
+									__( "There must be a params array set in the field"
+										 . "for a formset." ) );
+				return $error->get_error_message('formset_params');
+			}
+			$this->validate_formset( $field, $validate, $post_ID );
+			return;
+		} elseif ( $field['type'] == 'fieldset' ) {
+			$this->validate_fieldset( $field, $validate, $post_ID );
+			return;
+		} elseif ( $field['type'] == 'taxonomyselect') {
+			if ( ! isset( $field['taxonomy'] ) ) {
+				$error = new $this->error( 'no_taxonomy', __( 'No taxonomy set'
+										   . ' for field that requires it.' ) );
+				echo $error->get_error_message('no_taxonomy');
+				return;
+			}
+			$this->validate_taxonomyselect( $field, $post_ID );
+			return;
+		} elseif ( in_array( $field['type'], $this->selects ) ) {
+			if ( ! isset( $field['meta_key'] ) ) {
+				$error = new $this->error( 'no_meta_key', __( 'No meta_key is set.' ) );
+				echo $error->get_error_message('no_meta_key');
+				return;
+			}
+			$this->validate_select( $field, $post_ID );
+			return;
+		} elseif ( $field['type'] == 'date' ) {
+			if ( ! isset( $field['taxonomy'] ) ) {
+				$error = new $this->error( 'no_taxonomy', __( 'No taxonomy set'
+										   . ' for field that requires it.' ) );
+				echo $error->get_error_message('no_taxonomy');
+				return;
+			}
+			$this->validate_date( $field, $post_ID );
+			return;
+		} elseif ( $field['type'] == 'link' ) {
+			$this->validate_link($field, $post_ID);
+			return;
+		} else {
+			/*
+				For most field types we just need to make sure we have the data
+				we expect from the form and sanitize them before sending them to
+				save
+			*/
+			if ( ! isset( $_POST[$key] ) ) {
+				return;
+			}
+			$value = $_POST[$key];
+			if ( $field['type'] == 'number' ) {
+				if ( is_numeric( $value ) ) {
+					// if we're expecting a number, make sure we get a number
+					$value = intval( $value );
+				} else {
+					$value = null;
+				}
+			} elseif ( $field['type'] == 'url' && isset( $value ) ) {
+				// if we're expecting a url, make sure we get a url
+				$value = esc_url_raw( $value );
+			} elseif ( $field['type'] == 'email' ) {
+				// if we're expecting an email, make sure we get an email
+				$value = sanitize_email( $value );
+			} elseif ( ! empty( $value ) && ! is_array($value ) ) {
+				// make sure whatever we get for anything else is a string
+				$value = (string)$value;
+			}
+		}
+		$validate[$key] = $value;
+	}
 
-        // save post data for any fields that sent them
-        foreach ( $postvalues as $key => $value ) {
-            $existing = get_post_meta( $post_ID, $key, $single = true );
-            if ( $value == null && isset( $existing ) ) {
-                delete_post_meta( $post_ID, $key );
-            } elseif ( isset( $value ) ) {
-                update_post_meta( $post_ID, $meta_key = $key, $meta_value = $value );
-            } else {
-                return;
-            }
-        }
-    }
-    /**
-     * Runs validate, then save on $_POST data
-     * 
-     * @param  int $post_ID The id of the object we're saving
-     * @return void
-     */
-    public function validate_and_save( $post_ID ) {
-        $validate = array();
-        if ( empty( $this->fields ) ) {
-            $error = new $this->error( 'empty_fields', __( 'Empty fields array' ) );
-            echo $error->get_error_message('empty_fields');
-            return;
-        }
-        foreach ( $this->fields as $field ) {
-            $this->validate( $post_ID, $field, $validate );
-        }
-        $this->save( $post_ID, $validate );
-    }
+	/**
+	 * Takes cleaned $_POST data and save it as custom post meta
+	 *
+	 * @param  int $post_ID      The post we save data to
+	 * @param  array $postvalues Cleaned version of $_POST or some other array of trusted
+	 *                           data to be saved
+	 * @return nothing           Either deletes or updates post meta or returns empty
+	 */
+	public function save( $post_ID, $postvalues ) {
+		// Do nothing if we're auto saving
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+		return;
+
+		if ( empty( $postvalues ) ) {
+			// if we're passed an empty array, don't do anything
+			return;
+		}
+
+		// save post data for any fields that sent them
+		foreach ( $postvalues as $key => $value ) {
+			$existing = get_post_meta( $post_ID, $key, $single = true );
+			if ( $value == null && isset( $existing ) ) {
+				delete_post_meta( $post_ID, $key );
+			} elseif ( isset( $value ) ) {
+				update_post_meta( $post_ID, $meta_key = $key, $meta_value = $value );
+			} else {
+				return;
+			}
+		}
+	}
+	/**
+	 * Runs validate, then save on $_POST data
+	 *
+	 * @param  int $post_ID The id of the object we're saving
+	 * @return void
+	 */
+	public function validate_and_save( $post_ID ) {
+		$validate = array();
+		if ( empty( $this->fields ) ) {
+			$error = new $this->error( 'empty_fields', __( 'Empty fields array' ) );
+			echo $error->get_error_message('empty_fields');
+			return;
+		}
+		foreach ( $this->fields as $field ) {
+			$this->validate( $post_ID, $field, $validate );
+		}
+		$this->save( $post_ID, $validate );
+	}
 }

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -155,7 +155,7 @@ class Models {
             if ( isset( $processed[$i]['meta_key'] ) ) {
                 $processed[$i]['meta_key'] .= '_' . $i;
             }
-            if ( isset( $processed[$i]['meta_key'] ) ) {
+            if ( isset( $processed[$i]['slug'] ) ) {
                 $processed[$i]['slug'] .= '_' . $i;
             }
             foreach ( $processed[$i]['fields'] as $f ) {

--- a/inc/meta-box-view.php
+++ b/inc/meta-box-view.php
@@ -44,9 +44,9 @@ class View {
 		$this->HTML = $HTML;
 	}
 
-    public function error_handler( $Class ) {
-        $this->error = $Class;
-    }
+	public function error_handler( $Class ) {
+		$this->error = $Class;
+	}
 
 	public function process_defaults( $fields ) {
 		$ready = array();
@@ -219,17 +219,17 @@ class View {
 		return $default;
 	}
 	public function default_formset_params( $field ) {
-        if ( isset( $field['params'] ) ) {
-        	if ( ! isset( $field['params']['init_num_forms'] ) ) {
-        		$field['params']['init_num_forms'] = 1;
-        	}
-            if ( ! isset( $field['params']['max_num_forms'] ) ) {
-            	$field['params']['max_num_forms'] = 1;
-            }
-        } else {
-            $field['params'] = array( 'init_num_forms' => 1, 'max_num_forms' => 1 );
-        }
-        return $field;
+		if ( isset( $field['params'] ) ) {
+			if ( ! isset( $field['params']['init_num_forms'] ) ) {
+				$field['params']['init_num_forms'] = 1;
+			}
+			if ( ! isset( $field['params']['max_num_forms'] ) ) {
+				$field['params']['max_num_forms'] = 1;
+			}
+		} else {
+			$field['params'] = array( 'init_num_forms' => 1, 'max_num_forms' => 1 );
+		}
+		return $field;
 	}
 
 	public function ready_and_print_html( $post, $fields ) {

--- a/tests/test-meta_box_html.php
+++ b/tests/test-meta_box_html.php
@@ -19,12 +19,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	/***************************
 	 * HTML method tests *
 	 ***************************/
-    /**
-     * Tests whether the draw method will return WP_Error if given empty field
-     *
-     * @group stable
-     * @group wp_error
-     */
+	/**
+	 * Tests whether the draw method will return WP_Error if given empty field
+	 *
+	 * @group stable
+	 * @group wp_error
+	 */
 	function testDrawWithEmptyFieldExpectsWPErrorReturned() {
 		// arrange
 		$field = array();
@@ -38,24 +38,24 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf( 'WP_Error', $error );
 	}
 	/**
-     * Tests that the draw method will call draw_formset() if given field of
-     * of type 'formset'.
-     *
-     * @group stable
-     * @group formset
-     */
+	 * Tests that the draw method will call draw_formset() if given field of
+	 * of type 'formset'.
+	 *
+	 * @group stable
+	 * @group formset
+	 */
 	function testDrawWithFieldTypeFormsetCallsDrawFormset() {
 		//arrange
-        $TestValidBox = new \TestValidBox;
-        $TestValidBox->fields['field_one']['type'] = 'formset';
-        $field = $TestValidBox->fields['field_one'];
+		$TestValidBox = new \TestValidBox;
+		$TestValidBox->fields['field_one']['type'] = 'formset';
+		$field = $TestValidBox->fields['field_one'];
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'draw_formset', ) )
 					 ->getMock();
 		$HTML->expects( $this->once() )
 			 ->method( 'draw_formset' )
 			 ->will( $this->returnValue( true ) );
-        \WP_Mock::wpFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'esc_attr' );
 
 		//act
 		$HTML->draw( $field );
@@ -64,12 +64,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when called for formset type
 	}
 	/**
-     * Tests that the draw method will call draw_input() if given fields of 
-     * input types.
-     *
-     * @group stable
-     * @group draw_input
-     */
+	 * Tests that the draw method will call draw_input() if given fields of
+	 * input types.
+	 *
+	 * @group stable
+	 * @group draw_input
+	 */
 	function testDrawWithInputFieldCallsDrawInput() {
 		//arrange
 		$fields = array(
@@ -99,12 +99,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when called for input types
 	}
 	/**
-     * Tests that the draw method will call draw_input() if given fields of 
-     * select types.
-     *
-     * @group stable
-     * @group select
-     */
+	 * Tests that the draw method will call draw_input() if given fields of
+	 * select types.
+	 *
+	 * @group stable
+	 * @group select
+	 */
 	function testDrawWithSelectFieldCallsPassSelect() {
 		//arrange
 		$fields = array(
@@ -131,24 +131,24 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when called for select types
 	}
 	/**
-     * Tests that the draw method will call hidden() if given field of
-     * of type 'hidden'.
-     *
-     * @group stable
-     * @group hidden
-     */
+	 * Tests that the draw method will call hidden() if given field of
+	 * of type 'hidden'.
+	 *
+	 * @group stable
+	 * @group hidden
+	 */
 	function testDrawWithHiddenFieldCallsHidden() {
 		//arrange
 		$TestValidBox = new TestValidBox();
-        $TestValidBox->fields['field_one']['type'] = 'hidden';
-        $field = $TestValidBox->fields['field_one'];
+		$TestValidBox->fields['field_one']['type'] = 'hidden';
+		$field = $TestValidBox->fields['field_one'];
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'hidden', ) )
 					 ->getMock();
 		$HTML->expects( $this->once() )
 			 ->method( 'hidden' )
 			 ->will( $this->returnValue( true ) );
-        \WP_Mock::wpFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'esc_attr' );
 
 		//act
 		$HTML->draw( $field );
@@ -157,23 +157,23 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when called for hidden type
 	}
 	/**
-     * Tests that the draw method will call wp_nonce_field() if given field of
-     * of type 'nonce'.
-     *
-     * @group stable
-     * @group nonce
-     */
+	 * Tests that the draw method will call wp_nonce_field() if given field of
+	 * of type 'nonce'.
+	 *
+	 * @group stable
+	 * @group nonce
+	 */
 	function testDrawWithNonceFieldCallsWPNonceField() {
 		//arrange
 		$TestValidBox = new TestValidBox();
-        $TestValidBox->fields['field_one']['type'] = 'nonce';
-        $field = $TestValidBox->fields['field_one'];
+		$TestValidBox->fields['field_one']['type'] = 'nonce';
+		$field = $TestValidBox->fields['field_one'];
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
 		\WP_Mock::wpPassthruFunction('wp_nonce_field', array( 'times' => 1, ) );
 		\WP_Mock::wpPassthruFunction('plugin_basename', array( 'times' => 1, ) );
-        \WP_Mock::wpFunction( 'esc_attr' );
+		\WP_Mock::wpFunction( 'esc_attr' );
 
 		//act
 		$HTML->draw( $field );
@@ -181,53 +181,53 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		//assert
 		// Passes when called for nonce type
 	}
-    /**
-     * Tests that the draw_formset() method will call get_the_ID().
-     *
-     * @group stable
-     * @group wp_function
-     */
-    function testDrawFormsetShouldCallGetTheID() {
-        //arrange
-        $Formset = new TestValidFormsetField();
-        $HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-                     ->setMethods( array( 'get_existing_data', 'get_formset_id', 'draw' ) )
-                     ->getMock();
-        \WP_Mock::wpFunction( 'get_the_ID', array( 'times' => 1 ) );
-        \WP_Mock::wpFunction( 'get_post_custom' );
-
-        //act
-        $HTML->draw_formset( $Formset->fields['field'] );
-
-        //assert
-        // Passes if get_the_ID() is called once.
-    }
-    /**
-     * Tests that the draw_formset() method will call get_post_custom().
-     *
-     * @group stable
-     * @group wp_function
-     */
-    function testDrawFormsetShouldCallGetPostCustom() {
-        //arrange
-        $Formset = new TestValidFormsetField();
-        $HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-                     ->setMethods( array( 'get_existing_data', 'get_formset_id', 'draw' ) )
-                     ->getMock();
-        \WP_Mock::wpFunction( 'get_the_ID' );
-        \WP_Mock::wpFunction( 'get_post_custom', array( 'times' => 1 ) );
-        
-        //act
-        $HTML->draw_formset( $Formset->fields['field'] );
-
-        //assert
-        // Passes if get_post_custom() is called once.
-    }
 	/**
-     * Tests that the draw_formset() method will call get_formset_id().
-     *
-     * @group stable
-     */
+	 * Tests that the draw_formset() method will call get_the_ID().
+	 *
+	 * @group stable
+	 * @group wp_function
+	 */
+	function testDrawFormsetShouldCallGetTheID() {
+		//arrange
+		$Formset = new TestValidFormsetField();
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'draw' ) )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_the_ID', array( 'times' => 1 ) );
+		\WP_Mock::wpFunction( 'get_post_custom' );
+
+		//act
+		$HTML->draw_formset( $Formset->fields['field'] );
+
+		//assert
+		// Passes if get_the_ID() is called once.
+	}
+	/**
+	 * Tests that the draw_formset() method will call get_post_custom().
+	 *
+	 * @group stable
+	 * @group wp_function
+	 */
+	function testDrawFormsetShouldCallGetPostCustom() {
+		//arrange
+		$Formset = new TestValidFormsetField();
+		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
+					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'draw' ) )
+					 ->getMock();
+		\WP_Mock::wpFunction( 'get_the_ID' );
+		\WP_Mock::wpFunction( 'get_post_custom', array( 'times' => 1 ) );
+
+		//act
+		$HTML->draw_formset( $Formset->fields['field'] );
+
+		//assert
+		// Passes if get_post_custom() is called once.
+	}
+	/**
+	 * Tests that the draw_formset() method will call get_formset_id().
+	 *
+	 * @group stable
+	 */
 	function testDrawFormsetShouldCallGetFormsetID() {
 		//arrange
 		$field = array(
@@ -240,8 +240,8 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$HTML->expects( $this->once() )
 			 ->method( 'get_formset_id' )
 			 ->	will( $this->returnValue( true ) );
-        \WP_Mock::wpFunction( 'get_the_ID' );
-        \WP_Mock::wpFunction( 'get_post_custom' );
+		\WP_Mock::wpFunction( 'get_the_ID' );
+		\WP_Mock::wpFunction( 'get_post_custom' );
 
 		//act
 		$HTML->draw_formset( $field );
@@ -250,10 +250,10 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes if get_formset_id() is called once.
 	}
 	/**
-     * Tests that the draw_formset() method will call get_existing_data().
-     *
-     * @group stable
-     */
+	 * Tests that the draw_formset() method will call get_existing_data().
+	 *
+	 * @group stable
+	 */
 	function testDrawFormsetShouldCallGetExistingData() {
 		//arrange
 		$field = array(
@@ -266,8 +266,8 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$HTML->expects( $this->once() )
 			 ->method( 'get_existing_data' )
 			 ->	will( $this->returnValue( true ) );
-        \WP_Mock::wpFunction( 'get_the_ID' );
-        \WP_Mock::wpFunction( 'get_post_custom' );
+		\WP_Mock::wpFunction( 'get_the_ID' );
+		\WP_Mock::wpFunction( 'get_post_custom' );
 
 		//act
 		$HTML->draw_formset( $field );
@@ -276,16 +276,16 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes if get_existing_data() is called once.
 	}
 	/**
-     * Tests that the get_formset_id() method will return expected output.
-     * 
-     * get_formset_id() works by looking for a digit surrounded by underscores
-     * and then concatenates each digit by a '-' and returns it. This is used 
-     * for the front-end "Remove" button function to remove only a specific 
-     * formset.
-     *
-     * @group stable
-     * @group formset
-     */
+	 * Tests that the get_formset_id() method will return expected output.
+	 *
+	 * get_formset_id() works by looking for a digit surrounded by underscores
+	 * and then concatenates each digit by a '-' and returns it. This is used
+	 * for the front-end "Remove" button function to remove only a specific
+	 * formset.
+	 *
+	 * @group stable
+	 * @group formset
+	 */
 	function testGetFormsetIDReturnsExpectedOutput() {
 		// arrange
 		$form_meta_key = 'test_0_3';
@@ -301,11 +301,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( $actual, $expected );
 	}
 	/**
-     * Tests that the get_existing_data() method will add existing data to an 
-     * array that is passed by reference. 
-     *
-     * @group stable
-     */
+	 * Tests that the get_existing_data() method will add existing data to an
+	 * array that is passed by reference.
+	 *
+	 * @group stable
+	 */
 	function testGetExistingDataWithNonFieldsetFieldAddsExistingDataToArray() {
 		//arrange
 		$field = array(
@@ -327,36 +327,36 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( $existing, $expected );
 	}
 	/**
-     * Tests that the pass_select() method will call select() for each select
-     * typed field given.
-     *
-     * @group stable
-     * @group select
-     */
+	 * Tests that the pass_select() method will call select() for each select
+	 * typed field given.
+	 *
+	 * @group stable
+	 * @group select
+	 */
 	function testPassSelectCallsSelectForSelectMultiselectAndTaxonomySelectTypes() {
 		//arrange
 		$selections = array(
 			array(
-                'type' => 'select',
-                'meta_key' => 'select',
-                'params' => array(),
-                'value' => '',
-                'placeholder' => '',
-            ),
-            array(
-                'type' => 'multiselect',
-                'meta_key' => 'multiselect',
-                'params' => array(),
-                'value' => '',
-                'placeholder' => '',
-            ),
-            array(
-                'type' => 'taxonomyselect',
-                'meta_key' => 'taxonomyselect',
-                'params' => array(),
-                'value' => '',
-                'placeholder' => '',
-            ),
+				'type' => 'select',
+				'meta_key' => 'select',
+				'params' => array(),
+				'value' => '',
+				'placeholder' => '',
+			),
+			array(
+				'type' => 'multiselect',
+				'meta_key' => 'multiselect',
+				'params' => array(),
+				'value' => '',
+				'placeholder' => '',
+			),
+			array(
+				'type' => 'taxonomyselect',
+				'meta_key' => 'taxonomyselect',
+				'params' => array(),
+				'value' => '',
+				'placeholder' => '',
+			),
 		);
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'select', ) )
@@ -374,12 +374,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when select() is called 3 times
 	}
 	/**
-     * Tests that the pass_select() method will call taxonomy_as_meta() if given 
-     * field of type 'tax_as_meta'.
-     *
-     * @group stable
-     * @group select
-     */
+	 * Tests that the pass_select() method will call taxonomy_as_meta() if given
+	 * field of type 'tax_as_meta'.
+	 *
+	 * @group stable
+	 * @group select
+	 */
 	function testPassSelectCallsTaxonomyAsMetaForTaxAsMetaType() {		
 		//arrange
 		$field = array( 'type' => 'tax_as_meta', 'slug' => '', 'include' => '', 'value' => '', 'placeholder' => '' );
@@ -397,27 +397,27 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when taxonomy_as_meta() is called once
 	}
 	/**
-     * Tests that the pass_select() method will call post_select() twice for 
-     * fields of types 'post_select' and 'post_multiselect'.
-     *
-     * @group stable
-     * @group select
-     */
+	 * Tests that the pass_select() method will call post_select() twice for
+	 * fields of types 'post_select' and 'post_multiselect'.
+	 *
+	 * @group stable
+	 * @group select
+	 */
 	function testPassSelectCallsSelectForPostSelectAndPostMultiselectTypes() {
 		//arrange
 		$selections = array(
 			array(
-                'type' => 'post_select',
-                'params' => '',
-                'meta_key' => '',
-                'placeholder' => ''
-            ),
-            array(
-                'type' => 'post_multiselect',
-                'params' => '',
-                'meta_key' => '',
-                'placeholder' => ''
-            ),
+				'type' => 'post_select',
+				'params' => '',
+				'meta_key' => '',
+				'placeholder' => ''
+			),
+			array(
+				'type' => 'post_multiselect',
+				'params' => '',
+				'meta_key' => '',
+				'placeholder' => ''
+			),
 		);
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'post_select', ) )
@@ -437,20 +437,20 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when select() is called 2 times
 	}
 	/**
-     * Tests that the pass_select() method will call get_posts() once
-     *  if given field of type 'post_select'.
-     *
-     * @group stable
-     * @group select
-     */
+	 * Tests that the pass_select() method will call get_posts() once
+	 *  if given field of type 'post_select'.
+	 *
+	 * @group stable
+	 * @group select
+	 */
 	function testPassSelectCallsGetPosts() {
 		//arrange
 		$field = array(
-            'type' => 'post_select',
-            'params' => '',
-            'meta_key' => '',
-            'placeholder' => ''            
-        );
+			'type' => 'post_select',
+			'params' => '',
+			'meta_key' => '',
+			'placeholder' => ''
+		);
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'post_select', ) )
 					 ->getMock();
@@ -464,20 +464,20 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when get_posts() is called once
 	}
 	/**
-     * Tests that the pass_select() method will call get_post_meta() once if 
-     * given field of type 'post_select'.
-     *
-     * @group stable
-     * @group select
-     */
+	 * Tests that the pass_select() method will call get_post_meta() once if 
+	 * given field of type 'post_select'.
+	 *
+	 * @group stable
+	 * @group select
+	 */
 	function testPassSelectCallsGetPostMeta() {
 		//arrange
-        $field = array(
-            'type' => 'post_select',
-            'params' => '',
-            'meta_key' => '',
-            'placeholder' => ''            
-        );
+		$field = array(
+			'type' => 'post_select',
+			'params' => '',
+			'meta_key' => '',
+			'placeholder' => ''
+		);
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'post_select', ) )
 					 ->getMock();
@@ -491,12 +491,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when get_posts() is called once
 	}
 	/**
-     * Tests that the draw_input() method will call text_area() if given field of
-     * of type 'text_area'.
-     *
-     * @group stable
-     * @group draw_input
-     */
+	 * Tests that the draw_input() method will call text_area() if given field of
+	 * of type 'text_area'.
+	 *
+	 * @group stable
+	 * @group draw_input
+	 */
 	function testDrawInputCallsTextAreaForTextAreaType() {
 		//arrange
 		$TestValidTextAreaField = new TestValidTextAreaField();
@@ -514,15 +514,15 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when text_area() is called once
 	}
 	/**
-     * Tests that the draw_input() method will call single_input() if given fields of
-     * of input types.
-     *
-     * @group stable
-     * @group draw_input
-     */
+	 * Tests that the draw_input() method will call single_input() if given fields of
+	 * of input types.
+	 *
+	 * @group stable
+	 * @group draw_input
+	 */
 	function testDrawInputCallsSingleInputForNumberTextEmailURLTypes() {
 		//arrange
-        $field = new TestValidTextField();
+		$field = new TestValidTextField();
 		$types = array( 'number', 'text', 'email', 'url');
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'single_input', ) )
@@ -533,7 +533,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 
 		//act
 		foreach ( $types as $type ) {
-            $field->fields['one']['type'] = $type;
+			$field->fields['one']['type'] = $type;
 			$HTML->draw_input( $field->fields['one'] );
 		}
 
@@ -541,11 +541,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when single_input() is called 4 times
 	}
 	/**
-     * Tests that the draw_input() method will call date() for field type 'date'.
-     *
-     * @group stable
-     * @group draw_input
-     */
+	 * Tests that the draw_input() method will call date() for field type 'date'.
+	 *
+	 * @group stable
+	 * @group draw_input
+	 */
 	function testDrawInputCallsDateForDateType() {
 		//arrange
 		$field = new TestValidDateField();
@@ -563,16 +563,16 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when date() is called once
 	}
 	/**
-     * Tests that the draw_input() method will call single_input() twice if 
-     * field of type 'radio'.
-     *
-     * @group stable
-     * @group draw_input
-     */
+	 * Tests that the draw_input() method will call single_input() twice if
+	 * field of type 'radio'.
+	 *
+	 * @group stable
+	 * @group draw_input
+	 */
 	function testDrawInputCallsSingleInputForRadioTypeTwice() {
 		//arrange
-        $field = new TestValidTextField();
-        $field->fields['one']['type'] = 'radio';
+		$field = new TestValidTextField();
+		$field->fields['one']['type'] = 'radio';
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'single_input', ) )
 					 ->getMock();
@@ -587,12 +587,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when single_input() is called twice
 	}
 	/**
-     * Tests that the draw_input() method will call boolean_input() if given field
-     * of type 'boolean'.
-     *
-     * @group stable
-     * @group draw_input
-     */
+	 * Tests that the draw_input() method will call boolean_input() if given field
+	 * of type 'boolean'.
+	 *
+	 * @group stable
+	 * @group draw_input
+	 */
 	function testDrawInputCallsBooleanInputForBooleanType() {
 		//arrange
 		$field = array( 'type' => 'boolean', 'meta_key' => '' );
@@ -610,12 +610,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when boolean_input() is called once
 	}
 	/**
-     * Tests that the draw_input() method will call link_input() if given field
-     * of type 'link'.
-     *
-     * @group stable
-     * @group draw_input
-     */
+	 * Tests that the draw_input() method will call link_input() if given field
+	 * of type 'link'.
+	 *
+	 * @group stable
+	 * @group draw_input
+	 */
 	function testDrawInputCallsURLInputForLinkType() {
 		//arrange
 		$field = array( 'type' => 'link', 'meta_key' => '' );
@@ -633,12 +633,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when link_input() is called once
 	}
 	/**
-     * Tests that the link_input() method will call single_input() twice if given 
-     * field of type 'single_input'.
-     *
-     * @group stable
-     * @group link_input
-     */
+	 * Tests that the link_input() method will call single_input() twice if given
+	 * field of type 'single_input'.
+	 *
+	 * @group stable
+	 * @group link_input
+	 */
 	function testURLInputCallsSingleInputTwice() {		
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -656,12 +656,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when single_input() is called only once
 	}
 	/**
-     * Tests that the select() method will call single_input() twice if given 
-     * field of type 'single_input'.
-     *
-     * @group stable
-     * @group link_input
-     */
+	 * Tests that the select() method will call single_input() twice if given
+	 * field of type 'single_input'.
+	 *
+	 * @group stable
+	 * @group link_input
+	 */
 	function testSelectWithGivenTaxonomyCallsWPGetObjectTermsAndGetTheIDAndWPDropdownCategories() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -675,16 +675,16 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$HTML->select( null, null, 'tax', null, null, null, null, null, null, null );
 	}
 	/**
-     * Tests that the date() method taxonomy will draw select.
-     *
-     * @group unstable
-     * @group date
-     */
+	 * Tests that the date() method taxonomy will draw select.
+	 *
+	 * @group unstable
+	 * @group date
+	 */
 	function testDateCallsGetMonth24Times() {
 		//arrange
 		global $wp_locale;
-        $term = new \StdClass;
-        $term->name = '';
+		$term = new \StdClass;
+		$term->name = '';
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
@@ -702,11 +702,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// passes when get month is called 24 times
 	}
 	/**
-     * Tests that the date() method will call hidden() once.
-     *
-     * @group stable
-     * @group date
-     */
+	 * Tests that the date() method will call hidden() once.
+	 *
+	 * @group stable
+	 * @group date
+	 */
 	function testDateCallsHiddenOnce() {
 		//arrange
 		global $wp_locale;
@@ -728,30 +728,30 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		//assert
 		// Fails if date doesn't call hidden() once
 	}
-    /**
-     * Tests that the wysiwyg() method will call wp_editor() once.
-     *
-     * @group stable
-     * @group wysiwyg
-     */
-    function testWYSIWYGFieldCallsWPEditor() {
-        //arrange
-        $HTML = new HTML();
-        \WP_Mock::wpFunction( 'wp_editor', array( 'times' => 1 ) );
+	/**
+	 * Tests that the wysiwyg() method will call wp_editor() once.
+	 *
+	 * @group stable
+	 * @group wysiwyg
+	 */
+	function testWYSIWYGFieldCallsWPEditor() {
+		//arrange
+		$HTML = new HTML();
+		\WP_Mock::wpFunction( 'wp_editor', array( 'times' => 1 ) );
 
-        //act
-        $HTML->wysiwyg( 'content', 'meta_key', array(), null, null);
-    }
+		//act
+		$HTML->wysiwyg( 'content', 'meta_key', array(), null, null);
+	}
 	/***************************
 	 * HTML output tests *
 	 ***************************/
 	/**
-     * Tests that the draw() method will output the a title if set and if not
-     * field type is not 'formset'.
-     *
-     * @group unstable
-     * @group draw
-     */
+	 * Tests that the draw() method will output the a title if set and if not
+	 * field type is not 'formset'.
+	 *
+	 * @group unstable
+	 * @group draw
+	 */
 	function testDrawNotFormsetWithTitleExpectsTitle() {
 		//arrange
 		$field = array(
@@ -773,11 +773,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the draw() method will not output the a title if not set.
-     *
-     * @group unstable
-     * @group draw
-     */
+	 * Tests that the draw() method will not output the a title if not set.
+	 *
+	 * @group unstable
+	 * @group draw
+	 */
 	function testDrawNotFormsetWithoutTitleExpectsNoTitle() {
 		//arrange
 		$field = array(
@@ -798,12 +798,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertNotContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the draw() method will output the a title if set and if not
-     * field type is not 'formset'.
-     *
-     * @group unstable
-     * @group draw
-     */
+	 * Tests that the draw() method will output the a title if set and if not
+	 * field type is not 'formset'.
+	 *
+	 * @group unstable
+	 * @group draw
+	 */
 	function testDrawFormsetWithTitleExpectsNoTitle() {
 		//arrange
 		$field = array(
@@ -825,11 +825,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertNotContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the draw() method will output the 'howto' if set.
-     *
-     * @group unstable
-     * @group draw
-     */
+	 * Tests that the draw() method will output the 'howto' if set.
+	 *
+	 * @group unstable
+	 * @group draw
+	 */
 	function testDrawFieldHasHowToGetsEchoed() {
 		//arrange
 		$TestValidTextField = new TestValidTextField();
@@ -848,11 +848,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the draw() method will not output the 'howto' if not set.
-     *
-     * @group unstable
-     * @group draw
-     */
+	 * Tests that the draw() method will not output the 'howto' if not set.
+	 *
+	 * @group unstable
+	 * @group draw
+	 */
 	function testDrawFieldDoesNotHaveHowToSetDoesNotGetEchoed() {
 		//arrange
 		$field = array();
@@ -871,14 +871,14 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertNotContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the draw() method will not output the 'howto' if not set.
-     *
-     * @group unstable
-     * @group draw
-     */
+	 * Tests that the draw() method will not output the 'howto' if not set.
+	 *
+	 * @group unstable
+	 * @group draw
+	 */
 	function testDrawFieldWrapsWithCMSToolkitWrapperDiv() {
 		//arrange
-        $TestValidTextField = new TestValidTextField();
+		$TestValidTextField = new TestValidTextField();
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
@@ -887,19 +887,19 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 
 		//act
 		ob_start();
-        $HTML->draw( $TestValidTextField->fields['one'] );
+		$HTML->draw( $TestValidTextField->fields['one'] );
 		$haystack = ob_get_flush();
 
 		//assert
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the draw_formset() method will output div with field meta_key
-     * as html attribute id and concatenates it with 'formset'.
-     *
-     * @group unstable
-     * @group draw_formset
-     */
+	 * Tests that the draw_formset() method will output div with field meta_key
+	 * as html attribute id and concatenates it with 'formset'.
+	 *
+	 * @group unstable
+	 * @group draw_formset
+	 */
 	function testDrawFormsetShowsNewInitialField() {
 		//arrange
 		$field = array( 
@@ -923,12 +923,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the draw_formset() method will output a hidden div because when
-     * it is not an initial field and data does not exist for it.
-     *
-     * @group unstable
-     * @group draw_formset
-     */
+	 * Tests that the draw_formset() method will output a hidden div because when
+	 * it is not an initial field and data does not exist for it.
+	 *
+	 * @group unstable
+	 * @group draw_formset
+	 */
 	function testDrawFormsetHidesNonexistentNoninitialField() {
 		//arrange
 		$field = array( 'meta_key' => 'test', 'fields' => array() );
@@ -948,12 +948,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the draw_formset() method will output a hidden div because when
-     * it is not an initial field and data does not exist for it.
-     *
-     * @group unstable
-     * @group draw_formset
-     */
+	 * Tests that the draw_formset() method will output a hidden div because when
+	 * it is not an initial field and data does not exist for it.
+	 *
+	 * @group unstable
+	 * @group draw_formset
+	 */
 	function testDrawFormsetHidesHeaderForInvisibleField() {
 		//arrange
 		$field = array(
@@ -981,11 +981,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the draw_formset() method will output a header.
-     *
-     * @group unstable
-     * @group draw_formset
-     */
+	 * Tests that the draw_formset() method will output a header.
+	 *
+	 * @group unstable
+	 * @group draw_formset
+	 */
 	function testDrawFormsetShowsHeaderForVisibleField() {
 		//arrange
 		$field = array(
@@ -1014,19 +1014,19 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the draw_formset() method will show remove link and hide add
-     * link when field has data and/or is an initial field.
-     *
-     * @group unstable
-     * @group draw_formset
-     */
+	 * Tests that the draw_formset() method will show remove link and hide add
+	 * link when field has data and/or is an initial field.
+	 *
+	 * @group unstable
+	 * @group draw_formset
+	 */
 	function testDrawFormsetShowsRemoveButtonAndHidesAddButtonForVisibleField() {
 		//arrange
 		$field = array(
 			'title' => 'Test Title',
 			'fields' => array(
 				array(
-                    'type' => 'text',
+					'type' => 'text',
 					'meta_key' => 'test_field',
 				),
 			),
@@ -1052,12 +1052,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $add_button, $haystack );
 	}	
 	/**
-     * Tests that the draw_formset() method will hide remove link and show add
-     * link when field has no data and is not an initial field.
-     *
-     * @group unstable
-     * @group draw_formset
-     */
+	 * Tests that the draw_formset() method will hide remove link and show add
+	 * link when field has no data and is not an initial field.
+	 *
+	 * @group unstable
+	 * @group draw_formset
+	 */
 	function testDrawFormsetHidesRemoveButtonAndShowsAddButtonForInvisibleField() {
 		//arrange
 		$field = array(
@@ -1090,11 +1090,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $add_button, $haystack );
 	}
 	/**
-     * Tests that the text_area() method will draw label.
-     *
-     * @group unstable
-     * @group text_area
-     */
+	 * Tests that the text_area() method will draw label.
+	 *
+	 * @group unstable
+	 * @group text_area
+	 */
 	function testTextAreaDrawsLabelForFieldMetaKey() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1112,11 +1112,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the text_area() method will draw textarea element.
-     *
-     * @group unstable
-     * @group text_area
-     */
+	 * Tests that the text_area() method will draw textarea element.
+	 *
+	 * @group unstable
+	 * @group text_area
+	 */
 	function testTextAreaDrawsTextareaElement() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1134,11 +1134,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the single_input() method will draw label.
-     *
-     * @group unstable
-     * @group single_input
-     */
+	 * Tests that the single_input() method will draw label.
+	 *
+	 * @group unstable
+	 * @group single_input
+	 */
 	function testSingleInputDrawsLabel() {		
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1156,11 +1156,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the single_input() method will draw input of given type.
-     *
-     * @group unstable
-     * @group single_input
-     */
+	 * Tests that the single_input() method will draw input of given type.
+	 *
+	 * @group unstable
+	 * @group single_input
+	 */
 	function testSingleInputDrawsGivenTypeInput() {		
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1178,11 +1178,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the boolean_input() method will draw label.
-     *
-     * @group unstable
-     * @group boolean_input
-     */
+	 * Tests that the boolean_input() method will draw label.
+	 *
+	 * @group unstable
+	 * @group boolean_input
+	 */
 	function testBooleanInputPrintsLabel() {		
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1200,11 +1200,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the boolean_input() method will draw checkbox.
-     *
-     * @group unstable
-     * @group boolean_input
-     */
+	 * Tests that the boolean_input() method will draw checkbox.
+	 *
+	 * @group unstable
+	 * @group boolean_input
+	 */
 	function testBooleanInputPrintsCheckboxInput() {		
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1222,11 +1222,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the link_input() method will draw div with class 'link-field'.
-     *
-     * @group unstable
-     * @group link_input
-     */
+	 * Tests that the link_input() method will draw div with class 'link-field'.
+	 *
+	 * @group unstable
+	 * @group link_input
+	 */
 	function testURLInputPrintsDiv() {		
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1244,11 +1244,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the hidden() method will draw hidden input field.
-     *
-     * @group unstable
-     * @group hidden
-     */
+	 * Tests that the hidden() method will draw hidden input field.
+	 *
+	 * @group unstable
+	 * @group hidden
+	 */
 	function testHiddenPrintsHiddenField() {		
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1266,11 +1266,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the select() method will draw label.
-     *
-     * @group unstable
-     * @group select
-     */
+	 * Tests that the select() method will draw label.
+	 *
+	 * @group unstable
+	 * @group select
+	 */
 	function testSelectWithoutTaxonomyPrintsLabel() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1288,12 +1288,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the select() method without taxonomy will draw select with 
-     * blank option and it selected.
-     *
-     * @group unstable
-     * @group select
-     */
+	 * Tests that the select() method without taxonomy will draw select with
+	 * blank option and it selected.
+	 *
+	 * @group unstable
+	 * @group select
+	 */
 	function testSelectWithoutTaxonomyAndWithoutOptionsPrintsSelectFieldWithOnlyBlankOption() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1312,12 +1312,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the select() method without taxonomy will draw select with 
-     * blank option selected and other options.
-     *
-     * @group unstable
-     * @group select
-     */
+	 * Tests that the select() method without taxonomy will draw select with
+	 * blank option selected and other options.
+	 *
+	 * @group unstable
+	 * @group select
+	 */
 	function testSelectWithoutTaxonomyAndWithOptionsPrintsSelectFieldWithBlankOptionSelected() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1337,12 +1337,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the select() method without taxonomy will draw select with 
-     * blank option and selected option.
-     *
-     * @group unstable
-     * @group select
-     */
+	 * Tests that the select() method without taxonomy will draw select with
+	 * blank option and selected option.
+	 *
+	 * @group unstable
+	 * @group select
+	 */
 	function testSelectWithoutTaxonomyAndWithOptionsPrintsSelectFieldWithValueSelected() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1361,11 +1361,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the post_select() method without taxonomy will draw label.
-     *
-     * @group unstable
-     * @group post_select
-     */
+	 * Tests that the post_select() method without taxonomy will draw label.
+	 *
+	 * @group unstable
+	 * @group post_select
+	 */
 	function testPostSelectPrintsLabel() {		
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1383,11 +1383,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the post_select() method without taxonomy will draw select.
-     *
-     * @group unstable
-     * @group post_select
-     */
+	 * Tests that the post_select() method without taxonomy will draw select.
+	 *
+	 * @group unstable
+	 * @group post_select
+	 */
 	function testPostSelectPrintsSelect() {		
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1405,12 +1405,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the post_select() method without taxonomy will draw blank option
-     * selected.
-     *
-     * @group unstable
-     * @group post_select
-     */
+	 * Tests that the post_select() method without taxonomy will draw blank option
+	 * selected.
+	 *
+	 * @group unstable
+	 * @group post_select
+	 */
 	function testPostSelectPrintsBlankOptionSelectedWithoutValue() {
 		//arrange
 		$posts = array();
@@ -1433,11 +1433,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the post_select() method without will draw select.
-     *
-     * @group unstable
-     * @group post_select
-     */
+	 * Tests that the post_select() method without will draw select.
+	 *
+	 * @group unstable
+	 * @group post_select
+	 */
 	function testPostSelectPrintsBlankOptionWithSelectedValue() {
 		//arrange
 		$posts = array();
@@ -1460,11 +1460,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the taxonomy_as_meta() method will draw select.
-     *
-     * @group unstable
-     * @group taxonomy_as_meta
-     */
+	 * Tests that the taxonomy_as_meta() method will draw select.
+	 *
+	 * @group unstable
+	 * @group taxonomy_as_meta
+	 */
 	function testTaxonomyAsMetaPrintsSelect() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1482,12 +1482,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the taxonomy_as_meta() method will draw blank option
-     * selected when no value given.
-     *
-     * @group unstable
-     * @group taxonomy_as_meta
-     */
+	 * Tests that the taxonomy_as_meta() method will draw blank option
+	 * selected when no value given.
+	 *
+	 * @group unstable
+	 * @group taxonomy_as_meta
+	 */
 	function testTaxonomyAsMetaPrintsBlankOptionSelectedWithoutValue() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1511,12 +1511,12 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the taxonomy_as_meta() method will draw option with
-     * blank option and value option selected.
-     *
-     * @group unstable
-     * @group taxonomy_as_meta
-     */
+	 * Tests that the taxonomy_as_meta() method will draw option with
+	 * blank option and value option selected.
+	 *
+	 * @group unstable
+	 * @group taxonomy_as_meta
+	 */
 	function testTaxonomyAsMetaPrintsBlankOptionWithValueSelected() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1540,17 +1540,17 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the date() method will draw select with blank option
-     * selected.
-     *
-     * @group unstable
-     * @group date
-     */
+	 * Tests that the date() method will draw select with blank option
+	 * selected.
+	 *
+	 * @group unstable
+	 * @group date
+	 */
 	function testDatePrintSelectElementWithGenericOptionSelected() {
 		//arrange
 		global $wp_locale;
-        $term = new \StdClass;
-        $term->name = '';
+		$term = new \StdClass;
+		$term->name = '';
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
@@ -1572,16 +1572,16 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the date() method will draw 24 options
-     *
-     * @group unstable
-     * @group date
-     */
+	 * Tests that the date() method will draw 24 options
+	 *
+	 * @group unstable
+	 * @group date
+	 */
 	function testDatePrintsAll12Months() {
 		//arrange
 		global $wp_locale;
-        $term = new \StdClass;
-        $term->name = '';
+		$term = new \StdClass;
+		$term->name = '';
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
@@ -1607,16 +1607,16 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the date() method will draw 24 options
-     *
-     * @group unstable
-     * @group date
-     */
+	 * Tests that the date() method will draw 24 options
+	 *
+	 * @group unstable
+	 * @group date
+	 */
 	function testDatePrintsInputsForDayAndYear() {
 		//arrange
 		global $wp_locale;
-        $term = new \StdClass;
-        $term->name = '';
+		$term = new \StdClass;
+		$term->name = '';
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
@@ -1635,16 +1635,16 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the date() method will print unique message for single date
-     *
-     * @group unstable
-     * @group date
-     */
+	 * Tests that the date() method will print unique message for single date
+	 *
+	 * @group unstable
+	 * @group date
+	 */
 	function testDatePrintsOutputMessageForSingleDate() {
 		//arrange
 		global $wp_locale;
-        $term = new \StdClass;
-        $term->name = '';
+		$term = new \StdClass;
+		$term->name = '';
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
@@ -1662,11 +1662,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the date() method will draw date tag when stored as numeric.
-     *
-     * @group unstable
-     * @group date
-     */
+	 * Tests that the date() method will draw date tag when stored as numeric.
+	 *
+	 * @group unstable
+	 * @group date
+	 */
 	function testDatePrintsDateWhenStoredAsNumeric() {
 		//arrange
 		global $wp_locale;
@@ -1689,11 +1689,11 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-     * Tests that the date() method will draw date tag when stored as a string.
-     *
-     * @group unstable
-     * @group date
-     */
+	 * Tests that the date() method will draw date tag when stored as a string.
+	 *
+	 * @group unstable
+	 * @group date
+	 */
 	function testDatePrintsDateWhenStoredAsString() {
 		//arrange
 		global $wp_locale;

--- a/tests/test-meta_box_models.php
+++ b/tests/test-meta_box_models.php
@@ -19,6 +19,7 @@ class TestValidBox extends Models {
             'placeholder' => 'Enter text',
             'howto' => 'Type some text',
             'meta_key' => 'field_one',
+            'value' => '',
         ),
         'field_two' => array(
             'slug' => 'field_two',
@@ -28,6 +29,7 @@ class TestValidBox extends Models {
             'placeholder' => '0-100',
             'howto' => 'Type a number',
             'meta_key' => 'field_two',
+            'value' => '',
         ),
     );
 }
@@ -75,6 +77,8 @@ class TestValidTextAreaField extends Models {
             'label' => 'Text Label',
             'type' => 'text_area',
             'params' => array('max_length' => 255),
+            'rows' => 5,
+            'cols' => 5,
             'placeholder' => 'Type some text',
             'howto' => 'Up to 255 characters',
             'meta_key' => 'one',
@@ -185,6 +189,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
      */
     function testEmptyFieldsArrayExpectsError() {
         // arrange
+        global $post;
         $TestValidTextField = new TestValidTextField();
         $TestValidTextField->fields = array();
         $stub = $this->getMockBuilder( '\WP_Error' )
@@ -214,6 +219,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
      */
     function testFieldTypeIsNotSetExpectsError() {
         // arrange
+        global $post;
         $TestValidTextField = new TestValidTextField();
         $TestValidTextField->fields['one']['type'] = null;
         $stub = $this->getMockBuilder( '\WP_Error' )
@@ -243,6 +249,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
      */
     function testFieldMetakeySlugTaxonomyIsNotSetExpectsError() {
         // arrange
+        global $post;
         $TestValidTextField = new TestValidTextField();
         $TestValidTextField->fields['one']['meta_key'] = null;
         $TestValidTextField->fields['one']['slug'] = null;
@@ -274,6 +281,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
      */
     function testFieldTypeTaxonomyselectWhereTaxonomyIsNotSetExpectsError() {
         // arrange
+        global $post;
         $TestValidTextField = new TestValidTextField();
         $TestValidTextField->fields['one']['taxonomy'] = null;
         $TestValidTextField->fields['one']['type'] = 'taxonomyselect';
@@ -304,6 +312,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
      */
     function testFieldTypeDateWhereTaxonomyIsNotSetExpectsError() {
         // arrange
+        global $post;
         $TestValidTextField = new TestValidTextField();
         $TestValidTextField->fields['one']['taxonomy'] = null;
         $TestValidTextField->fields['one']['type'] = 'date';
@@ -334,6 +343,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
      */
     function testFieldTypeOfSelectsArrayWhereMetakeyIsNotSetExpectsError() {
         // arrange
+        global $post;
         $TestValidTextField = new TestValidTextField();
         $TestValidTextField->fields['one']['meta_key'] = null;
         $TestValidTextField->fields['one']['type'] = 'select';
@@ -363,6 +373,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
      */
     function testFieldTypeFormsetWhereParamsArrayIsNotSetExpectsError() {
         // arrange
+        global $post;
         $TestValidTextField = new TestValidFormsetField();
         $TestValidTextField->fields['field']['params'] = null;
         $stub = $this->getMockBuilder( '\WP_Error' )
@@ -391,6 +402,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
      */
     function testFieldTypeFormsetWhereMaxNumFormsInParamsArrayIsNotSetExpectsError() {
         // arrange
+        global $post;
         $TestValidTextField = new TestValidFormsetField();
         $TestValidTextField->fields['field']['params']['max_num_forms'] = null;
         $stub = $this->getMockBuilder( '\WP_Error' )
@@ -642,7 +654,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
         $TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
 
         // assert
-        $this->assertTrue( is_null($actual['one']) );
+        $this->assertTrue( ! isset( $actual['one'] ) );
     }
 
     /**

--- a/tests/test-meta_box_models.php
+++ b/tests/test-meta_box_models.php
@@ -3,1706 +3,1705 @@ use CFPB\Utils\MetaBox\Models;
 use CFPB\Utils\MetaBox\Callbacks;
 
 class TestValidBox extends Models {
-    public $title = 'Meta Box';
-    public $slug = 'meta_box';
-    public $post_type = 'post';
-    public $context = 'side';
-    public $priority = 'default';
-    public $fields = array(
-        'field_one' => array(
-            'title' => 'This is a field',
-            'slug' => 'field_one',
-            'type' => 'text_area',
-            'params' => array(
-                'cols' => 27,
-            ),
-            'placeholder' => 'Enter text',
-            'howto' => 'Type some text',
-            'meta_key' => 'field_one',
-            'value' => '',
-        ),
-        'field_two' => array(
-            'slug' => 'field_two',
-            'title' => 'This is another field',
-            'type' => 'number',
-            'params' => array(),
-            'placeholder' => '0-100',
-            'howto' => 'Type a number',
-            'meta_key' => 'field_two',
-            'value' => '',
-        ),
-    );
+	public $title = 'Meta Box';
+	public $slug = 'meta_box';
+	public $post_type = 'post';
+	public $context = 'side';
+	public $priority = 'default';
+	public $fields = array(
+		'field_one' => array(
+			'title' => 'This is a field',
+			'slug' => 'field_one',
+			'type' => 'text_area',
+			'params' => array(
+				'cols' => 27,
+			),
+			'placeholder' => 'Enter text',
+			'howto' => 'Type some text',
+			'meta_key' => 'field_one',
+			'value' => '',
+		),
+		'field_two' => array(
+			'slug' => 'field_two',
+			'title' => 'This is another field',
+			'type' => 'number',
+			'params' => array(),
+			'placeholder' => '0-100',
+			'howto' => 'Type a number',
+			'meta_key' => 'field_two',
+			'value' => '',
+		),
+	);
 }
 
 class TestNumberField extends Models {
-    public $title = 'Meta Box';
-    public $slug = 'meta_box';
-    public $post_type = 'post';
-    public $context = 'side';
-    public $fields = array(
-        'field_one' => array(
-            'slug' => 'field_one',
-            'title' => 'This is another field',
-            'type' => 'number',
-            'params' => array(),
-            'placeholder' => '0-100',
-            'howto' => 'Type a number',
-            'meta_key' => 'field_one',
-        ),
-    );
+	public $title = 'Meta Box';
+	public $slug = 'meta_box';
+	public $post_type = 'post';
+	public $context = 'side';
+	public $fields = array(
+		'field_one' => array(
+			'slug' => 'field_one',
+			'title' => 'This is another field',
+			'type' => 'number',
+			'params' => array(),
+			'placeholder' => '0-100',
+			'howto' => 'Type a number',
+			'meta_key' => 'field_one',
+		),
+	);
 }
 
 class TestValidTextField extends Models {
-    public $post_type = 'post';
-    public $fields = array(
-        'one' => array(
-            'title' => 'Text Field',
-            'slug' => 'one',
-            'label' => 'Text Label',
-            'type' => 'text',
-            'params' => array('max_length' => 255),
-            'placeholder' => 'Type some text',
-            'howto' => 'Up to 255 characters',
-            'meta_key' => 'one',
-        ),
-    );
+	public $post_type = 'post';
+	public $fields = array(
+		'one' => array(
+			'title' => 'Text Field',
+			'slug' => 'one',
+			'label' => 'Text Label',
+			'type' => 'text',
+			'params' => array('max_length' => 255),
+			'placeholder' => 'Type some text',
+			'howto' => 'Up to 255 characters',
+			'meta_key' => 'one',
+		),
+	);
 }
 
 class TestValidTextAreaField extends Models {
-    public $post_type = 'post';
-    public $fields = array(
-        'one' => array(
-            'title' => 'Text Area Field',
-            'slug' => 'one',
-            'label' => 'Text Label',
-            'type' => 'text_area',
-            'params' => array('max_length' => 255),
-            'rows' => 5,
-            'cols' => 5,
-            'placeholder' => 'Type some text',
-            'howto' => 'Up to 255 characters',
-            'meta_key' => 'one',
-        ),
-    );
+	public $post_type = 'post';
+	public $fields = array(
+		'one' => array(
+			'title' => 'Text Area Field',
+			'slug' => 'one',
+			'label' => 'Text Label',
+			'type' => 'text_area',
+			'params' => array('max_length' => 255),
+			'rows' => 5,
+			'cols' => 5,
+			'placeholder' => 'Type some text',
+			'howto' => 'Up to 255 characters',
+			'meta_key' => 'one',
+		),
+	);
 }
 
 class TestValidEmailField extends Models {
-    public $post_type = 'post';
-    public $fields = array(
-        'one' => array(
-            'title' => 'Email Field',
-            'slug' => 'one',
-            'label' => 'Email Label',
-            'type' => 'email',
-            'params' => array(),
-            'placeholder' => 'Type some text',
-            'howto' => 'Up to 255 characters',
-            'meta_key' => 'one',
-        ),
-    );
+	public $post_type = 'post';
+	public $fields = array(
+		'one' => array(
+			'title' => 'Email Field',
+			'slug' => 'one',
+			'label' => 'Email Label',
+			'type' => 'email',
+			'params' => array(),
+			'placeholder' => 'Type some text',
+			'howto' => 'Up to 255 characters',
+			'meta_key' => 'one',
+		),
+	);
 }
 
 class TestValidDateField extends Models {
-    public $post_type = 'post';
-    public $fields = array(
-        'category' => array(
-            'title' => 'Issued date:',
-            'slug' => 'category',
-            'label' => '',
-            'type' => 'date',
-            'params' => array(),
-            'multiple' => false,
-            'placeholder' => '',
-            'howto' => '',
-            'taxonomy' => 'category',
-        ),
-    );
+	public $post_type = 'post';
+	public $fields = array(
+		'category' => array(
+			'title' => 'Issued date:',
+			'slug' => 'category',
+			'label' => '',
+			'type' => 'date',
+			'params' => array(),
+			'multiple' => false,
+			'placeholder' => '',
+			'howto' => '',
+			'taxonomy' => 'category',
+		),
+	);
 }
 
 class TestValidFieldsetField extends Models {
-    public $post_type = 'post';
-    public $fields = array(
-        'field' => array(
-            'type' => 'fieldset',
-            'fields' => array(
-                array(
-                    'type' => 'text',
-                    'meta_key' => 'num',
-                ),
-                array(
-                    'type' => 'text',
-                    'meta_key' => 'desc',
-                ),
-            ),
-            'params' => array(),
-            'meta_key' => 'field',
-        ),
-    );
+	public $post_type = 'post';
+	public $fields = array(
+		'field' => array(
+			'type' => 'fieldset',
+			'fields' => array(
+				array(
+					'type' => 'text',
+					'meta_key' => 'num',
+				),
+				array(
+					'type' => 'text',
+					'meta_key' => 'desc',
+				),
+			),
+			'params' => array(),
+			'meta_key' => 'field',
+		),
+	);
 }
 
 class TestValidFormsetField extends Models {
-    public $post_type = 'post';
-    public $fields = array(
-        'field' => array(
-            'type' => 'formset',
-            'fields' => array(
-                array(
-                    'title' => 'Title',
-                    'type' => 'text',
-                    'meta_key' => 'title',
-                ),
-            ),
-            'params' => array(
-                'init_num_forms' => 1,
-                'max_num_forms' => 2,
-            ),
-            'meta_key' => 'field',
-        ),
-    );
+	public $post_type = 'post';
+	public $fields = array(
+		'field' => array(
+			'type' => 'formset',
+			'fields' => array(
+				array(
+					'title' => 'Title',
+					'type' => 'text',
+					'meta_key' => 'title',
+				),
+			),
+			'params' => array(
+				'init_num_forms' => 1,
+				'max_num_forms' => 2,
+			),
+			'meta_key' => 'field',
+		),
+	);
 }
 
 class ValidationTest extends PHPUnit_Framework_TestCase {
-    function setUp() {
-        global $post;
-        $post = new \StdClass;
-        $post->ID = 1;
-        $post->post_type = 'post';
-        \WP_Mock::setUp();
-    }
+	function setUp() {
+		global $post;
+		$post = new \StdClass;
+		$post->ID = 1;
+		$post->post_type = 'post';
+		\WP_Mock::setUp();
+	}
 
-    function tearDown() {
-        \WP_Mock::tearDown();
-    }
+	function tearDown() {
+		\WP_Mock::tearDown();
+	}
 
 /***************************
  * Error handling tests *
  ***************************/
-    /**
-     * Tests whether the validate_and_save method will throw an error if there
-     * is an empty fields array.
-     *
-     *
-     * @group stable
-     * @group empty_data
-     * @group isolated
-     * @group validation
-     */
-    function testEmptyFieldsArrayExpectsError() {
-        // arrange
-        global $post;
-        $TestValidTextField = new TestValidTextField();
-        $TestValidTextField->fields = array();
-        $stub = $this->getMockBuilder( '\WP_Error' )
-                     ->setMethods( array('get_error_message') )
-                     ->getMock();
-        $TestValidTextField->error_handler($stub);
-        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-        $TestValidTextField->error->expects( $this->once() )
-             ->method( 'get_error_message' )
-             ->will( $this->returnValue( true ) );
+	/**
+	 * Tests whether the validate_and_save method will throw an error if there
+	 * is an empty fields array.
+	 *
+	 *
+	 * @group stable
+	 * @group empty_data
+	 * @group isolated
+	 * @group validation
+	 */
+	function testEmptyFieldsArrayExpectsError() {
+		// arrange
+		global $post;
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields = array();
+		$stub = $this->getMockBuilder( '\WP_Error' )
+					 ->setMethods( array('get_error_message') )
+					 ->getMock();
+		$TestValidTextField->error_handler($stub);
+		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+		$TestValidTextField->error->expects( $this->once() )
+			 ->method( 'get_error_message' )
+			 ->will( $this->returnValue( true ) );
 
-        // act
-        $TestValidTextField->validate_and_save( $post->ID );
-        
-        // assert
-        // Passes when error is called
-    }
-    /**
-     * Tests if the validate method will throw an error if there
-     * is the type of the field is not set.
-     *
-     *
-     * @group stable
-     * @group empty_data
-     * @group isolated
-     * @group validation
-     */
-    function testFieldTypeIsNotSetExpectsError() {
-        // arrange
-        global $post;
-        $TestValidTextField = new TestValidTextField();
-        $TestValidTextField->fields['one']['type'] = null;
-        $stub = $this->getMockBuilder( '\WP_Error' )
-                     ->setMethods( array('get_error_message') )
-                     ->getMock();
-        $TestValidTextField->error_handler($stub);
-        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-        $TestValidTextField->error->expects( $this->once() )
-             ->method( 'get_error_message' )
-             ->will( $this->returnValue( true ) );
+		// act
+		$TestValidTextField->validate_and_save( $post->ID );
 
-        // act
-        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
-        
-        // assert
-        // Passes when error is called
-    }
-    /**
-     * Tests if the validate method will throw an error if the field does not have
-     * the meta_key, slug, or taxonomy set.
-     *
-     *
-     * @group stable
-     * @group empty_data
-     * @group isolated
-     * @group validation
-     */
-    function testFieldMetakeySlugTaxonomyIsNotSetExpectsError() {
-        // arrange
-        global $post;
-        $TestValidTextField = new TestValidTextField();
-        $TestValidTextField->fields['one']['meta_key'] = null;
-        $TestValidTextField->fields['one']['slug'] = null;
-        $TestValidTextField->fields['one']['taxonomy'] = null;
-        $stub = $this->getMockBuilder( '\WP_Error' )
-                     ->setMethods( array('get_error_message') )
-                     ->getMock();
-        $TestValidTextField->error_handler($stub);
-        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-        $TestValidTextField->error->expects( $this->once() )
-             ->method( 'get_error_message' )
-             ->will( $this->returnValue( true ) );
+		// assert
+		// Passes when error is called
+	}
+	/**
+	 * Tests if the validate method will throw an error if there
+	 * is the type of the field is not set.
+	 *
+	 *
+	 * @group stable
+	 * @group empty_data
+	 * @group isolated
+	 * @group validation
+	 */
+	function testFieldTypeIsNotSetExpectsError() {
+		// arrange
+		global $post;
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields['one']['type'] = null;
+		$stub = $this->getMockBuilder( '\WP_Error' )
+					 ->setMethods( array('get_error_message') )
+					 ->getMock();
+		$TestValidTextField->error_handler($stub);
+		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+		$TestValidTextField->error->expects( $this->once() )
+			 ->method( 'get_error_message' )
+			 ->will( $this->returnValue( true ) );
 
-        // act
-        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
-        
-        // assert
-        // Passes when error is called
-    }
-    /**
-     * Tests if the validate method will throw an error if the field does not have
-     * the taxonomy set when required for taxonomyselect field.
-     *
-     *
-     * @group stable
-     * @group empty_data
-     * @group isolated
-     * @group validation
-     */
-    function testFieldTypeTaxonomyselectWhereTaxonomyIsNotSetExpectsError() {
-        // arrange
-        global $post;
-        $TestValidTextField = new TestValidTextField();
-        $TestValidTextField->fields['one']['taxonomy'] = null;
-        $TestValidTextField->fields['one']['type'] = 'taxonomyselect';
-        $stub = $this->getMockBuilder( '\WP_Error' )
-                     ->setMethods( array('get_error_message') )
-                     ->getMock();
-        $TestValidTextField->error_handler($stub);
-        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-        $TestValidTextField->error->expects( $this->once() )
-             ->method( 'get_error_message' )
-             ->will( $this->returnValue( true ) );
+		// act
+		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
 
-        // act
-        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
-        
-        // assert
-        // Passes when error is called
-    }
-    /**
-     * Tests if the validate method will throw an error if the field does not have
-     * the taxonomy set when required for date field.
-     *
-     *
-     * @group stable
-     * @group empty_data
-     * @group isolated
-     * @group validation
-     */
-    function testFieldTypeDateWhereTaxonomyIsNotSetExpectsError() {
-        // arrange
-        global $post;
-        $TestValidTextField = new TestValidTextField();
-        $TestValidTextField->fields['one']['taxonomy'] = null;
-        $TestValidTextField->fields['one']['type'] = 'date';
-        $stub = $this->getMockBuilder( '\WP_Error' )
-                     ->setMethods( array('get_error_message') )
-                     ->getMock();
-        $TestValidTextField->error_handler($stub);
-        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-        $TestValidTextField->error->expects( $this->once() )
-             ->method( 'get_error_message' )
-             ->will( $this->returnValue( true ) );
+		// assert
+		// Passes when error is called
+	}
+	/**
+	 * Tests if the validate method will throw an error if the field does not have
+	 * the meta_key, slug, or taxonomy set.
+	 *
+	 *
+	 * @group stable
+	 * @group empty_data
+	 * @group isolated
+	 * @group validation
+	 */
+	function testFieldMetakeySlugTaxonomyIsNotSetExpectsError() {
+		// arrange
+		global $post;
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields['one']['meta_key'] = null;
+		$TestValidTextField->fields['one']['slug'] = null;
+		$TestValidTextField->fields['one']['taxonomy'] = null;
+		$stub = $this->getMockBuilder( '\WP_Error' )
+					 ->setMethods( array('get_error_message') )
+					 ->getMock();
+		$TestValidTextField->error_handler($stub);
+		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+		$TestValidTextField->error->expects( $this->once() )
+			 ->method( 'get_error_message' )
+			 ->will( $this->returnValue( true ) );
 
-        // act
-        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
-        
-        // assert
-        // Passes when error is called
-    }
-    /**
-     * Tests if the validate method will throw an error if the field does not have
-     * the meta_key set when required for select field(s). This will only test 
-     * one of the fields of the selects array.
-     *
-     * @group stable
-     * @group empty_data
-     * @group isolated
-     * @group validation
-     */
-    function testFieldTypeOfSelectsArrayWhereMetakeyIsNotSetExpectsError() {
-        // arrange
-        global $post;
-        $TestValidTextField = new TestValidTextField();
-        $TestValidTextField->fields['one']['meta_key'] = null;
-        $TestValidTextField->fields['one']['type'] = 'select';
-        $stub = $this->getMockBuilder( '\WP_Error' )
-                     ->setMethods( array('get_error_message') )
-                     ->getMock();
-        $TestValidTextField->error_handler($stub);
-        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-        $TestValidTextField->error->expects( $this->once() )
-             ->method( 'get_error_message' )
-             ->will( $this->returnValue( true ) );
+		// act
+		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
 
-        // act
-        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
-        
-        // assert
-        // Passes when error is called
-    }
-    /**
-     * Tests if the validate method will throw an error if the field of formset
-     * type does not have a params array set.
-     *
-     * @group stable
-     * @group empty_data
-     * @group isolated
-     * @group validation
-     */
-    function testFieldTypeFormsetWhereParamsArrayIsNotSetExpectsError() {
-        // arrange
-        global $post;
-        $TestValidTextField = new TestValidFormsetField();
-        $TestValidTextField->fields['field']['params'] = null;
-        $stub = $this->getMockBuilder( '\WP_Error' )
-                     ->setMethods( array('get_error_message') )
-                     ->getMock();
-        $TestValidTextField->error_handler($stub);
-        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-        $TestValidTextField->error->expects( $this->once() )
-             ->method( 'get_error_message' )
-             ->will( $this->returnValue( true ) );
+		// assert
+		// Passes when error is called
+	}
+	/**
+	 * Tests if the validate method will throw an error if the field does not have
+	 * the taxonomy set when required for taxonomyselect field.
+	 *
+	 *
+	 * @group stable
+	 * @group empty_data
+	 * @group isolated
+	 * @group validation
+	 */
+	function testFieldTypeTaxonomyselectWhereTaxonomyIsNotSetExpectsError() {
+		// arrange
+		global $post;
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields['one']['taxonomy'] = null;
+		$TestValidTextField->fields['one']['type'] = 'taxonomyselect';
+		$stub = $this->getMockBuilder( '\WP_Error' )
+					 ->setMethods( array('get_error_message') )
+					 ->getMock();
+		$TestValidTextField->error_handler($stub);
+		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+		$TestValidTextField->error->expects( $this->once() )
+			 ->method( 'get_error_message' )
+			 ->will( $this->returnValue( true ) );
 
-        // act
-        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['field'] ), $actual );
-        
-        // assert
-        // Passes when error is called
-    }
-    /**
-     * Tests if the validate method will throw an error if the field of formset
-     * type does not have a max_num_forms set in the params array.
-     *
-     * @group stable
-     * @group empty_data
-     * @group isolated
-     * @group validation
-     */
-    function testFieldTypeFormsetWhereMaxNumFormsInParamsArrayIsNotSetExpectsError() {
-        // arrange
-        global $post;
-        $TestValidTextField = new TestValidFormsetField();
-        $TestValidTextField->fields['field']['params']['max_num_forms'] = null;
-        $stub = $this->getMockBuilder( '\WP_Error' )
-                     ->setMethods( array('get_error_message') )
-                     ->getMock();
-        $TestValidTextField->error_handler($stub);
-        $TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-        $TestValidTextField->error->expects( $this->once() )
-             ->method( 'get_error_message' )
-             ->will( $this->returnValue( true ) );
+		// act
+		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
 
-        // act
-        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['field'] ), $actual );
-        
-        // assert
-        // Passes when error is called
-    }
+		// assert
+		// Passes when error is called
+	}
+	/**
+	 * Tests if the validate method will throw an error if the field does not have
+	 * the taxonomy set when required for date field.
+	 *
+	 *
+	 * @group stable
+	 * @group empty_data
+	 * @group isolated
+	 * @group validation
+	 */
+	function testFieldTypeDateWhereTaxonomyIsNotSetExpectsError() {
+		// arrange
+		global $post;
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields['one']['taxonomy'] = null;
+		$TestValidTextField->fields['one']['type'] = 'date';
+		$stub = $this->getMockBuilder( '\WP_Error' )
+					 ->setMethods( array('get_error_message') )
+					 ->getMock();
+		$TestValidTextField->error_handler($stub);
+		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+		$TestValidTextField->error->expects( $this->once() )
+			 ->method( 'get_error_message' )
+			 ->will( $this->returnValue( true ) );
+
+		// act
+		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
+
+		// assert
+		// Passes when error is called
+	}
+	/**
+	 * Tests if the validate method will throw an error if the field does not have
+	 * the meta_key set when required for select field(s). This will only test
+	 * one of the fields of the selects array.
+	 *
+	 * @group stable
+	 * @group empty_data
+	 * @group isolated
+	 * @group validation
+	 */
+	function testFieldTypeOfSelectsArrayWhereMetakeyIsNotSetExpectsError() {
+		// arrange
+		global $post;
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields['one']['meta_key'] = null;
+		$TestValidTextField->fields['one']['type'] = 'select';
+		$stub = $this->getMockBuilder( '\WP_Error' )
+					 ->setMethods( array('get_error_message') )
+					 ->getMock();
+		$TestValidTextField->error_handler($stub);
+		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+		$TestValidTextField->error->expects( $this->once() )
+			 ->method( 'get_error_message' )
+			 ->will( $this->returnValue( true ) );
+
+		// act
+		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
+
+		// assert
+		// Passes when error is called
+	}
+	/**
+	 * Tests if the validate method will throw an error if the field of formset
+	 * type does not have a params array set.
+	 *
+	 * @group stable
+	 * @group empty_data
+	 * @group isolated
+	 * @group validation
+	 */
+	function testFieldTypeFormsetWhereParamsArrayIsNotSetExpectsError() {
+		// arrange
+		global $post;
+		$TestValidTextField = new TestValidFormsetField();
+		$TestValidTextField->fields['field']['params'] = null;
+		$stub = $this->getMockBuilder( '\WP_Error' )
+					 ->setMethods( array('get_error_message') )
+					 ->getMock();
+		$TestValidTextField->error_handler($stub);
+		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+		$TestValidTextField->error->expects( $this->once() )
+			 ->method( 'get_error_message' )
+			 ->will( $this->returnValue( true ) );
+
+		// act
+		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['field'] ), $actual );
+
+		// assert
+		// Passes when error is called
+	}
+	/**
+	 * Tests if the validate method will throw an error if the field of formset
+	 * type does not have a max_num_forms set in the params array.
+	 *
+	 * @group stable
+	 * @group empty_data
+	 * @group isolated
+	 * @group validation
+	 */
+	function testFieldTypeFormsetWhereMaxNumFormsInParamsArrayIsNotSetExpectsError() {
+		// arrange
+		global $post;
+		$TestValidTextField = new TestValidFormsetField();
+		$TestValidTextField->fields['field']['params']['max_num_forms'] = null;
+		$stub = $this->getMockBuilder( '\WP_Error' )
+					 ->setMethods( array('get_error_message') )
+					 ->getMock();
+		$TestValidTextField->error_handler($stub);
+		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
+		$TestValidTextField->error->expects( $this->once() )
+			 ->method( 'get_error_message' )
+			 ->will( $this->returnValue( true ) );
+
+		// act
+		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['field'] ), $actual );
+
+		// assert
+		// Passes when error is called
+	}
 /***************************
  * Validation method tests *
  ***************************/
-    /**
-     * Tests whether the validate method will save a null value to the array if
-     * data from $_POST is missing
-     *
-     * If a form is submitted with a field deleted, no key for that field is 
-     * assigned in the $_POST superglobal. This is fine if the field is already 
-     * empty but if the field is pre-populated it can make getting rid of the 
-     * data impossible. This passes the key with a null value to make the data
-     * more reliable for `save`.
-     *
-     * @group stable
-     * @group empty_data
-     * @group isolated
-     * @group validation
-     */
-    function testEmptyPOSTExpectsNullArrayForFieldKey() {
-        // arrange
-        $_POST = array();
-        global $post;
-        $TestValidTextField = new TestValidTextField();
-        $actual = array();
-        // act
-        $TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields ), $actual );
-        // assert
-        $this->assertTrue( empty( $actual ) );
-    }
-    /**
-     * Tests whether the validate method when called on an email field calls
-     * 'sanitize_email' from the WP API once
-     *
-     * @group stable
-     * @group isolated
-     * @group user_input
-     * @group validation
-     */
+	/**
+	 * Tests whether the validate method will save a null value to the array if
+	 * data from $_POST is missing
+	 *
+	 * If a form is submitted with a field deleted, no key for that field is
+	 * assigned in the $_POST superglobal. This is fine if the field is already
+	 * empty but if the field is pre-populated it can make getting rid of the
+	 * data impossible. This passes the key with a null value to make the data
+	 * more reliable for `save`.
+	 *
+	 * @group stable
+	 * @group empty_data
+	 * @group isolated
+	 * @group validation
+	 */
+	function testEmptyPOSTExpectsNullArrayForFieldKey() {
+		// arrange
+		$_POST = array();
+		global $post;
+		$TestValidTextField = new TestValidTextField();
+		$actual = array();
+		// act
+		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields ), $actual );
+		// assert
+		$this->assertTrue( empty( $actual ) );
+	}
+	/**
+	 * Tests whether the validate method when called on an email field calls
+	 * 'sanitize_email' from the WP API once
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group user_input
+	 * @group validation
+	 */
 
-    function testEmailExpectsSanitizeMethodCalled() {
-        // arrange
-        global $post;
-        \WP_Mock::wpPassthruFunction('sanitize_email', array('times' => 1));
-        $TestValidEmailField = new TestValidEmailField();
-        $_POST = array(
-            'one' => 'foo@bar.baz',
-        );
-        $actual = array();
-        // act
-        $TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual);
-    }
+	function testEmailExpectsSanitizeMethodCalled() {
+		// arrange
+		global $post;
+		\WP_Mock::wpPassthruFunction('sanitize_email', array('times' => 1));
+		$TestValidEmailField = new TestValidEmailField();
+		$_POST = array(
+			'one' => 'foo@bar.baz',
+		);
+		$actual = array();
+		// act
+		$TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual);
+	}
 
-    /**
-     * Tests whether a number field has data replaced
-     *
-     * @group number
-     * @group stable
-     * @group isolated
-     * @group user_input
-     * @group validation
-     */
-    function testValidNumberFieldExpectsDataReturned() {
-        $TestNumberField = new TestNumberField();
-        $_POST = array(
-            'post_ID' => 1,
-            'field_one' => 2,
-        );
-        $actual = array();
+	/**
+	 * Tests whether a number field has data replaced
+	 *
+	 * @group number
+	 * @group stable
+	 * @group isolated
+	 * @group user_input
+	 * @group validation
+	 */
+	function testValidNumberFieldExpectsDataReturned() {
+		$TestNumberField = new TestNumberField();
+		$_POST = array(
+			'post_ID' => 1,
+			'field_one' => 2,
+		);
+		$actual = array();
 
-        // act
-        $TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual);
+		// act
+		$TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual);
 
-        // assert
-        $expected = 2;
-        $this->assertEquals(
-            $expected,
-            $actual['field_one'],
-            'Numeric strings should be accepted and converted to a number.');
-    }
+		// assert
+		$expected = 2;
+		$this->assertEquals(
+			$expected,
+			$actual['field_one'],
+			'Numeric strings should be accepted and converted to a number.');
+	}
 
-    /**
-     * Tests whether an invalid number is not accepted
-     *
-     * @group stable
-     * @group isolated
-     * @group number
-     * @group user_input
-     * @group validation
-     *
-     */
-    function testInvalidNumericFieldExpectsDataRemoved() {
+	/**
+	 * Tests whether an invalid number is not accepted
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group number
+	 * @group user_input
+	 * @group validation
+	 *
+	 */
+	function testInvalidNumericFieldExpectsDataRemoved() {
 
-        // arrange
-        
-        $TestNumberField = new TestNumberField();
-        $_POST = array(
-            'post_ID' => 1,
-            'field_one' => 'Two',
-        );
-        $actual = array();
+		// arrange
+		$TestNumberField = new TestNumberField();
+		$_POST = array(
+			'post_ID' => 1,
+			'field_one' => 'Two',
+		);
+		$actual = array();
 
-        // act
-        $TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual);
-        // assert
-        $expected = null;
-        $this->assertEquals(
-            $expected,
-            $actual['field_one'],
-            'Non-numeric strings should not be accepted for a number input type.'
-        );
-    }
+		// act
+		$TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual);
+		// assert
+		$expected = null;
+		$this->assertEquals(
+			$expected,
+			$actual['field_one'],
+			'Non-numeric strings should not be accepted for a number input type.'
+		);
+	}
 
-    /**
-     * Tests whether a text field accepts and returns a textual string
-     *
-     * @group user_input
-     * @group stable
-     * @group isolated
-     * @group text
-     * @group validation
-     */
-    function testTextFieldExpectsStringReturned() {
+	/**
+	 * Tests whether a text field accepts and returns a textual string
+	 *
+	 * @group user_input
+	 * @group stable
+	 * @group isolated
+	 * @group text
+	 * @group validation
+	 */
+	function testTextFieldExpectsStringReturned() {
 
-        // arrange
-        $TestValidTextField = new TestValidTextField();
-        $TestValidTextField->fields['one']['type'] = 'text';
-        $_POST = array(
-            'post_ID' => 1,
-            'one' => 'Text field expects a string',
-        );
-        $actual = array();
+		// arrange
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields['one']['type'] = 'text';
+		$_POST = array(
+			'post_ID' => 1,
+			'one' => 'Text field expects a string',
+		);
+		$actual = array();
 
-        // act
-        $TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['one'], $actual);
+		// act
+		$TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['one'], $actual);
 
-        // assert
-        $this->assertEquals(
-            'Text field expects a string',
-            $actual['one']
-        );
-    }
+		// assert
+		$this->assertEquals(
+			'Text field expects a string',
+			$actual['one']
+		);
+	}
 
-    /**
-     * Tests wheter an integer is converted to a string if field == text
-     *
-     * @group text
-     * @group user_input
-     * @group stable
-     * @group isolated
-     * @group validation
-     */
-    function testTextFieldGivenNumberExpectsNumericStringValueReturned() {
+	/**
+	 * Tests wheter an integer is converted to a string if field == text
+	 *
+	 * @group text
+	 * @group user_input
+	 * @group stable
+	 * @group isolated
+	 * @group validation
+	 */
+	function testTextFieldGivenNumberExpectsNumericStringValueReturned() {
 
-        // arrange
-        global $post;
-        $TestValidTextField = new TestValidTextField();
-        $TestValidTextField->fields['one']['type'] = 'text';
-        $_POST = array(
-            'post_ID' => 1,
-            'one' => 1,
-        );
-        $actual = array();
+		// arrange
+		global $post;
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields['one']['type'] = 'text';
+		$_POST = array(
+			'post_ID' => 1,
+			'one' => 1,
+		);
+		$actual = array();
 
-        // act
-        $TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['one'], $actual);
+		// act
+		$TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['one'], $actual);
 
-        // assert
-        $this->assertEquals('1', $actual['one']);
-    }
+		// assert
+		$this->assertEquals('1', $actual['one']);
+	}
 
-    /**
-     * Tests whether a text area field accepts and returns a string.
-     *
-     * @group textarea
-     * @group isolated
-     * @group stable
-     * @group validation
-     *
-     */
-    function testTextAreaFieldExpectsStringReturned() {
-        // arrange
-        global $post;
-        $post = new \StdClass();
-        $post->ID = 1;
-        $post->post_type = 'post';
-        $TestValidTextAreaField = new TestValidTextAreaField();
-        // \WP_Mock::wpFunction(
-        //  'get_post',
-        //  array('times' => 1, 'returns' => $post)
-        // );
-        $_POST = array(
-            'post_ID' => 1,
-            'one' => 'Foo',
-        );
-        $actual = array();
+	/**
+	 * Tests whether a text area field accepts and returns a string.
+	 *
+	 * @group textarea
+	 * @group isolated
+	 * @group stable
+	 * @group validation
+	 *
+	 */
+	function testTextAreaFieldExpectsStringReturned() {
+		// arrange
+		global $post;
+		$post = new \StdClass();
+		$post->ID = 1;
+		$post->post_type = 'post';
+		$TestValidTextAreaField = new TestValidTextAreaField();
+		// \WP_Mock::wpFunction(
+		//  'get_post',
+		//  array('times' => 1, 'returns' => $post)
+		// );
+		$_POST = array(
+			'post_ID' => 1,
+			'one' => 'Foo',
+		);
+		$actual = array();
 
-        // act
-        $TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
+		// act
+		$TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
 
-        //assert
-        $this->assertEquals('Foo', $actual['one']);
-    }
+		//assert
+		$this->assertEquals('Foo', $actual['one']);
+	}
 
-    /**
-     * tests whether an array is not accepted and an error is returned.
-     * @group strings
-     * @group isolated
-     * @group user_input
-     * @group stable
-     * @group returns_null
-     * @group validation
-     */
-    function testTextAreaFieldNonStringExpectsNullReturned() {
-        // arrange
-        global $post; 
-        // $post = new StdClass;
-        // $post->post_type = 'post';
-        // $post->ID = 1;
-        $stub = $this->getMock('\WP_Error', array('get_error_message'));
-        // \WP_Mock::wpFunction(
-        //  'get_post',
-        //  array('times' => 1, 'return' => $post));
-        $TestValidTextAreaField = new TestValidTextAreaField();
-        $TestValidTextAreaField->error_handler($stub);
-        $_POST = array(
-            'post_ID' => 1,
-            'one' => null,
-        );
-        $actual = array();
+	/**
+	 * tests whether an array is not accepted and an error is returned.
+	 * @group strings
+	 * @group isolated
+	 * @group user_input
+	 * @group stable
+	 * @group returns_null
+	 * @group validation
+	 */
+	function testTextAreaFieldNonStringExpectsNullReturned() {
+		// arrange
+		global $post;
+		// $post = new StdClass;
+		// $post->post_type = 'post';
+		// $post->ID = 1;
+		$stub = $this->getMock('\WP_Error', array('get_error_message'));
+		// \WP_Mock::wpFunction(
+		//  'get_post',
+		//  array('times' => 1, 'return' => $post));
+		$TestValidTextAreaField = new TestValidTextAreaField();
+		$TestValidTextAreaField->error_handler($stub);
+		$_POST = array(
+			'post_ID' => 1,
+			'one' => null,
+		);
+		$actual = array();
 
-        // act
-        $TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
+		// act
+		$TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
 
-        // assert
-        $this->assertTrue( ! isset( $actual['one'] ) );
-    }
+		// assert
+		$this->assertTrue( ! isset( $actual['one'] ) );
+	}
 
-    /**
-     * Tests whether url field data will be sent to WordPress and sanitized
-     *
-     * @group urls
-     * @group user_input
-     * @group stable
-     * @group isolated
-     * @group validation
-     */
-    function testURLFieldExpectsEscRawURLCall() {
-        // arrange
-        global $post;
-        \WP_Mock::wpPassthruFunction(
-            'esc_url_raw',
-            array('times' => 1, 'return' => 'http://google.com')
-        );
-        // \WP_Mock::wpFunction(
-        //  'get_post',
-        //  array('times' => 1,'return' => $post,)
-        // );
-        $TestValidEmailField = new TestValidEmailField();
-        $TestValidEmailField->fields['one']['type'] = 'url';
-        $_POST = array(
-            'one' => 'http://google.com',
-        );
-        $actual = array();
+	/**
+	 * Tests whether url field data will be sent to WordPress and sanitized
+	 *
+	 * @group urls
+	 * @group user_input
+	 * @group stable
+	 * @group isolated
+	 * @group validation
+	 */
+	function testURLFieldExpectsEscRawURLCall() {
+		// arrange
+		global $post;
+		\WP_Mock::wpPassthruFunction(
+			'esc_url_raw',
+			array('times' => 1, 'return' => 'http://google.com')
+		);
+		// \WP_Mock::wpFunction(
+		//  'get_post',
+		//  array('times' => 1,'return' => $post,)
+		// );
+		$TestValidEmailField = new TestValidEmailField();
+		$TestValidEmailField->fields['one']['type'] = 'url';
+		$_POST = array(
+			'one' => 'http://google.com',
+		);
+		$actual = array();
 
-        // act
-        $TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual );
+		// act
+		$TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual );
 
-        // assert
-        $this->assertEquals($actual['one'], 'http://google.com');
-    }
+		// assert
+		$this->assertEquals($actual['one'], 'http://google.com');
+	}
 
-    /**
-     * Tests whether validate will call the appropriate special validator for 
-     * a taxonomy select field.
-     *
-     * @group stable
-     * @group isolated
-     * @group taxonomy_select
-     * @group validation
-     */
-    function testTaxonomySelectFieldExpectsTaxonomySelectValidatorCalled() {
-        // arrange
-        global $post;
-        $factory = $this->getMockBuilder('TestValidDateField')
-                        ->setMethods(array('validate_taxonomyselect',))
-                        ->getMock();
-        $factory->fields['category']['type'] = 'taxonomyselect';
+	/**
+	 * Tests whether validate will call the appropriate special validator for
+	 * a taxonomy select field.
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group taxonomy_select
+	 * @group validation
+	 */
+	function testTaxonomySelectFieldExpectsTaxonomySelectValidatorCalled() {
+		// arrange
+		global $post;
+		$factory = $this->getMockBuilder('TestValidDateField')
+						->setMethods(array('validate_taxonomyselect',))
+						->getMock();
+		$factory->fields['category']['type'] = 'taxonomyselect';
 
-        $factory->expects($this->once())
-                ->method('validate_taxonomyselect')
-                ->will($this->returnValue(true));
-        $actual = array();
+		$factory->expects($this->once())
+				->method('validate_taxonomyselect')
+				->will($this->returnValue(true));
+		$actual = array();
 
-        // act
-        $factory->validate($post->ID, $factory->fields['category'], $actual);
+		// act
+		$factory->validate($post->ID, $factory->fields['category'], $actual);
 
-        // assert
-        // Test will fail if validate_taxonomyselect called more than once
-    }
+		// assert
+		// Test will fail if validate_taxonomyselect called more than once
+	}
 
-    /**
-     * Tests whether validate will call the appropriate special validator for 
-     * a select field.
-     *
-     * @group stable
-     * @group isolated
-     * @group taxonomy_select
-     * @group validation
-     */
-    function testSelectFieldExpectsTaxonomySelectValidatorCalled() {
-        // arrange
-        global $post;
-        $factory = $this->getMockBuilder('TestNumberField')
-                        ->setMethods(array('validate_select',))
-                        ->getMock();
+	/**
+	 * Tests whether validate will call the appropriate special validator for
+	 * a select field.
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group taxonomy_select
+	 * @group validation
+	 */
+	function testSelectFieldExpectsTaxonomySelectValidatorCalled() {
+		// arrange
+		global $post;
+		$factory = $this->getMockBuilder('TestNumberField')
+						->setMethods(array('validate_select',))
+						->getMock();
 
-        $factory->expects($this->once())
-                ->method('validate_select')
-                ->will($this->returnValue(true));
-        $factory->fields['field_one']['type'] = 'select';
-        $actual = array();
+		$factory->expects($this->once())
+				->method('validate_select')
+				->will($this->returnValue(true));
+		$factory->fields['field_one']['type'] = 'select';
+		$actual = array();
 
-        // act
-        $factory->validate($post->ID, $factory->fields['field_one'], $actual);
+		// act
+		$factory->validate($post->ID, $factory->fields['field_one'], $actual);
 
-        // assert
-        // Test will fail if validate_taxonomyselect called more than once
-    }
+		// assert
+		// Test will fail if validate_taxonomyselect called more than once
+	}
 
-    /**
-     * Tests whether validate will call the appropriate special validator for 
-     * a link field.
-     *
-     * @group stable
-     * @group isolated
-     * @group taxonomy_select
-     * @group validation
-     */
-    function testLinkFieldExpectsTaxonomySelectValidatorCalled() {
-        // arrange
-        global $post;
-        $factory = $this->getMockBuilder('TestNumberField')
-                        ->setMethods(array('validate_link',))
-                        ->getMock();
+	/**
+	 * Tests whether validate will call the appropriate special validator for
+	 * a link field.
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group taxonomy_select
+	 * @group validation
+	 */
+	function testLinkFieldExpectsTaxonomySelectValidatorCalled() {
+		// arrange
+		global $post;
+		$factory = $this->getMockBuilder('TestNumberField')
+						->setMethods(array('validate_link',))
+						->getMock();
 
-        $factory->expects($this->once())
-                ->method('validate_link')
-                ->will($this->returnValue(true));
-        $factory->fields['field_one']['type'] = 'link';
-        $actual = array();
+		$factory->expects($this->once())
+				->method('validate_link')
+				->will($this->returnValue(true));
+		$factory->fields['field_one']['type'] = 'link';
+		$actual = array();
 
-        // act
-        $factory->validate($post->ID, $factory->fields['field_one'], $actual);
+		// act
+		$factory->validate($post->ID, $factory->fields['field_one'], $actual);
 
-        // assert
-        // Test will fail if validate_taxonomyselect called more than once
-    }
+		// assert
+		// Test will fail if validate_taxonomyselect called more than once
+	}
 
-    /**
-     * Tests whether a field with do_not_validate in the key will continue to 
-     * validate. Expects `validate` to return.
-     *
-     * @group stable
-     * @group isolated
-     * @group negative
-     * @group validation
-     * 
-     */
-    
-    function testDoNotValidateReturnsInsteadOfValidates() {
-        $TestNumberField = new TestNumberField();
-        $_POST = array(
-            'post_ID' => 1,
-            'field_one' => 2,
-        );
-        $actual = array();
+	/**
+	 * Tests whether a field with do_not_validate in the key will continue to
+	 * validate. Expects `validate` to return.
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group negative
+	 * @group validation
+	 *
+	 */
 
-        // act
-        $TestNumberField->fields['field_one']['do_not_validate'] = true;
-        $TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual );
+	function testDoNotValidateReturnsInsteadOfValidates() {
+		$TestNumberField = new TestNumberField();
+		$_POST = array(
+			'post_ID' => 1,
+			'field_one' => 2,
+		);
+		$actual = array();
 
-        // assert
-        $this->assertTrue(empty($actual));
-    }
-    /**
-     * Tests whether the validate_fieldset method is called when validating a 
-     * field of type 'fieldset'
-     *
-     * @group stable
-     * @group fieldset
-     * @group isolated
-     * @group validate_fieldset
-     */
-    function testValidFieldsetExpectsValidateToBeCalled() {
-        // arrange
-        global $post;
-        $factory = $this->getMockBuilder('TestValidFieldsetField')
-                        ->setMethods( array( 'validate_fieldset', ) )
-                        ->getMock();
-        $factory->expects($this->once())
-                ->method('validate_fieldset')
-                ->will($this->returnValue(true));
-        $validate = array();
+		// act
+		$TestNumberField->fields['field_one']['do_not_validate'] = true;
+		$TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual );
 
-        // act
-        $factory->validate( $post->ID, $factory->fields['field'], $validate );
+		// assert
+		$this->assertTrue(empty($actual));
+	}
+	/**
+	 * Tests whether the validate_fieldset method is called when validating a
+	 * field of type 'fieldset'
+	 *
+	 * @group stable
+	 * @group fieldset
+	 * @group isolated
+	 * @group validate_fieldset
+	 */
+	function testValidFieldsetExpectsValidateToBeCalled() {
+		// arrange
+		global $post;
+		$factory = $this->getMockBuilder('TestValidFieldsetField')
+						->setMethods( array( 'validate_fieldset', ) )
+						->getMock();
+		$factory->expects($this->once())
+				->method('validate_fieldset')
+				->will($this->returnValue(true));
+		$validate = array();
 
-        // assert
-        // Test will fail if validate_fieldset isn't executed once and only once
-    }
-    /**
-     * Tests whether the validate_formset method is called when validating a 
-     * field of type 'formset'
-     *
-     * @group stable
-     * @group formset
-     * @group isolated
-     * @group validate_formset
-     */
-    function testValidFormsetExpectsValidateToBeCalled() {
-        // arrange
-        global $post;
-        $factory = $this->getMockBuilder('TestValidFormsetField')
-                        ->setMethods( array( 'validate_formset', ) )
-                        ->getMock();
-        $factory->expects($this->once())
-                ->method('validate_formset')
-                ->will($this->returnValue(true));
-        $validate = array();
+		// act
+		$factory->validate( $post->ID, $factory->fields['field'], $validate );
 
-        // act
-        $factory->validate( $post->ID, $factory->fields['field'], $validate );
+		// assert
+		// Test will fail if validate_fieldset isn't executed once and only once
+	}
+	/**
+	 * Tests whether the validate_formset method is called when validating a
+	 * field of type 'formset'
+	 *
+	 * @group stable
+	 * @group formset
+	 * @group isolated
+	 * @group validate_formset
+	 */
+	function testValidFormsetExpectsValidateToBeCalled() {
+		// arrange
+		global $post;
+		$factory = $this->getMockBuilder('TestValidFormsetField')
+						->setMethods( array( 'validate_formset', ) )
+						->getMock();
+		$factory->expects($this->once())
+				->method('validate_formset')
+				->will($this->returnValue(true));
+		$validate = array();
 
-        // assert
-        // Test will fail if validate_formset isn't executed once and only once
-    }
+		// act
+		$factory->validate( $post->ID, $factory->fields['field'], $validate );
+
+		// assert
+		// Test will fail if validate_formset isn't executed once and only once
+	}
 
 
 /***************
  * Save method *
  ***************/
 
-    /**
-     * Tests whether save will call update_post_meta
-     *
-     * @group isolated
-     * @group stable
-     * @group save
-     */
-    function testSaveExpectsUpdatePostMetaCalledOnce() {
+	/**
+	 * Tests whether save will call update_post_meta
+	 *
+	 * @group isolated
+	 * @group stable
+	 * @group save
+	 */
+	function testSaveExpectsUpdatePostMetaCalledOnce() {
 
-        // arrange
-        $post_id = 100;
-        $postvalues = array(
-            'one' => 'Some text',
-        );
-        \WP_Mock::wpFunction( 'get_post_meta', array(
-            'times' => 1,
-            'return' => false,
-            )
-        );
-        \WP_Mock::wpFunction( 'update_post_meta', array(
-            'times' => 1,
-            'return' => true,
-            'with' => array(
-                $post_id,
-                'one',
-                'Some text',
-            ),
-            )
-        );
+		// arrange
+		$post_id = 100;
+		$postvalues = array(
+			'one' => 'Some text',
+		);
+		\WP_Mock::wpFunction( 'get_post_meta', array(
+			'times' => 1,
+			'return' => false,
+			)
+		);
+		\WP_Mock::wpFunction( 'update_post_meta', array(
+			'times' => 1,
+			'return' => true,
+			'with' => array(
+				$post_id,
+				'one',
+				'Some text',
+			),
+			)
+		);
 
-        $form = new TestValidTextField();
-        $form->post_type = 'post';
+		$form = new TestValidTextField();
+		$form->post_type = 'post';
 
-        // act
-        $form->save($post_id, $postvalues);
+		// act
+		$form->save($post_id, $postvalues);
 
-        // assert
+		// assert
 
-    }
+	}
 
-    /**
-     * Tests whether save() will call update_post_meta if $_POST is empty, expects
-     * it not to.
-     * @group stable
-     * @group isolated
-     * @group negative
-     * @group save
-     */
-    function testEmptyPostDataSaveExpectsNothing() {
+	/**
+	 * Tests whether save() will call update_post_meta if $_POST is empty, expects
+	 * it not to.
+	 * @group stable
+	 * @group isolated
+	 * @group negative
+	 * @group save
+	 */
+	function testEmptyPostDataSaveExpectsNothing() {
 
-        // arrange
-        $post_id = 100;
-        $postvalues = null;
+		// arrange
+		$post_id = 100;
+		$postvalues = null;
 
-        \WP_Mock::wpFunction( 'update_post_meta', array(
-            'times' => 0,)
-        );
+		\WP_Mock::wpFunction( 'update_post_meta', array(
+			'times' => 0,)
+		);
 
-        $form = new TestValidTextField();
+		$form = new TestValidTextField();
 
-        // act
-        $form->save( $post_id, $postvalues );
-    }
+		// act
+		$form->save( $post_id, $postvalues );
+	}
 
-    /**
-     * Tests whether save() will call update_post_meta if $_POST is empty, expects
-     * it not to.
-     * @group stable
-     * @group isolated
-     * @group negative
-     * @group save
-     */
-    function testEmptyPostKeySaveExpectsReturn() {
+	/**
+	 * Tests whether save() will call update_post_meta if $_POST is empty, expects
+	 * it not to.
+	 * @group stable
+	 * @group isolated
+	 * @group negative
+	 * @group save
+	 */
+	function testEmptyPostKeySaveExpectsReturn() {
 
-        // arrange
-        $post_id = 100;
-        $postvalues = array('one' => null);
-        \WP_Mock::wpFunction( 'get_post_meta', array(
-            'times' => 1,
-            'return' => false,
-            'with' => array( $post_id, 'one')
-            )
-        );
-        \WP_Mock::wpFunction( 'delete_post_meta', array(
-            'times' => 1)
-        );
-        \WP_Mock::wpFunction( 'update_post_meta', array(
-            'times' => 0,)
-        );
+		// arrange
+		$post_id = 100;
+		$postvalues = array('one' => null);
+		\WP_Mock::wpFunction( 'get_post_meta', array(
+			'times' => 1,
+			'return' => false,
+			'with' => array( $post_id, 'one')
+			)
+		);
+		\WP_Mock::wpFunction( 'delete_post_meta', array(
+			'times' => 1)
+		);
+		\WP_Mock::wpFunction( 'update_post_meta', array(
+			'times' => 0,)
+		);
 
-        $form = new TestValidTextField();
+		$form = new TestValidTextField();
 
-        // act
-        $form->save( $post_id, $postvalues );
-    }
-    /**
-     * Tests whether an empty key will call delete_post_meta()
-     *
-     * @group stable
-     * @group save
-     * @group isolated
-     */
-    function testEmptyKeyValueExpectsDeletePostMeta() {
-        // arrange
-        $post_id = 1;
-        $postvalues = array('one' => null);
-        $existing = 'exists';
-        \WP_Mock::wpFunction( 
-            'get_post_meta', 
-            array(
-                'times' => 1,
-                'return' => $existing,
-            )
-        );
-        \WP_Mock::wpFunction(
-            'delete_post_meta',
-            array(
-                'times' => 1,
-                'return' => true,
-                'with' => array('post_ID' => 1, 'meta_key' => 'one'),   
-            )
-        );
-        $form = new TestValidTextField();
-        // act
-        $form->save( $post_id, $postvalues);
-        // assert
-    }
+		// act
+		$form->save( $post_id, $postvalues );
+	}
+	/**
+	 * Tests whether an empty key will call delete_post_meta()
+	 *
+	 * @group stable
+	 * @group save
+	 * @group isolated
+	 */
+	function testEmptyKeyValueExpectsDeletePostMeta() {
+		// arrange
+		$post_id = 1;
+		$postvalues = array('one' => null);
+		$existing = 'exists';
+		\WP_Mock::wpFunction(
+			'get_post_meta',
+			array(
+				'times' => 1,
+				'return' => $existing,
+			)
+		);
+		\WP_Mock::wpFunction(
+			'delete_post_meta',
+			array(
+				'times' => 1,
+				'return' => true,
+				'with' => array('post_ID' => 1, 'meta_key' => 'one'),
+			)
+		);
+		$form = new TestValidTextField();
+		// act
+		$form->save( $post_id, $postvalues);
+		// assert
+	}
 
-    /**
-     * Tests whether validate() and save() can be called in succession.
-     *
-     * @group isolated
-     * @group stable
-     * @group save
-     */
-    function testVerifyAndSaveExpectsSuccess() {
-        // arrange
-        $_POST = array('post_ID' => 1, 'field_one' => 'value');
-        $actual = array();
-        $factory = $this->getMockBuilder('TestNumberField')
-                        ->setMethods( array( 'validate', 'save' ) )
-                        ->getMock();
+	/**
+	 * Tests whether validate() and save() can be called in succession.
+	 *
+	 * @group isolated
+	 * @group stable
+	 * @group save
+	 */
+	function testVerifyAndSaveExpectsSuccess() {
+		// arrange
+		$_POST = array('post_ID' => 1, 'field_one' => 'value');
+		$actual = array();
+		$factory = $this->getMockBuilder('TestNumberField')
+						->setMethods( array( 'validate', 'save' ) )
+						->getMock();
 
-        $factory->expects($this->once())
-                ->method('validate')
-                ->will($this->returnValue(true))
-                ->with(1, $factory->fields['field_one'], $actual);
-        $factory->expects($this->once())
-                ->method('save')
-                ->with(1, $actual);
+		$factory->expects($this->once())
+				->method('validate')
+				->will($this->returnValue(true))
+				->with(1, $factory->fields['field_one'], $actual);
+		$factory->expects($this->once())
+				->method('save')
+				->with(1, $actual);
 
-        // act
-        $factory->validate_and_save( 1 );
-    }
+		// act
+		$factory->validate_and_save( 1 );
+	}
 
 /**************************
  * Specialized validators *
  **************************/
 
-    /**
-     * Tests whether the validate method when called on a date field calls the
-     * date method from the Callbacks class.
-     *
-     * @group stable
-     * @group date
-     * @group isolated
-     * @group user_input
-     */
-    function testValidDateFieldExpectsCallbackCalledOnce() {
-        // arrange
-        $stub = $this->getMockBuilder('Callbacks')
-                    ->setMethods(array('date'))
-                    ->getMock();
+	/**
+	 * Tests whether the validate method when called on a date field calls the
+	 * date method from the Callbacks class.
+	 *
+	 * @group stable
+	 * @group date
+	 * @group isolated
+	 * @group user_input
+	 */
+	function testValidDateFieldExpectsCallbackCalledOnce() {
+		// arrange
+		$stub = $this->getMockBuilder('Callbacks')
+					->setMethods(array('date'))
+					->getMock();
 
-        $stub->expects( $this->once() )
-             ->method( 'date' )
-             ->with( $this->anything(), $this->anything(), $this->anything() );
+		$stub->expects( $this->once() )
+			 ->method( 'date' )
+			 ->with( $this->anything(), $this->anything(), $this->anything() );
 
-        // $stub->expects( $this->once() )
-        //  ->method( 'method' );
+		// $stub->expects( $this->once() )
+		//  ->method( 'method' );
 
-        $form = new TestValidDateField();
-        $form->set_callbacks($stub);
-        $term = \WP_Mock::wpFunction( 'wp_get_post_terms' ); 
-        $_POST = array(
-            'post_ID' => 1,
-            'category_year' => '1970' ,
-            'category_month' => 'January',
-            'category_day' => '01');
+		$form = new TestValidDateField();
+		$form->set_callbacks($stub);
+		$term = \WP_Mock::wpFunction( 'wp_get_post_terms' );
+		$_POST = array(
+			'post_ID' => 1,
+			'category_year' => '1970' ,
+			'category_month' => 'January',
+			'category_day' => '01');
 
-        // act
-        $form->validate_date( $form->fields['category'], $_POST['post_ID']);
-        // $stub->method();
-    }
+		// act
+		$form->validate_date( $form->fields['category'], $_POST['post_ID']);
+		// $stub->method();
+	}
 
-    /**
-     * Tests whether taxonomyselect will use a string if the given term does not exist.
-     *
-     * @group stable
-     * @group isolated
-     * @group taxonomyselect
-     */
-    function testTermDoesNotExistExpectsStringUsed() {
-        // Arrange
-        $form = new TestNumberField();
-        $form->fields['field_one']['type'] = 'taxonomyselect';
-        $form->fields['field_one']['taxonomy'] = 'category';
-        $form->fields['field_one']['multiple'] = false;
-        $field = $form->fields['field_one'];
-        $_POST = array('post_ID' => 1, 'field_one' => 'term');
-        $term = \WP_Mock::wpFunction(
-            'sanitize_text_field',
-            array(
-                'times' => 1,
-                'args' => array( $_POST['field_one'] ),
-                'return' => 'term',
-            )
-        );
-        \WP_Mock::wpFunction('get_term_by', array('times' => 1, 'return' => false));
-        \WP_Mock::wpFunction(
-            'wp_set_object_terms',
-            array(
-                'times' => 1,
-            )
-        );
+	/**
+	 * Tests whether taxonomyselect will use a string if the given term does not exist.
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group taxonomyselect
+	 */
+	function testTermDoesNotExistExpectsStringUsed() {
+		// Arrange
+		$form = new TestNumberField();
+		$form->fields['field_one']['type'] = 'taxonomyselect';
+		$form->fields['field_one']['taxonomy'] = 'category';
+		$form->fields['field_one']['multiple'] = false;
+		$field = $form->fields['field_one'];
+		$_POST = array('post_ID' => 1, 'field_one' => 'term');
+		$term = \WP_Mock::wpFunction(
+			'sanitize_text_field',
+			array(
+				'times' => 1,
+				'args' => array( $_POST['field_one'] ),
+				'return' => 'term',
+			)
+		);
+		\WP_Mock::wpFunction('get_term_by', array('times' => 1, 'return' => false));
+		\WP_Mock::wpFunction(
+			'wp_set_object_terms',
+			array(
+				'times' => 1,
+			)
+		);
 
-        // act
-        $form->validate_taxonomyselect($form->fields['field_one'], $_POST['post_ID']);
+		// act
+		$form->validate_taxonomyselect($form->fields['field_one'], $_POST['post_ID']);
 
-        // Assert: test will fail if wp_set_object_terms, get_term_by or
-        // sanitize_text_field do not fire or fire more than once
-    }
+		// Assert: test will fail if wp_set_object_terms, get_term_by or
+		// sanitize_text_field do not fire or fire more than once
+	}
 
-    /**
-     * Tests whether validate_link will call add post meta with the correct values
-     *
-     * @group isolated
-     * @group stable
-     * @group validate_link
-    **/
-    function testValidateLinkExpectsAddPostMetaTwice() {
-        $_POST = array(
-            'link_url' => 'http://example.com',
-            'link_text' => 'example.com',
-        );
-        $field = array(
-            'slug' => 'link',
-            'type' => 'link',
-            'params' => array(),
-            'meta_key' => 'link',
-            'howto' => "Some howto text",
-        );
-        $form = new TestNumberField();
-        global $post;
-        $post = new StdClass();
-        $post_id = 1;
-        $form->fields = $field;
-        \WP_Mock::wpFunction(
-            'add_post_meta',
-            array( 'times' => 2, 'return' => true )
-        );
-        $post = new \StdClass;
-        \WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
-        \WP_Mock::wpFunction('delete_post_meta', array('times' => 0));
-        $form->validate_link( $field, $post_id);
-    }
+	/**
+	 * Tests whether validate_link will call add post meta with the correct values
+	 *
+	 * @group isolated
+	 * @group stable
+	 * @group validate_link
+	**/
+	function testValidateLinkExpectsAddPostMetaTwice() {
+		$_POST = array(
+			'link_url' => 'http://example.com',
+			'link_text' => 'example.com',
+		);
+		$field = array(
+			'slug' => 'link',
+			'type' => 'link',
+			'params' => array(),
+			'meta_key' => 'link',
+			'howto' => "Some howto text",
+		);
+		$form = new TestNumberField();
+		global $post;
+		$post = new StdClass();
+		$post_id = 1;
+		$form->fields = $field;
+		\WP_Mock::wpFunction(
+			'add_post_meta',
+			array( 'times' => 2, 'return' => true )
+		);
+		$post = new \StdClass;
+		\WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
+		\WP_Mock::wpFunction('delete_post_meta', array('times' => 0));
+		$form->validate_link( $field, $post_id);
+	}
 
-    /**
-    * Tests whether count will default to 1 if none is passed in the model
-    *
-    * @group stable
-    * @group isolated
-    * @group validate_link
-    **/
-    function testValidateLinkCountNotGivenExpectsUpdatePostMetaCalledOnce() {
-        // arrange
-        $_POST = array(
-            'link_url' => 'http://example.com',
-            'link_text' => 'example.com',
-        );
-        $field = array(
-            'slug' => 'link',
-            'type' => 'link',
-            'params' => array(),
-            'meta_key' => 'link',
-            'howto' => "Some howto text",
-        );
-        $form = new TestNumberField();
-        $post_id = 1;
-        $form->fields = $field;
-        \WP_Mock::wpFunction(
-            'add_post_meta',
-            array( 'times' => 2, 'return' => true )
-        );
-        $post = new \StdClass;
-        \WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
+	/**
+	* Tests whether count will default to 1 if none is passed in the model
+	*
+	* @group stable
+	* @group isolated
+	* @group validate_link
+	**/
+	function testValidateLinkCountNotGivenExpectsUpdatePostMetaCalledOnce() {
+		// arrange
+		$_POST = array(
+			'link_url' => 'http://example.com',
+			'link_text' => 'example.com',
+		);
+		$field = array(
+			'slug' => 'link',
+			'type' => 'link',
+			'params' => array(),
+			'meta_key' => 'link',
+			'howto' => "Some howto text",
+		);
+		$form = new TestNumberField();
+		$post_id = 1;
+		$form->fields = $field;
+		\WP_Mock::wpFunction(
+			'add_post_meta',
+			array( 'times' => 2, 'return' => true )
+		);
+		$post = new \StdClass;
+		\WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
 
-        // act
-        $form->validate_link( $field, $post_id);
+		// act
+		$form->validate_link( $field, $post_id);
 
-        // assert: Test will fail if get_ or update_post_meta called more than once.
-    }
-    /**
-     * Tests whether validate_link will use the $existing variable if it is set
-     *
-    **/
-    function testValidateLinkWithExistingDataExpectsDataDeletedAndReplaced() {
-        // arrange
-        $_POST = array(
-            'link_url' => 'http://example.com',
-            'link_text' => 'example.com',
-        );
-        $field = array(
-            'slug' => 'link',
-            'type' => 'link',
-            'params' => array(),
-            'meta_key' => 'link',
-            'howto' => "Some howto text",
-        );
-        $existing = array( 'http://google.com', 'Google');
-        $form = new TestNumberField();
-        $post_id = 1;
-        $form->fields = $field;
-        // \WP_Mock::wpFunction(
-        //  'delete_post_meta',
-        //  array( 'times' => 1, 'return' => true)
-        // );
-        // \WP_Mock::wpFunction(
-        //  'add_post_meta',
-        //  array( 'times' => 2, 'return' => true)
-        // );
-        \WP_Mock::wpFunction(
-            'update_post_meta',
-            array( 'times' => 2, 'return' => true)
-        );
-        \WP_Mock::wpFunction(
-            'get_post_meta',
-            array( 'times' => 1, 'return' => $existing )
-        );
+		// assert: Test will fail if get_ or update_post_meta called more than once.
+	}
+	/**
+	 * Tests whether validate_link will use the $existing variable if it is set
+	 *
+	**/
+	function testValidateLinkWithExistingDataExpectsDataDeletedAndReplaced() {
+		// arrange
+		$_POST = array(
+			'link_url' => 'http://example.com',
+			'link_text' => 'example.com',
+		);
+		$field = array(
+			'slug' => 'link',
+			'type' => 'link',
+			'params' => array(),
+			'meta_key' => 'link',
+			'howto' => "Some howto text",
+		);
+		$existing = array( 'http://google.com', 'Google');
+		$form = new TestNumberField();
+		$post_id = 1;
+		$form->fields = $field;
+		// \WP_Mock::wpFunction(
+		//  'delete_post_meta',
+		//  array( 'times' => 1, 'return' => true)
+		// );
+		// \WP_Mock::wpFunction(
+		//  'add_post_meta',
+		//  array( 'times' => 2, 'return' => true)
+		// );
+		\WP_Mock::wpFunction(
+			'update_post_meta',
+			array( 'times' => 2, 'return' => true)
+		);
+		\WP_Mock::wpFunction(
+			'get_post_meta',
+			array( 'times' => 1, 'return' => $existing )
+		);
 
 
-        // act
-        $form->validate_link( $field, $post_id );
+		// act
+		$form->validate_link( $field, $post_id );
 
-        // assert
-        // Test will fail if add_post_meta is called more than twice, and if
-        // get_post_meta or delete_post_meta are called more than once.
-    }
+		// assert
+		// Test will fail if add_post_meta is called more than twice, and if
+		// get_post_meta or delete_post_meta are called more than once.
+	}
 
-    /**
-    * Tests whether validate_link will return rather than re-save existing data
-    *
-    * @group stable
-    * @group link_validate
-    *
-    **/
-    function testValidateLinkWithExistingDataMatchingSubmittedExpectsNoaction() {
-        // arrange
-        $_POST = array(
-            'link_url' => 'http://example.com',
-            'link_text' => 'example.com',
-        );
-        $field = array(
-            'slug' => 'link',
-            'type' => 'link',
-            'params' => array(),
-            'meta_key' => 'link',
-            'howto' => "Some howto text",
-        );
-        $existing = array( 'http://example.com', 'example.com');
-        $form = new TestNumberField();
-        $post_id = 1;
-        $form->fields = $field;
-        \WP_Mock::wpFunction(
-            'add_post_meta',
-            array( 'times' => 0 )
-        );
-        \WP_Mock::wpFunction(
-            'get_post_meta',
-            array( 'times' => 1, 'return' => $existing )
-        );
-        \WP_Mock::wpFunction(
-            'update_post_meta',
-            array( 'times' => 0)
-        );
-        // act
-        $form->validate_link( $field, $post_id );
-        // assert
-        // Test will fail if add_post_meta or delete_post_meta is called and if
-        // get_post_meta is called more than once.
-    }
-    /**
-     * Tests whether taxonomyselect will use the term object when a term exists
-     *
-     * @group stable
-     * @group isolated
-     * @group taxonomyselect
-     */
-    function testTermExistsExpectsStringUsed() {
-        // Arrange
-        global $post;
-        $form = new TestNumberField();
-        $form->fields['field_one']['type'] = 'taxonomyselect';
-        $form->fields['field_one']['taxonomy'] = 'category';
-        $form->fields['field_one']['multiple'] = false;
-        $_POST = array( 'field_one' => 'term' );
-        $existing = new \StdClass;
-        $existing->name = 'Sluggo';
-        \WP_Mock::wpFunction('sanitize_text_field', array('times' => 1));
-        \WP_Mock::wpFunction(
-            'get_term_by', 
-            array('times' => 1, 'return' => $existing));
-        \WP_Mock::wpFunction('wp_set_object_terms', array( 'times' => 1 ) );
+	/**
+	* Tests whether validate_link will return rather than re-save existing data
+	*
+	* @group stable
+	* @group link_validate
+	*
+	**/
+	function testValidateLinkWithExistingDataMatchingSubmittedExpectsNoaction() {
+		// arrange
+		$_POST = array(
+			'link_url' => 'http://example.com',
+			'link_text' => 'example.com',
+		);
+		$field = array(
+			'slug' => 'link',
+			'type' => 'link',
+			'params' => array(),
+			'meta_key' => 'link',
+			'howto' => "Some howto text",
+		);
+		$existing = array( 'http://example.com', 'example.com');
+		$form = new TestNumberField();
+		$post_id = 1;
+		$form->fields = $field;
+		\WP_Mock::wpFunction(
+			'add_post_meta',
+			array( 'times' => 0 )
+		);
+		\WP_Mock::wpFunction(
+			'get_post_meta',
+			array( 'times' => 1, 'return' => $existing )
+		);
+		\WP_Mock::wpFunction(
+			'update_post_meta',
+			array( 'times' => 0)
+		);
+		// act
+		$form->validate_link( $field, $post_id );
+		// assert
+		// Test will fail if add_post_meta or delete_post_meta is called and if
+		// get_post_meta is called more than once.
+	}
+	/**
+	 * Tests whether taxonomyselect will use the term object when a term exists
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group taxonomyselect
+	 */
+	function testTermExistsExpectsStringUsed() {
+		// Arrange
+		global $post;
+		$form = new TestNumberField();
+		$form->fields['field_one']['type'] = 'taxonomyselect';
+		$form->fields['field_one']['taxonomy'] = 'category';
+		$form->fields['field_one']['multiple'] = false;
+		$_POST = array( 'field_one' => 'term' );
+		$existing = new \StdClass;
+		$existing->name = 'Sluggo';
+		\WP_Mock::wpFunction('sanitize_text_field', array('times' => 1));
+		\WP_Mock::wpFunction(
+			'get_term_by',
+			array('times' => 1, 'return' => $existing));
+		\WP_Mock::wpFunction('wp_set_object_terms', array( 'times' => 1 ) );
 
-        // act
-        $form->validate_taxonomyselect($form->fields['field_one'], $post->ID);
+		// act
+		$form->validate_taxonomyselect($form->fields['field_one'], $post->ID);
 
-        // Assert: test will fail if wp_set_object_terms, get_term_by or
-        // sanitize_text_field do not fire or fire more than once
-    }
+		// Assert: test will fail if wp_set_object_terms, get_term_by or
+		// sanitize_text_field do not fire or fire more than once
+	}
 
-    /**
-     * Tests whether if no existing metadata, add_post_meta is called by validate_select
-     *
-     * @group stable
-     * @group select
-     * @group isolated
-    **/
-    function testNoExistingDataValidateSelectExpectsAddPostMetaFiredOnce() {
-        // Arrange
-        global $post;
-        $form = new TestNumberField();
-        $form->fields['field_one']['type'] = 'select';
-        $form->fields['field_one']['multiple'] = false;
-        $_POST = array( 'field_one' => 'metadata');
-        \WP_Mock::wpFunction('sanitize_text_field', array('times' => 1));
-        \WP_Mock::wpFunction(
-            'get_post_meta',
-            array('times' => 1, 'return' => array() )
-        );
-        \WP_Mock::wpFunction('add_post_meta', array( 'times' => 1 ) );
+	/**
+	 * Tests whether if no existing metadata, add_post_meta is called by validate_select
+	 *
+	 * @group stable
+	 * @group select
+	 * @group isolated
+	**/
+	function testNoExistingDataValidateSelectExpectsAddPostMetaFiredOnce() {
+		// Arrange
+		global $post;
+		$form = new TestNumberField();
+		$form->fields['field_one']['type'] = 'select';
+		$form->fields['field_one']['multiple'] = false;
+		$_POST = array( 'field_one' => 'metadata');
+		\WP_Mock::wpFunction('sanitize_text_field', array('times' => 1));
+		\WP_Mock::wpFunction(
+			'get_post_meta',
+			array('times' => 1, 'return' => array() )
+		);
+		\WP_Mock::wpFunction('add_post_meta', array( 'times' => 1 ) );
 
-        // act
-        $form->validate_select($form->fields['field_one'],$post->ID);
-    }
+		// act
+		$form->validate_select($form->fields['field_one'],$post->ID);
+	}
 
-    /**
-     * Tests whether if no existing metadata, add_post_meta will be called twice by 
-     * validate_select if multiple values are in $_POST
-     *
-     * A multi select field will pass an array of values to the $_POST array, we 
-     * expect cms-toolkit to iterate over that array adding new post data for each
-     * entry.
-     *
-     * @group stable
-     * @group select
-     * @group isolated
-     */
-    function testNoExistingDataValidateSelectExpectsAddPostMetaTwice() {
-        global $post;
-        $form = new TestNumberField();
-        $form->fields['field_one']['type'] = 'select';
-        $form->fields['field_one']['multiple'] = false;
-        $_POST = array( 'field_one' => array( 'metadata', 'otherdata' ) );
-        \WP_Mock::wpFunction('sanitize_text_field', array('times' => 2));
-        \WP_Mock::wpFunction(
-            'get_post_meta',
-            array('times' => 1, 'return' => array() )
-        );
-        \WP_Mock::wpFunction('add_post_meta', array( 'times' => 2 ) );
+	/**
+	 * Tests whether if no existing metadata, add_post_meta will be called twice by
+	 * validate_select if multiple values are in $_POST
+	 *
+	 * A multi select field will pass an array of values to the $_POST array, we
+	 * expect cms-toolkit to iterate over that array adding new post data for each
+	 * entry.
+	 *
+	 * @group stable
+	 * @group select
+	 * @group isolated
+	 */
+	function testNoExistingDataValidateSelectExpectsAddPostMetaTwice() {
+		global $post;
+		$form = new TestNumberField();
+		$form->fields['field_one']['type'] = 'select';
+		$form->fields['field_one']['multiple'] = false;
+		$_POST = array( 'field_one' => array( 'metadata', 'otherdata' ) );
+		\WP_Mock::wpFunction('sanitize_text_field', array('times' => 2));
+		\WP_Mock::wpFunction(
+			'get_post_meta',
+			array('times' => 1, 'return' => array() )
+		);
+		\WP_Mock::wpFunction('add_post_meta', array( 'times' => 2 ) );
 
-        // act
-        $form->validate_select($form->fields['field_one'],$post->ID);
+		// act
+		$form->validate_select($form->fields['field_one'],$post->ID);
 
-    }
+	}
 
-    /**
-     * Tests whether, if post has existing custom data but those data are
-     * not in the $_POST array, delete_post_meta will be called on each
-     * existing value.
-     *
-     * When a select field is submitted it will may contian values that 
-     * exist already for this post in addition to new ones the user wants
-     * to add. If a term is in both arrays ($existing and $_POST), we 
-     * should keep it. If the term is in $existing but not $_POST, then a
-     * user has removed it or chosen a different value and we should 
-     * delete the previously stored metadata. This test verifies the latter
-     * condition specifically where there is no _POST data set at all (a user
-     * has set the <select> to a null value indicating they wish to delete 
-     * the value and not replace it.
-     *
-     * @group stable
-     * @group select
-     * @group isolated
-     */
-    function testExistingDataButEmptyPostValidateSelectExpectsDeletePostMetaOnce() {
-        global $post;
-        $form = new TestNumberField();
-        $form->fields['field_one']['type'] = 'select';
-        $form->fields['field_one']['multiple'] = false;
-        $_POST = array( 'field_one' => array( ) );
-        \WP_Mock::wpFunction(
-            'get_post_meta',
-            array('times' => 1, 'return' => array('existing') )
-        );
-        \WP_Mock::wpFunction('delete_post_meta', array( 'times' => 1 ) );
+	/**
+	 * Tests whether, if post has existing custom data but those data are
+	 * not in the $_POST array, delete_post_meta will be called on each
+	 * existing value.
+	 *
+	 * When a select field is submitted it will may contian values that
+	 * exist already for this post in addition to new ones the user wants
+	 * to add. If a term is in both arrays ($existing and $_POST), we
+	 * should keep it. If the term is in $existing but not $_POST, then a
+	 * user has removed it or chosen a different value and we should
+	 * delete the previously stored metadata. This test verifies the latter
+	 * condition specifically where there is no _POST data set at all (a user
+	 * has set the <select> to a null value indicating they wish to delete
+	 * the value and not replace it.
+	 *
+	 * @group stable
+	 * @group select
+	 * @group isolated
+	 */
+	function testExistingDataButEmptyPostValidateSelectExpectsDeletePostMetaOnce() {
+		global $post;
+		$form = new TestNumberField();
+		$form->fields['field_one']['type'] = 'select';
+		$form->fields['field_one']['multiple'] = false;
+		$_POST = array( 'field_one' => array( ) );
+		\WP_Mock::wpFunction(
+			'get_post_meta',
+			array('times' => 1, 'return' => array('existing') )
+		);
+		\WP_Mock::wpFunction('delete_post_meta', array( 'times' => 1 ) );
 
-        // act
-        $form->validate_select($form->fields['field_one'],$post->ID);
+		// act
+		$form->validate_select($form->fields['field_one'],$post->ID);
 
-    }
+	}
 
-    /**
-     * Tests whether, if $_POST contains non-identical values to $existing delete_post_meta
-     * will be called on each existing value. Similar to L978 _supra_
-     *
-     * @group stable
-     * @group select
-     * @group isolated
-     */
-    function testExistingDataMismatchPostValidateSelectExpectsDeletePostMetaAndAddPostMetaOnceEach() {
-        global $post;
-        $form = new TestNumberField();
-        $form->fields['field_one']['type'] = 'select';
-        $form->fields['field_one']['multiple'] = false;
-        $_POST = array( 'field_one' => array( 'non-existent' ) );
-        \WP_Mock::wpFunction(
-            'get_post_meta',
-            array('times' => 1, 'return' => array('existing') )
-        );
-        \WP_Mock::wpFunction( 'sanitize_text_field', array( 'times' => 1 ) );
-        \WP_Mock::wpFunction( 'delete_post_meta', array( 'times' => 1 ) );
-        \WP_Mock::wpFunction( 'add_post_meta', array( 'times' => 1 ) );
+	/**
+	 * Tests whether, if $_POST contains non-identical values to $existing delete_post_meta
+	 * will be called on each existing value. Similar to L978 _supra_
+	 *
+	 * @group stable
+	 * @group select
+	 * @group isolated
+	 */
+	function testExistingDataMismatchPostValidateSelectExpectsDeletePostMetaAndAddPostMetaOnceEach() {
+		global $post;
+		$form = new TestNumberField();
+		$form->fields['field_one']['type'] = 'select';
+		$form->fields['field_one']['multiple'] = false;
+		$_POST = array( 'field_one' => array( 'non-existent' ) );
+		\WP_Mock::wpFunction(
+			'get_post_meta',
+			array('times' => 1, 'return' => array('existing') )
+		);
+		\WP_Mock::wpFunction( 'sanitize_text_field', array( 'times' => 1 ) );
+		\WP_Mock::wpFunction( 'delete_post_meta', array( 'times' => 1 ) );
+		\WP_Mock::wpFunction( 'add_post_meta', array( 'times' => 1 ) );
 
-        // act
-        $form->validate_select($form->fields['field_one'],$post->ID);
+		// act
+		$form->validate_select($form->fields['field_one'],$post->ID);
 
-    }
+	}
 
-    /**
-     * Tests whether, if $_POST is completley empty delete_post_meta will be called
-     * on each existing value. Similar to L978 _supra_
-     *
-     * @group stable
-     * @group select
-     * @group isolated
-     */
-    function testExistingDataEmptyPostValidateSelectExpectsDeletePostMetaAndAddPostMetaOnceEach() {
-        global $post;
-        $form = new TestNumberField();
-        $form->fields['field_one']['type'] = 'select';
-        $form->fields['field_one']['multiple'] = false;
-        $_POST = array();
-        \WP_Mock::wpFunction(
-            'get_post_meta',
-            array('times' => 0, 'return' => array('existing') )
-        );
-        \WP_Mock::wpFunction( 'sanitize_text_field', array( 'times' => 0 ) );
-        \WP_Mock::wpFunction( 'delete_post_meta', array( 'times' => 1 ) );
-        \WP_Mock::wpFunction( 'add_post_meta', array( 'times' => 0 ) );
+	/**
+	 * Tests whether, if $_POST is completley empty delete_post_meta will be called
+	 * on each existing value. Similar to L978 _supra_
+	 *
+	 * @group stable
+	 * @group select
+	 * @group isolated
+	 */
+	function testExistingDataEmptyPostValidateSelectExpectsDeletePostMetaAndAddPostMetaOnceEach() {
+		global $post;
+		$form = new TestNumberField();
+		$form->fields['field_one']['type'] = 'select';
+		$form->fields['field_one']['multiple'] = false;
+		$_POST = array();
+		\WP_Mock::wpFunction(
+			'get_post_meta',
+			array('times' => 0, 'return' => array('existing') )
+		);
+		\WP_Mock::wpFunction( 'sanitize_text_field', array( 'times' => 0 ) );
+		\WP_Mock::wpFunction( 'delete_post_meta', array( 'times' => 1 ) );
+		\WP_Mock::wpFunction( 'add_post_meta', array( 'times' => 0 ) );
 
-        // act
-        $form->validate_select($form->fields['field_one'],$post->ID);
+		// act
+		$form->validate_select($form->fields['field_one'],$post->ID);
 
-    }
-    /**
-    * Tests a fieldset to make sure that validate is called for each of the 
-    * fieldset's fields.
-    *
-     * @group stable
-     * @group validate
-     * @group fieldset
-     * @group validate_fieldset
-     * @group isolated
-    */
-    function testValidFieldsetOfTwoFieldsCallsValidateTwice() {
-        //arrange
-        global $post;
-        $factory = $this->getMockBuilder('TestValidFieldsetField')
-                        ->setMethods( array( 'validate',) )
-                        ->getMock();
-        $factory->expects( $this->exactly( 2 ) )
-                ->method( 'validate' )
-                ->will( $this->returnValue( true ) );
-        $expected = array();
+	}
+	/**
+	* Tests a fieldset to make sure that validate is called for each of the
+	* fieldset's fields.
+	*
+	 * @group stable
+	 * @group validate
+	 * @group fieldset
+	 * @group validate_fieldset
+	 * @group isolated
+	*/
+	function testValidFieldsetOfTwoFieldsCallsValidateTwice() {
+		//arrange
+		global $post;
+		$factory = $this->getMockBuilder('TestValidFieldsetField')
+						->setMethods( array( 'validate',) )
+						->getMock();
+		$factory->expects( $this->exactly( 2 ) )
+				->method( 'validate' )
+				->will( $this->returnValue( true ) );
+		$expected = array();
 
-        //act
-        $factory->validate_fieldset( $factory->fields['field'], $expected, $post->ID );
+		//act
+		$factory->validate_fieldset( $factory->fields['field'], $expected, $post->ID );
 
-        //assert
-        // Test will fail if only each of the fields in the fieldset are validated
-    }
-    /**
-    * Tests a fieldset to make sure that validate adds validated values to the 
-    * array that was passed in by reference.
-    *
-     * @group stable
-     * @group validate
-     * @group fieldset
-     * @group validate_fieldset
-     * @group isolated
-    */
-    function testValidateAddsValidatedValuesToPassedInArrayByValidateFieldset() {
-        // arrange
-        global $post;
-        $_POST = array( 'field_num' => '0123456789', 'field_desc' => 'description' );
-        $testValidFieldsetField = new TestValidFieldsetField();
-        $actual = array();
-        $expected = array( 'field_num' => '0123456789', 'field_desc' => 'description' );
+		//assert
+		// Test will fail if only each of the fields in the fieldset are validated
+	}
+	/**
+	* Tests a fieldset to make sure that validate adds validated values to the
+	* array that was passed in by reference.
+	*
+	 * @group stable
+	 * @group validate
+	 * @group fieldset
+	 * @group validate_fieldset
+	 * @group isolated
+	*/
+	function testValidateAddsValidatedValuesToPassedInArrayByValidateFieldset() {
+		// arrange
+		global $post;
+		$_POST = array( 'field_num' => '0123456789', 'field_desc' => 'description' );
+		$testValidFieldsetField = new TestValidFieldsetField();
+		$actual = array();
+		$expected = array( 'field_num' => '0123456789', 'field_desc' => 'description' );
 
-        //act
-        $testValidFieldsetField->validate_fieldset( $testValidFieldsetField->fields['field'], $actual, $post->ID );
+		//act
+		$testValidFieldsetField->validate_fieldset( $testValidFieldsetField->fields['field'], $actual, $post->ID );
 
-        //assert
-        $this->assertEquals( $expected, $actual );
-    }
-    /**
-    * Tests a formset to make sure that validate is called for each of the 
-    * formset's fields.
-    *
-     * @group stable
-     * @group validate
-     * @group fieldset
-     * @group validate_formset
-     * @group isolated
-    */
-    function testValidFormsetOfTwoFieldsCallsValidateTwice() {
-        //arrange
-        global $post;
-        $factory = $this->getMockBuilder('TestValidFormsetField')
-                        ->setMethods( array( 'validate', ) )
-                        ->getMock();
-        $factory->expects( $this->exactly( 2 ) )
-                ->method( 'validate' )
-                ->will( $this->returnValue( true ) );
-        $actual = array();
+		//assert
+		$this->assertEquals( $expected, $actual );
+	}
+	/**
+	* Tests a formset to make sure that validate is called for each of the 
+	* formset's fields.
+	*
+	 * @group stable
+	 * @group validate
+	 * @group fieldset
+	 * @group validate_formset
+	 * @group isolated
+	*/
+	function testValidFormsetOfTwoFieldsCallsValidateTwice() {
+		//arrange
+		global $post;
+		$factory = $this->getMockBuilder('TestValidFormsetField')
+						->setMethods( array( 'validate', ) )
+						->getMock();
+		$factory->expects( $this->exactly( 2 ) )
+				->method( 'validate' )
+				->will( $this->returnValue( true ) );
+		$actual = array();
 
-        //act
-        $factory->validate_formset( $factory->fields['field'], $actual, $post->ID );
+		//act
+		$factory->validate_formset( $factory->fields['field'], $actual, $post->ID );
 
-        //assert
-    }
-    /**
-    * Tests a formset to make sure that validate adds validated values to the 
-    * array that was passed in by reference.
-    *
-     * @group stable
-     * @group validate
-     * @group formset
-     * @group validate_fieldset
-     * @group isolated
-    */
-    function testValidateAddsValidatedValuesToPassedInArrayByValidateFormset() {
-        // arrange
-        global $post;
-        $_POST = array( 'field_0_title' => 'Title 1', 'field_1_title' => 'Title 2' );
-        $testValidFormsetField = new TestValidFormsetField();
-        $actual = array();
-        $expected = array( 'field_0_title' => 'Title 1', 'field_1_title' => 'Title 2' );
+		//assert
+	}
+	/**
+	* Tests a formset to make sure that validate adds validated values to the
+	* array that was passed in by reference.
+	*
+	 * @group stable
+	 * @group validate
+	 * @group formset
+	 * @group validate_fieldset
+	 * @group isolated
+	*/
+	function testValidateAddsValidatedValuesToPassedInArrayByValidateFormset() {
+		// arrange
+		global $post;
+		$_POST = array( 'field_0_title' => 'Title 1', 'field_1_title' => 'Title 2' );
+		$testValidFormsetField = new TestValidFormsetField();
+		$actual = array();
+		$expected = array( 'field_0_title' => 'Title 1', 'field_1_title' => 'Title 2' );
 
-        //act
-        $testValidFormsetField->validate_formset( $testValidFormsetField->fields['field'], $actual, $post->ID );
+		//act
+		$testValidFormsetField->validate_formset( $testValidFormsetField->fields['field'], $actual, $post->ID );
 
-        //assert
-        $this->assertEquals( $expected, $actual );
-    }
+		//assert
+		$this->assertEquals( $expected, $actual );
+	}
 /**************
  * Generators *
 /**************/
-    /**
-     * Tests that a meta box is generated if the given post type exists.
-     *
-     * @group isolated
-     * @group stable
-     * @group meta_boxes
-     * @group generate
-     */
-    function testPostTypeExistsGenerateExpectsMetaBoxAdded() {
-        // Arrange
-        $form = new TestValidBox();
-        \WP_Mock::wpFunction('post_type_exists', array(
-            'times' => 1,
-            'args' => $form->post_type,
-            'return' => true,
-            )
-        );
-        \WP_Mock::wpPassthruFunction('sanitize_key');
-        \WP_Mock::wpFunction('add_meta_box', array(
-            'times' => 1,
-            'return' => true,
-            )
-        );
+	/**
+	 * Tests that a meta box is generated if the given post type exists.
+	 *
+	 * @group isolated
+	 * @group stable
+	 * @group meta_boxes
+	 * @group generate
+	 */
+	function testPostTypeExistsGenerateExpectsMetaBoxAdded() {
+		// Arrange
+		$form = new TestValidBox();
+		\WP_Mock::wpFunction('post_type_exists', array(
+			'times' => 1,
+			'args' => $form->post_type,
+			'return' => true,
+			)
+		);
+		\WP_Mock::wpPassthruFunction('sanitize_key');
+		\WP_Mock::wpFunction('add_meta_box', array(
+			'times' => 1,
+			'return' => true,
+			)
+		);
 
-        // act
-        $form->generate();
+		// act
+		$form->generate();
 
-        // Assert: test will fail if add_meta_box is not called, or called more than once
-    }
+		// Assert: test will fail if add_meta_box is not called, or called more than once
+	}
 
-    /**
-     * Tests whether post_type exists is called once
-     *
-     * @group stable
-     * @group generate
-     **/
-    function testPostTypeExistsCheckPostTypeExpectsPostTypeNameReturned() {
-        // Arrange
-        \WP_Mock::wpFunction('sanitize_key', array(
-            'times' => 1,
-            'return' => 'post'
-            )
-        );
-        \WP_Mock::wpFunction('post_type_exists', array(
-            'times' => 1,
-            'arg' => array( \WP_Mock\Functions::type('string') ),
-            'return' => true
-            )
-        );
-        $form = new TestValidBox();
-        $expected = 'post';
-        // act
-        $actual = $form->check_post_type($form->post_type);
-        // Assert
-        $this->assertEquals($expected, $actual, 'Post type did not verify correctly');
-    }
-    /**
-     * Tests whether check_post_type returns false if post type doesn't exist
-     *
-     * @group stable
-     * @group isolated
-     * @group meta_boxes
-     * @group generate
-     */
-    function testPostTypeNotExistsCheckPostTypeExpectsPostTypeNameReturned() {
-        // Arrange
-        \WP_Mock::wpFunction('sanitize_key', array(
-            'times' => 0,
-            )
-        );
-        \WP_Mock::wpFunction('post_type_exists', array(
-            'times' => 1,
-            'return' => false
-            )
-        );
-        $form = new TestValidBox();
-        $expected = false;
-        // act
-        $actual = $form->check_post_type($form->post_type);
-        // Assert
-        $this->assertEquals($expected, $actual, 'Post type did not verify correctly');
-    }
-    /**
-     * Tests whether a meta box can be attached to more than one post type
-     *
-     * @group stable
-     * @group meta_boxes
-     * @group generate
-     *
-     */
-    function testArrayinPostTypeExpectsBoxesGenerated() {
-        // arrange
-        $Box = new TestValidBox();
-        $Box->post_type = array('post', 'page');
-        \WP_Mock::wpFunction('post_type_exists', array(
-            'times' => 2,
-            'return' => true,)
-        );
-        \WP_Mock::wpPassthruFunction('sanitize_key');
-        \WP_Mock::wpFunction('add_meta_box', array(
-            'times' => 2,
-            'return' => true,
-            )
-        );
-        // act
-        $Box->generate();
-        // assert
-    }
-    /**
-     * Tests whether generate will make a meta box if the post type does not exist
-     *
-     * @group wp_error
-     * @group isolated
-     * @group stable
-     * @group generate
-     */
-    function testPostTypeNotExistsGenerateExpectsWPError() {
-        // Arrange
-        $stub = $this->getMockBuilder('TestValidBox')
-            ->setMethods(array('check_post_type'))
-            ->getMock();
-        $stub->expects($this->once())
-            ->method('check_post_type')
-            ->with($stub->post_type[0])
-            ->will($this->returnValue(false));
-        $error = $this->getMock('\WP_Error', array('get_error_message'));
-        $stub->error_handler(get_class($error));
-        // act
-        $actual = $stub->generate();
+	/**
+	 * Tests whether post_type exists is called once
+	 *
+	 * @group stable
+	 * @group generate
+	 **/
+	function testPostTypeExistsCheckPostTypeExpectsPostTypeNameReturned() {
+		// Arrange
+		\WP_Mock::wpFunction('sanitize_key', array(
+			'times' => 1,
+			'return' => 'post'
+			)
+		);
+		\WP_Mock::wpFunction('post_type_exists', array(
+			'times' => 1,
+			'arg' => array( \WP_Mock\Functions::type('string') ),
+			'return' => true
+			)
+		);
+		$form = new TestValidBox();
+		$expected = 'post';
+		// act
+		$actual = $form->check_post_type($form->post_type);
+		// Assert
+		$this->assertEquals($expected, $actual, 'Post type did not verify correctly');
+	}
+	/**
+	 * Tests whether check_post_type returns false if post type doesn't exist
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group meta_boxes
+	 * @group generate
+	 */
+	function testPostTypeNotExistsCheckPostTypeExpectsPostTypeNameReturned() {
+		// Arrange
+		\WP_Mock::wpFunction('sanitize_key', array(
+			'times' => 0,
+			)
+		);
+		\WP_Mock::wpFunction('post_type_exists', array(
+			'times' => 1,
+			'return' => false
+			)
+		);
+		$form = new TestValidBox();
+		$expected = false;
+		// act
+		$actual = $form->check_post_type($form->post_type);
+		// Assert
+		$this->assertEquals($expected, $actual, 'Post type did not verify correctly');
+	}
+	/**
+	 * Tests whether a meta box can be attached to more than one post type
+	 *
+	 * @group stable
+	 * @group meta_boxes
+	 * @group generate
+	 *
+	 */
+	function testArrayinPostTypeExpectsBoxesGenerated() {
+		// arrange
+		$Box = new TestValidBox();
+		$Box->post_type = array('post', 'page');
+		\WP_Mock::wpFunction('post_type_exists', array(
+			'times' => 2,
+			'return' => true,)
+		);
+		\WP_Mock::wpPassthruFunction('sanitize_key');
+		\WP_Mock::wpFunction('add_meta_box', array(
+			'times' => 2,
+			'return' => true,
+			)
+		);
+		// act
+		$Box->generate();
+		// assert
+	}
+	/**
+	 * Tests whether generate will make a meta box if the post type does not exist
+	 *
+	 * @group wp_error
+	 * @group isolated
+	 * @group stable
+	 * @group generate
+	 */
+	function testPostTypeNotExistsGenerateExpectsWPError() {
+		// Arrange
+		$stub = $this->getMockBuilder('TestValidBox')
+			->setMethods(array('check_post_type'))
+			->getMock();
+		$stub->expects($this->once())
+			->method('check_post_type')
+			->with($stub->post_type[0])
+			->will($this->returnValue(false));
+		$error = $this->getMock('\WP_Error', array('get_error_message'));
+		$stub->error_handler(get_class($error));
+		// act
+		$actual = $stub->generate();
 
-        // Assert
-    }
+		// Assert
+	}
 
-    /**
-     * Tests whether generate will make a meta box if the post type does not exist
-     *
-     * @group wp_error
-     * @group isolated
-     * @group stable
-     * @group generate
-     */
-    function testInvalidContextGenerateExpectsWPError() {
-        // Arrange
-        $stub = $this->getMock('\WP_Error', array('get_error_message'));
-        $form = new TestValidDateField();
-        $form->error_handler(($stub));
-        $form->context = 'context';
-        // act
-        $actual = $form->generate();
+	/**
+	 * Tests whether generate will make a meta box if the post type does not exist
+	 *
+	 * @group wp_error
+	 * @group isolated
+	 * @group stable
+	 * @group generate
+	 */
+	function testInvalidContextGenerateExpectsWPError() {
+		// Arrange
+		$stub = $this->getMock('\WP_Error', array('get_error_message'));
+		$form = new TestValidDateField();
+		$form->error_handler(($stub));
+		$form->context = 'context';
+		// act
+		$actual = $form->generate();
 
-        // Assert
-    }
+		// Assert
+	}
 /************************
  * Dependency injection *
  ************************/
-    /**
-     * Tests the ability replace the internal View class
-     *
-     * @group stable
-     * @group set_view
-     * @group isolated
-     * @group dependency_injection
-     */
-    function testSetViewExpectsViewReplaced() {
-        // Arrange
-        $newView = new \StdClass;
-        $form = new TestNumberField();
+	/**
+	 * Tests the ability replace the internal View class
+	 *
+	 * @group stable
+	 * @group set_view
+	 * @group isolated
+	 * @group dependency_injection
+	 */
+	function testSetViewExpectsViewReplaced() {
+		// Arrange
+		$newView = new \StdClass;
+		$form = new TestNumberField();
 
-        // act
-        $form->set_view($newView);
+		// act
+		$form->set_view($newView);
 
-        // Assert
-        $this->assertInstanceOf('StdClass', $form->View, 'Not working.');
-    }
+		// Assert
+		$this->assertInstanceOf('StdClass', $form->View, 'Not working.');
+	}
 }

--- a/tests/test-meta_box_view.php
+++ b/tests/test-meta_box_view.php
@@ -436,6 +436,9 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		$HTML = $this->getMock('HTML');
 		$View = new View();
 		$View->replace_HTML($HTML);
+		\WP_Mock::wpFunction(
+			'wp_get_object_terms',
+			array('times'=>1, 'return' => 'term'));
 
 		$cleaned = $View->process_defaults($fields);
 
@@ -689,11 +692,13 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		$fields = array(
 			'field' => array(
 	            'type' => 'formset',
+	            'title' => 'title',
 	            'fields' => array(
 	                array(
 	                    'title' => 'Title',
 	                    'type' => 'text',
 	                    'meta_key' => 'title',
+	                    'slug' => 'title',
 	                ),
 	            ),
 	            'params' => array(
@@ -701,6 +706,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	                'max_num_forms' => 2,
 	            ),
 	            'meta_key' => 'field',
+	            'slug' => 'field',
 	        ),
 		);
 		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
@@ -723,11 +729,13 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		$fields = array(
 			'field' => array(
 	            'type' => 'formset',
+	            'title' => 'title',
 	            'fields' => array(
 	                array(
 	                    'title' => 'Title',
 	                    'type' => 'text',
 	                    'meta_key' => 'title',
+	                    'slug' => 'title',
 	                ),
 	            ),
 	            'params' => array(
@@ -735,6 +743,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	                'max_num_forms' => 2,
 	            ),
 	            'meta_key' => 'field',
+	            'slug' => 'field',
 	        ),
 		);
 		$View = new View();
@@ -763,8 +772,8 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		        ),
 		        'meta_key' => 'field_0',
 		        'init' => true,
-		        'slug' => '_0',
-		        'title' => '',
+		        'slug' => 'field_0',
+		        'title' => 'title 1',
 	        ),
 			'field_1' => array(
 	            'type' => 'formset',
@@ -787,8 +796,8 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		                'max_num_forms' => 2,
 	            ),
 		        'meta_key' => 'field_1',
-		        'slug' => '_1',
-		        'title' => '',
+		        'slug' => 'field_1',
+		        'title' => 'title 2',
 	        ),
 	    );
 		//act

--- a/tests/test-meta_box_view.php
+++ b/tests/test-meta_box_view.php
@@ -566,20 +566,20 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		// arrange
 		$fields = array(
 			'field' => array(
-	            'type' => 'formset',
-	            'fields' => array(
-	                array(
-	                    'title' => 'Title',
-	                    'type' => 'text',
-	                    'meta_key' => 'title',
-	                ),
-	            ),
-	            'params' => array(
-	                'init_num_forms' => 1,
-	                'max_num_forms' => 2,
-	            ),
-	            'meta_key' => 'field',
-	        ),
+				'type' => 'formset',
+				'fields' => array(
+					array(
+						'title' => 'Title',
+						'type' => 'text',
+						'meta_key' => 'title',
+					),
+				),
+				'params' => array(
+					'init_num_forms' => 1,
+					'max_num_forms' => 2,
+				),
+				'meta_key' => 'field',
+			),
 		);
 		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
 					 ->setMethods( array( 'process_formset_defaults', 'default_value' ) )
@@ -602,20 +602,20 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		// arrange
 		$fields = array(
 			'field' => array(
-		        'type' => 'fieldset',
-		        'fields' => array(
-		            array(
-		                'type' => 'text',
-		                'meta_key' => 'num',
-		            ),
-		            array(
-		                'type' => 'text',
-		                'meta_key' => 'desc',
-		            ),
-		        ),
-		        'params' => array(),
-		        'meta_key' => 'field',
-		    ),
+				'type' => 'fieldset',
+				'fields' => array(
+					array(
+						'type' => 'text',
+						'meta_key' => 'num',
+					),
+					array(
+						'type' => 'text',
+						'meta_key' => 'desc',
+					),
+				),
+				'params' => array(),
+				'meta_key' => 'field',
+			),
 		);
 		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
 					 ->setMethods( array( 'assign_defaults', 'default_value' ) )
@@ -691,23 +691,23 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		// arrange
 		$fields = array(
 			'field' => array(
-	            'type' => 'formset',
-	            'title' => 'title',
-	            'fields' => array(
-	                array(
-	                    'title' => 'Title',
-	                    'type' => 'text',
-	                    'meta_key' => 'title',
-	                    'slug' => 'title',
-	                ),
-	            ),
-	            'params' => array(
-	                'init_num_forms' => 1,
-	                'max_num_forms' => 2,
-	            ),
-	            'meta_key' => 'field',
-	            'slug' => 'field',
-	        ),
+				'type' => 'formset',
+				'title' => 'title',
+				'fields' => array(
+					array(
+						'title' => 'Title',
+						'type' => 'text',
+						'meta_key' => 'title',
+						'slug' => 'title',
+					),
+				),
+				'params' => array(
+					'init_num_forms' => 1,
+					'max_num_forms' => 2,
+				),
+				'meta_key' => 'field',
+				'slug' => 'field',
+			),
 		);
 		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
 					 ->setMethods( array( 'process_defaults', ) )
@@ -728,78 +728,78 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		//arrange
 		$fields = array(
 			'field' => array(
-	            'type' => 'formset',
-	            'title' => 'title',
-	            'fields' => array(
-	                array(
-	                    'title' => 'Title',
-	                    'type' => 'text',
-	                    'meta_key' => 'title',
-	                    'slug' => 'title',
-	                ),
-	            ),
-	            'params' => array(
-	                'init_num_forms' => 1,
-	                'max_num_forms' => 2,
-	            ),
-	            'meta_key' => 'field',
-	            'slug' => 'field',
-	        ),
+				'type' => 'formset',
+				'title' => 'title',
+				'fields' => array(
+					array(
+						'title' => 'Title',
+						'type' => 'text',
+						'meta_key' => 'title',
+						'slug' => 'title',
+					),
+				),
+				'params' => array(
+					'init_num_forms' => 1,
+					'max_num_forms' => 2,
+				),
+				'meta_key' => 'field',
+				'slug' => 'field',
+			),
 		);
 		$View = new View();
 		\WP_Mock::wpFunction('get_post_meta', array('times' => 2, 'return' => array()));
 		$actual = array();
 		$expected = array(
 			'field_0' => array(
-	            'type' => 'formset',
-	            'fields' => array(
-	                'field_0_title' => array(
-	                    'title' => 'Title',
-	                    'type' => 'text',
-	                    'meta_key' => 'field_0_title',
-	                    'slug' => 'field_0_title',
-	                    'value' => '',
-	                    'label' => '',
-	                    'max_length' => 255,
-	                    'placeholder' => '',
-	                    'multiselect' => false,
-	                    'taxonomy' => false,
-	                ),
-	            ),
-		        'params' => array(
-		                'init_num_forms' => 1,
-		                'max_num_forms' => 2,
-		        ),
-		        'meta_key' => 'field_0',
-		        'init' => true,
-		        'slug' => 'field_0',
-		        'title' => 'title 1',
-	        ),
+				'type' => 'formset',
+				'fields' => array(
+					'field_0_title' => array(
+						'title' => 'Title',
+						'type' => 'text',
+						'meta_key' => 'field_0_title',
+						'slug' => 'field_0_title',
+						'value' => '',
+						'label' => '',
+						'max_length' => 255,
+						'placeholder' => '',
+						'multiselect' => false,
+						'taxonomy' => false,
+					),
+				),
+				'params' => array(
+						'init_num_forms' => 1,
+						'max_num_forms' => 2,
+				),
+				'meta_key' => 'field_0',
+				'init' => true,
+				'slug' => 'field_0',
+				'title' => 'title 1',
+			),
 			'field_1' => array(
-	            'type' => 'formset',
-	            'fields' => array(
-	                'field_1_title' => array(
-	                    'title' => 'Title',
-	                    'type' => 'text',
-	                    'meta_key' => 'field_1_title',
-	                    'slug' => 'field_1_title',
-	                    'value' => '',
-	                    'label' => '',
-	                    'max_length' => 255,
-	                    'placeholder' => '',
-	                    'multiselect' => false,
-	                    'taxonomy' => false,
-	                ),
-	            ),
-		        'params' => array(
-		                'init_num_forms' => 1,
-		                'max_num_forms' => 2,
-	            ),
-		        'meta_key' => 'field_1',
-		        'slug' => 'field_1',
-		        'title' => 'title 2',
-	        ),
-	    );
+				'type' => 'formset',
+				'fields' => array(
+					'field_1_title' => array(
+						'title' => 'Title',
+						'type' => 'text',
+						'meta_key' => 'field_1_title',
+						'slug' => 'field_1_title',
+						'value' => '',
+						'label' => '',
+						'max_length' => 255,
+						'placeholder' => '',
+						'multiselect' => false,
+						'taxonomy' => false,
+					),
+				),
+				'params' => array(
+						'init_num_forms' => 1,
+						'max_num_forms' => 2,
+				),
+				'meta_key' => 'field_1',
+				'slug' => 'field_1',
+				'title' => 'title 2',
+			),
+		);
 		//act
 		$View->process_formset_defaults( $fields['field'], $actual );
 


### PR DESCRIPTION
The code merged in from pull request #40 had failing tests due to an inconsistency in the testing environments between local and build server configurations. The local configuration was causing the tests to pass but the build's configuration caused 49 of them to fail. This is is making the Jenkin's build to fail. Once those inconsistencies were reconciled, the tests failed locally and the changes were made to make them passing.