### PR TITLE
Change where and how date/time/datetime is saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## 1.3.0 - 2015-01-15
 
 ### Added
-- Arbitrary formset functionality
+- Meta-data saving of `date`, `time`, `datetime` fields
 
 ### Fixed
-- Lots of issues with saving and removing fields
-- Some visual issues
+- Readability of those field's taxonomy tags
+- Format of how each field is saved

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 1.4.0
+Version: 1.5.0
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/inc/meta-box-callbacks.php
+++ b/inc/meta-box-callbacks.php
@@ -1,6 +1,8 @@
 <?php
 namespace CFPB\Utils\MetaBox;
 use \CFPB\Utils\Taxonomy;
+use \CFPB\Utils\MetaBox\Models;
+use \DateTime;
 
 class Callbacks {
 	public $taxonomy;
@@ -39,21 +41,17 @@ class Callbacks {
 		global $post;
 		
 		$rmTerm     = 'rm_' . $taxonomy . '_' . $term_num;
-		if ( isset( $_POST[$rmTerm] ) ) {
+		if ( isset( $_POST[$rmTerm] ) and !empty( $_POST[$rmTerm] ) ) {
 			$tounset = get_term_by( 'name', $_POST[$rmTerm], $taxonomy );
 			if ( $tounset ) {
 				$this->Taxonomy->remove_post_term( $post_id, $tounset->term_id, $taxonomy );
 			}
-		}
-		
-		if ( isset($data[$taxonomy] ) ) {
-			$time = strval( strtotime( $data[$taxonomy] ) );
-		} else {
-			$time = strtotime('now');
-			return $time;
-		}
-		if ( $time != strtotime('now') ) {
-			wp_set_object_terms( $post_id, $time, $taxonomy, $append = $multiples );
+			if ( isset( $data[$taxonomy] ) ) {
+				Models::save( $post_id, array( $taxonomy => strval( strtotime( $data[$taxonomy] ) ) ) );
+			}
+		} elseif ( isset( $data[$taxonomy] ) and !empty( $data[$taxonomy] ) ) {
+			wp_set_object_terms( $post_id, $data[$taxonomy], $taxonomy, $append = $multiples );
+			Models::save( $post_id, array( $taxonomy => date( Datetime::ISO8601, strval( strtotime( $data[$taxonomy] ) ) ) ) );
 		}
 	}
 }

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -528,16 +528,16 @@ class HTML {
 							$natdate = date( 'F j, Y @ h:ia T', intval( $term->name ) );
 						}
 						?><span><a id="<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>"
-								  class="tagdelbutton <?php echo esc_attr( $term->name ) ?>"><?php
+								  class="tagdelbutton -<?php echo esc_attr( $term->name ) ?>"><?php
 									echo esc_attr( $term->name );
 								?></a><?php
-							?>&nbsp;<?php echo esc_attr( $natdate );
+							?>&nbsp;<?php echo esc_attr( $term->name );
 						?></span><?php
 					} else {
 						$date = strtotime( $term->name );
 						?><span><a id="<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>"
-								  class="tagdelbutton <?php echo esc_attr( $date ) ?>"><?php
-									echo esc_attr( $term->name );
+								  class="tagdelbutton -<?php echo esc_attr( $term->name ) ?>"><?php
+									echo esc_attr( $date );
 								?></a><?php
 							?>&nbsp;<?php echo esc_attr( $term->name );
 						?></span><?php

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -521,11 +521,11 @@ class HTML {
 					// Checks if the current set term is wholly numeric (in this case a timestamp)
 					if ( is_numeric( $term->name ) ) {
 						if ( $type == 'date' ) {
-							$natdate = date( 'j F, Y', intval( $term->name ) );
+							$natdate = date( 'j F Y', intval( $term->name ) );
 						} elseif ( $type == 'time' ) {
 							$natdate = date( 'h:ia T', intval( $term->name ) );
 						} elseif ( $type == 'datetime' ) {
-							$natdate = date( 'F j, Y @ h:ia T', intval( $term->name ) );
+							$natdate = date( 'F j Y h:ia T', intval( $term->name ) );
 						}
 						?><span><a id="<?php echo esc_attr( $taxonomy ) ?>-check-num-<?php echo esc_attr( $i ) ?>"
 								  class="tagdelbutton -<?php echo esc_attr( $term->name ) ?>"><?php

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -331,6 +331,23 @@ class Models {
 			$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], null, $t );
 		}
 		$data = array($field['taxonomy'] => '');
+		if ( $field['type'] != 'time') {
+			$month = $field['taxonomy'] . '_month';
+			$day = $field['taxonomy'] . '_day';
+			$year = $field['taxonomy'] . '_year';
+			if ( isset($_POST[$month]) ) {
+				$data[$field['taxonomy']] .= $_POST[$month];
+			}
+			if ( isset( $_POST[$day] ) ) {
+				$data[$field['taxonomy']] .= ' ' . $_POST[$day];
+			}
+			if ( isset( $_POST[$year] ) ) {
+				$data[$field['taxonomy']] .= ' ' . $_POST[$year];
+			}
+		}
+		if ( $field['type'] == 'datetime' ) {
+			$data[$field['taxonomy']] .= ' ';
+		}
 		if ( $field['type'] != 'date') {
 			$hour = $field['taxonomy'] . '_hour';
 			$minute = $field['taxonomy'] . '_minute';
@@ -349,34 +366,16 @@ class Models {
 				$data[$field['taxonomy']] .= ' ' . $_POST[$timezone][0];
 			}
 		}
-		if ( $field['type'] == 'datetime' ) {
-			$data[$field['taxonomy']] .= ' ';
-		}
-		if ( $field['type'] != 'time') {
-			$month = $field['taxonomy'] . '_month';
-			$day = $field['taxonomy'] . '_day';
-			$year = $field['taxonomy'] . '_year';
-			if ( isset($_POST[$month]) ) {
-				$data[$field['taxonomy']] .= $_POST[$month];
-			}
-			if ( isset( $_POST[$day] ) ) {
-				$data[$field['taxonomy']] .= ' ' . $_POST[$day];
-			}
-			if ( isset( $_POST[$year] ) ) {
-				$data[$field['taxonomy']] .= ' ' . $_POST[$year];
-			}
-		}
-		if ( $field['type'] == 'time' ) {
-			date_default_timezone_set( $_POST[$field['taxonomy'] . '_timezone'][0] );
-			$date = DateTime::createFromFormat('h:ia T', $data[$field['taxonomy']]);
-		} elseif ( $field['type'] == 'date' ) {
+		if ( $field['type'] == 'date' ) {
 			$date = DateTime::createFromFormat('F j Y', $data[$field['taxonomy']]);
+		} elseif ( $field['type'] == 'time' ) {
+			if ( isset( $_POST[$field['taxonomy'] . '_timezone'] ) )
+				date_default_timezone_set( $_POST[$field['taxonomy'] . '_timezone'][0] );
+			$date = DateTime::createFromFormat('h:ia T', $data[$field['taxonomy']]);
 		} elseif ( $field['type'] == 'datetime' ) {
-			date_default_timezone_set( $_POST[$field['taxonomy'] . '_timezone'][0] );
-			$date = DateTime::createFromFormat('h:ia T F j Y', $data[$field['taxonomy']]);
-		}
-		if ( $field['type'] != 'date') {
-			$this->save( $post_ID, array( $field['taxonomy'] . '_timezone' => $_POST[$field['taxonomy'] . '_timezone'] ) );
+			if ( isset( $_POST[$field['taxonomy'] . '_timezone'] ) )
+				date_default_timezone_set( $_POST[$field['taxonomy'] . '_timezone'][0] );
+			$date = DateTime::createFromFormat('F j Y h:ia T', $data[$field['taxonomy']]);
 		}
 		if ( $date ) {
 			$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $data, null );

--- a/js/functions.js
+++ b/js/functions.js
@@ -89,9 +89,8 @@ jQuery('.tagdelbutton').click( function() {
     var taxAndTagNum = jQuery(this).attr('id').split('-');
     var taxonomy = taxAndTagNum[0];
     var tagNum = taxAndTagNum[3];
-    var term = jQuery(this).attr('class').split(' ')[1];
+    var term = jQuery(this).attr('class').split('-')[1];
     jQuery('input[id=rm_' + taxonomy + '_' + tagNum + ']').val(term);
-
     jQuery(this).parent().html('');
 });
 jQuery('.filedelbutton').click( function() {

--- a/tests/test-meta-box-callbacks.php
+++ b/tests/test-meta-box-callbacks.php
@@ -30,6 +30,9 @@ class MetaBoxCallbacksTest extends \PHPUnit_Framework_TestCase {
 	 */
 	function testDateExpectsWPSetObjectTermsFromAPI() {
 		// Arrange
+		\WP_Mock::wpFunction( 'get_post_meta' );
+		\WP_Mock::wpFunction( 'remove_post_meta' );
+		\WP_Mock::wpFunction( 'update_post_meta' );
 		\WP_Mock::wpFunction('wp_set_object_terms', array('times' => 1));
 		$post_id = 0;
 		$taxonomy = 'category';
@@ -52,8 +55,11 @@ class MetaBoxCallbacksTest extends \PHPUnit_Framework_TestCase {
 	 */
 	function testDateCallsGetTermByWhenAttemptingToDeleteATerm() {
 		// Arrange
+		\WP_Mock::wpFunction( 'get_post_meta' );
+		\WP_Mock::wpFunction( 'remove_post_meta' );
+		\WP_Mock::wpFunction( 'update_post_meta' );
 		$c = new Callbacks();
-		$_POST = array( 'rm_tax_0' => '' );
+		$_POST = array( 'rm_tax_0' => 'term' );
 		\WP_Mock::wpFunction('get_term_by', array('times' => 1, 'return' => false ) );
 		// Act
 		$c->date( 0, 'tax', false, array(), 0 );
@@ -72,6 +78,9 @@ class MetaBoxCallbacksTest extends \PHPUnit_Framework_TestCase {
 	 */
 	function testDateCallsRemovePostTermWhenAttemptingToDeleteATerm() {
 		// Arrange
+		\WP_Mock::wpFunction( 'get_post_meta' );
+		\WP_Mock::wpFunction( 'remove_post_meta' );
+		\WP_Mock::wpFunction( 'update_post_meta' );
 		$_POST = array( 'rm_tax_0' => 'term' );
 		$term = new \StdClass;
 		$term->term_id = 1;
@@ -89,30 +98,6 @@ class MetaBoxCallbacksTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Tests whether the current time will be assigned if non is given.
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group date
-	 * @group taxonomy_save
-	 * 
-	 */
-	function testDateExpectsCurrentTime() {
-		// Arrange
-		$post_id = 0;
-		$taxonomy = 'category';
-		// replace fix time at 12:00 today just in case the test takes longer than 1 second to run (it shouldn't)
-		self::$now = strtotime('12:00');
-		$expected = strtotime('now');
-		// Act
-		$c = new Callbacks();
-		$actual = $c->date($post_id, $taxonomy );
-
-		// Assert
-		$this->assertEquals($expected, $actual, 'Time should be equal to the current time, but was not.');
-	}
-
-	/**
 	 * Test whether a post term will be removed if a rm_{taxonomy} key is passed
 	 *
 	 * @group stable
@@ -122,6 +107,9 @@ class MetaBoxCallbacksTest extends \PHPUnit_Framework_TestCase {
 	 */
 	function testRmTermKeyDateExpectsRemovePostTermCalled() {
 		// Arrange
+		\WP_Mock::wpFunction( 'get_post_meta' );
+		\WP_Mock::wpFunction( 'remove_post_meta' );
+		\WP_Mock::wpFunction( 'update_post_meta' );
 		$post_id = 0;
 		$_POST['rm_category_1'] = 'term';
 		$taxonomy = 'category';


### PR DESCRIPTION
### Changes
Previously, `date`, `time`, and `datetime` field types were saved under a taxonomy as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time). This code will change that. Each of these will still be saved as a taxonomy, but as the following [formats](http://php.net/manual/en/datetime.formats.date.php) for better readability:
* `date` --> `m DD YY` _ex: January 1 2015_
* `time` --> `hh:MMmeridan tz` _ex: 4:30am American/New\_York_
* `datetime` --> `m DD YY hh:MMmeridan tz` _ex: January 1 2015 4:30am American/New\_York_

Additionally, they are saved as the post meta data as the [ISO8601 format](http://php.net/manual/en/class.datetime.php#datetime.constants.iso8601) regardless of field type. This keeps the format consistent and simplify parsing. Changes to the flask processor will be in a future pull request.

##### More changes thrown in
* Removed unnecessary test due to code change
* Refactored tests

#### Reviewers
@willbarton 
@dpford 
@Scotchester 