### PR TITLE
Add custom file type checking

### DIFF
--- a/inc/README.md
+++ b/inc/README.md
@@ -212,7 +212,7 @@ the 'checkbox' type * `radio` two input fields with values 'true' and 'false'
 * `url` an input with the 'url' type 
 * `link` two inputs, one with the `url` type and another with `text`, validates 
 as an array like `array(0 => 'url', 1 => 'text')`; 
-* `file` generates a button to browse your local file directory and choose a file to upload. Here is a list of approved file types: PDF, PNG, GIF, JPG, CSV, ZIP, DOC(X), XLS(X), PPT(X), JSON, XML, MP(E)G, HTML, TXT, MP3, MOV, TSV
+* `file` generates a button to browse your local file directory and choose a file to upload. You can specify which file types you'd like to limit the field to accepting by creating a `'allowed_file_types'` attribute, which _must_be an array and can only be one of the supported file types. Here is a list of supported file types: PDF, PNG, GIF, JPG, CSV, ZIP, DOC(X), XLS(X), PPT(X), JSON, XML, MP(E)G, HTML, TXT, MP3, MOV, TSV
 * `date` generates a trio of fields: a dropdown for months and two
 input fields for day and year
 * `time` generates a similar trio of fields for hour, minute, and am/pm selection.

--- a/inc/README.md
+++ b/inc/README.md
@@ -212,7 +212,9 @@ the 'checkbox' type * `radio` two input fields with values 'true' and 'false'
 * `url` an input with the 'url' type 
 * `link` two inputs, one with the `url` type and another with `text`, validates 
 as an array like `array(0 => 'url', 1 => 'text')`; 
-* `file` generates a button to browse your local file directory and choose a file to upload. You can specify which file types you'd like to limit the field to accepting by creating a `'allowed_file_types'` attribute, which _must_be an array and can only be one of the supported file types. Here is a list of supported file types: PDF, PNG, GIF, JPG, CSV, ZIP, DOC(X), XLS(X), PPT(X), JSON, XML, MP(E)G, HTML, TXT, MP3, MOV, TSV
+* `file` generates a button to browse your local file directory and choose a file to upload. You can specify which file types you'd like to limit the field to accepting by creating an `'allowed_file_types'` attribute, which _must_ be an array and can only include supported file types.
+
+	Here is a list of supported file types: PDF, PNG, GIF, JPG, CSV, ZIP, DOC(X), XLS(X), PPT(X), JSON, XML, MP(E)G, HTML, TXT, MP3, MOV, TSV
 * `date` generates a trio of fields: a dropdown for months and two
 input fields for day and year
 * `time` generates a similar trio of fields for hour, minute, and am/pm selection.

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -375,6 +375,18 @@ class Models {
 	}
 
 	public function validate_file( $field, $post_ID ) {
+		if ( isset( $field['allowed_file_types'] ) and 
+			( is_array( $field['allowed_file_types'] ) and !empty( $field['allowed_file_types'] ) ) ) {
+			foreach ( $field['allowed_file_types'] as $type ) {
+				if ( in_array( $type, $this->supported_types ) ) {
+					$supported_types[] = $type;
+				} else {
+					wp_die( $type . ' is not a supported type.' );
+				}
+			}
+		} else {
+			$supported_types = $this->supported_types;
+		}
 		if ( isset( $_POST['rm_' . $field['meta_key']] ) and !empty( $_POST['rm_' . $field['meta_key']] ) ) {
 			$file = get_post_meta( $post_ID, $_POST['rm_' . $field['meta_key']], true );
 			if ( unlink( $file['file'] ) ) {
@@ -386,7 +398,7 @@ class Models {
 		if ( !empty( $_FILES[$field['meta_key']] ) and !empty( $_FILES[$field['meta_key']]['name'] ) ) {
 			$arr_file_type = wp_check_filetype( basename( $_FILES[$field['meta_key']]['name'] ) );
 			$uploaded_type = $arr_file_type['type'];
-			if ( in_array( $uploaded_type, $this->supported_types ) ) {
+			if ( in_array( $uploaded_type, $supported_types ) ) {
 				$upload = wp_upload_bits( $_FILES[$field['meta_key']]['name'], null, file_get_contents( $_FILES[$field['meta_key']]['tmp_name'] ) );
 				if ( $upload['error'] ) {
 					wp_die( 'File upload error: ' . $upload['error'] );


### PR DESCRIPTION
This adds an attribute to the file field that sets allowable file types. These types must be apart of the set of supported mime types and be apart of an array.

#### Reviewers
@willbarton 
@dpford 