### PR TITLE
Add file field type to the cms-toolkit api

### DIFF
--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -31,6 +31,7 @@ function cfpb_build_plugin() {
 	require_once( CFPB_INC . 'taxonomies.php');
 	define( 'DEPENDENCIES_READY', true);
 	add_action('admin_enqueue_scripts', 'cfpb_cms_toolkit_scripts');
+	add_action( 'post_edit_form_tag' , 'post_edit_form_tag' );
 }
 $general_error = new \WP_Error(
 	'_general_toolkit_error',
@@ -41,6 +42,9 @@ function cfpb_cms_toolkit_scripts() {
 	wp_enqueue_script( 'multi-select_js', plugins_url( '/js/jquery.multi-select.js', __FILE__ ), 'jquery', '1.0', $in_footer = true );
 	wp_register_style( 'cms_toolkit_styles',  plugins_url( '/css/styles.css', __FILE__ ), null, '1.0');
 	wp_enqueue_style( 'cms_toolkit_styles' );
+}
+function post_edit_form_tag( ) {
+   echo ' enctype="multipart/form-data"';
 }
 
 if (PHP_VERSION_ID >= 50300) {

--- a/inc/README.md
+++ b/inc/README.md
@@ -212,6 +212,7 @@ the 'checkbox' type * `radio` two input fields with values 'true' and 'false'
 * `url` an input with the 'url' type 
 * `link` two inputs, one with the `url` type and another with `text`, validates 
 as an array like `array(0 => 'url', 1 => 'text')`; 
+* `file` generates a button to browse your local file directory and choose a file to upload. Here is a list of approved file types: PDF, PNG, GIF, JPG, CSV, ZIP, DOC(X), XLS(X), PPT(X), JSON, XML, MP(E)G, HTML, TXT, MP3, MOV, TSV
 * `date` generates a trio of fields: a dropdown for months and two
 input fields for day and year 
 * `select` generates a `<select>` field with options specified in the 'params' 

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -5,7 +5,7 @@ class HTML {
 
 	private $elements = array(
 		'selects' => array( 'select', 'multiselect', 'taxonomyselect', 'tax_as_meta', 'post_select', 'post_multiselect' ),
-		'inputs' => array( 'text_area', 'number', 'text', 'boolean', 'email', 'url', 'date', 'radio', 'link', 'wysiwyg', ),
+		'inputs' => array( 'text_area', 'number', 'text', 'boolean', 'email', 'url', 'date', 'radio', 'link', 'wysiwyg', 'file' ),
 		'hidden' => array( 'nonce', 'hidden', 'separator', 'fieldset' ),
 		);
 
@@ -184,6 +184,10 @@ class HTML {
 		if ( $field['type'] == 'link' ) {
 			$this->link_input($field['meta_key'], $value, $required, $label, $form_id );
 		}
+
+		if ( $field['type'] == 'file' ) {
+			$this->file_input( $field['meta_key'], $value, $label, $required, $form_id );
+		}
 	}
 
 /**
@@ -299,6 +303,25 @@ class HTML {
 				$this->single_input( $meta_key . "_url", $existing[0], 'url', $required, NULL, 'URL', NULL, $form_id );
 		}
 		?></div><?php
+	}
+
+	public function file_input( $meta_key, $value = NULL, $label = NULL, $required = NULL, $form_id = NULL ) {
+		if ( $label ) {
+			?><label class="cms-toolkit-file block-label form-input_<?php echo esc_attr( $form_id ) ?>"><?php
+				echo esc_attr( $label );
+			?></label><?php
+		}
+		if ( $value ) {
+			?><div class="tagchecklist">
+				<span><a id="<?php echo esc_attr( $meta_key ) ?>" class="filedelbutton <?php echo esc_attr( $meta_key ) ?>"><?php echo esc_attr( $value['name'] ) ?></a>&nbsp;<?php echo $value['name'] ?></span><?php
+				$this->hidden( 'rm_' . $meta_key, null, null );
+			?></div><?php
+		}
+		?><input id="<?php echo esc_attr( $meta_key ) 
+			   ?>" name="<?php echo esc_attr( $meta_key ) 
+			   ?>" class="cms-toolkit-input <?php echo "form-input_{$form_id}"; 
+			   ?>" type="file" value="<?php echo esc_attr( $value['url'] ) ?>"<?php
+			   if ( $required ): echo ' required '; endif; ?>/><?php
 	}
 
 	/**

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -43,6 +43,29 @@ class Models {
 		'wysiwyg',
 	);
 	private $other   = array( 'nonce', 'hidden', 'separator', 'fieldset', 'formset' );
+	protected $supported_types = array(
+		'application/pdf',
+		'image/png',
+		'image/gif',
+		'image/jpeg',
+		'video/jpeg',
+		'text/csv',
+		'application/zip',
+		'application/msword',
+		'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+		'application/vnd.ms-excel',
+		'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+		'application/vnd.ms-powerpoint',
+		'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+		'application/json',
+		'application/xml',
+		'video/mpeg',
+		'audio/mpeg',
+		'text/html',
+		'text/plain',
+		'video/vnd.sealedmedia.softseal-mov',
+		'text/tab-separated-values',
+	);
 
 	public function __construct() {
 		$this->Callbacks = new Callbacks();
@@ -337,10 +360,9 @@ class Models {
 		    }
 		}
 		if ( !empty( $_FILES[$field['meta_key']] ) and !empty( $_FILES[$field['meta_key']]['name'] ) ) {
-			$supported_types = array( 'application/pdf' );
 	        $arr_file_type = wp_check_filetype( basename( $_FILES[$field['meta_key']]['name'] ) );
 	        $uploaded_type = $arr_file_type['type'];
-	        if ( in_array( $uploaded_type, $supported_types ) ) {
+	        if ( in_array( $uploaded_type, $this->supported_types ) ) {
 				$upload = wp_upload_bits( $_FILES[$field['meta_key']]['name'], null, file_get_contents( $_FILES[$field['meta_key']]['tmp_name'] ) );
 	            if ( $upload['error'] ) {
 					wp_die( 'File upload error: ' . $upload['error'] );

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -354,27 +354,27 @@ class Models {
 		if ( isset( $_POST['rm_' . $field['meta_key']] ) and !empty( $_POST['rm_' . $field['meta_key']] ) ) {
 			$file = get_post_meta( $post_ID, $_POST['rm_' . $field['meta_key']], true );
 			if ( unlink( $file['file'] ) ) {
-		        delete_post_meta( $post_ID, $field['meta_key'] );
-		    } else {
-		        wp_die('There was an error trying to delete your file.');
-		    }
+				delete_post_meta( $post_ID, $field['meta_key'] );
+			} else {
+				wp_die('There was an error trying to delete your file.');
+			}
 		}
 		if ( !empty( $_FILES[$field['meta_key']] ) and !empty( $_FILES[$field['meta_key']]['name'] ) ) {
-	        $arr_file_type = wp_check_filetype( basename( $_FILES[$field['meta_key']]['name'] ) );
-	        $uploaded_type = $arr_file_type['type'];
-	        if ( in_array( $uploaded_type, $this->supported_types ) ) {
+			$arr_file_type = wp_check_filetype( basename( $_FILES[$field['meta_key']]['name'] ) );
+			$uploaded_type = $arr_file_type['type'];
+			if ( in_array( $uploaded_type, $this->supported_types ) ) {
 				$upload = wp_upload_bits( $_FILES[$field['meta_key']]['name'], null, file_get_contents( $_FILES[$field['meta_key']]['tmp_name'] ) );
-	            if ( $upload['error'] ) {
+				if ( $upload['error'] ) {
 					wp_die( 'File upload error: ' . $upload['error'] );
-	            } else {
+				} else {
 					$upload['name'] = $_FILES[$field['meta_key']]['name'];
-	                update_post_meta( $post_ID, $field['meta_key'], $upload );
-	            }
-	        }
-	        else {
+					update_post_meta( $post_ID, $field['meta_key'], $upload );
+				}
+			}
+			else {
 				wp_die( 'File upload error: Unsupported type ' . $uploaded_type );
-	        }
-	    }
+			}
+		}
 	}
 
 	/**

--- a/js/functions.js
+++ b/js/functions.js
@@ -94,3 +94,8 @@ jQuery('.datedelbutton').click( function() {
 
     jQuery(this).parent().html('');
 });
+jQuery('.filedelbutton').click( function() {
+    var file_id = jQuery(this).attr('id');
+    jQuery('input[id=rm_' + file_id + ']').val(file_id);
+    jQuery(this).parent().html('');
+});


### PR DESCRIPTION
This adds a file field type to be used for the cms-toolkit. It doesn't look pretty but it sure does work. Here's the list of approved file types given to me by @jameshupp.

This will work similarly to the date field in that a tag will be shown with a delete button and the file name that is used to delete the file, but there is currently not functionality for multiple file's to be uploaded to a single field.
- PDF
- PNG
- GIF
- JPG
- CSV
- ZIP
- DOC(X)
- XLS(X)
- PPT(X)
- JSON
- XML
- MP(E)G
- HTML
- TXT
- MP3
- MOV
- TSV
