### PR TITLE
Remove browser validation from the url field

### DIFF
--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 1.5.2
+Version: 1.5.3
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government
@@ -44,7 +44,7 @@ function cfpb_cms_toolkit_scripts() {
 	wp_enqueue_style( 'cms_toolkit_styles' );
 }
 function post_edit_form_tag( ) {
-   echo ' enctype="multipart/form-data"';
+   echo ' enctype="multipart/form-data" novalidate';
 }
 
 if (PHP_VERSION_ID >= 50300) {

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -44,7 +44,7 @@ function cfpb_cms_toolkit_scripts() {
 	wp_enqueue_style( 'cms_toolkit_styles' );
 }
 function post_edit_form_tag( ) {
-   echo ' enctype="multipart/form-data" novalidate';
+   echo ' enctype="multipart/form-data"';
 }
 
 if (PHP_VERSION_ID >= 50300) {

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -309,10 +309,10 @@ class HTML {
 		?><div class="link-field <?php echo "{$meta_key}" ?>"><?php
 		if ( ! isset( $existing[0] ) || ! isset( $existing[1] ) ) { 
 				$this->single_input( $meta_key . "_text", $value, 'text', $required, NULL, 'Link Text', 'Url text here', $form_id );
-				$this->single_input( $meta_key . "_url", $value, 'url', $required, NULL, 'Link URL', 'Url here', $form_id );
+				$this->single_input( $meta_key . "_url", $value, 'text', $required, NULL, 'Link URL', 'Url here', $form_id );
 		} else { 
 				$this->single_input( $meta_key . "_text", $existing[1], 'text', $required, NULL, 'Link Text', NULL, $form_id );
-				$this->single_input( $meta_key . "_url", $existing[0], 'url', $required, NULL, 'Link URL', NULL, $form_id );
+				$this->single_input( $meta_key . "_url", $existing[0], 'text', $required, NULL, 'Link URL', NULL, $form_id );
 		}
 		?></div><?php
 	}


### PR DESCRIPTION
### Why do we need this
Content folks would like to be able to add relative urls in the url field so they won't have to update every post after RAMPing.

#### And they can't do it because...
The browser is doing it's own validation. Any data entered into a url type input field must conform to the validations' standards. It does not. 

#### Okay so how did we fix it?
~~We can specify an attribute in the form tag named `novalidate` documented [here](http://www.w3schools.com/tags/att_input_formnovalidate.asp).~~ We change the input type from `url` to `text` to workaround the validation.

### Side effects?
Yes. We are relying on this kind of validation for making sure the entered data is a valid url. ~~stopping the submission of data without required fields. This would allow fields that we've specified as required to be submitted _without data_. Though, we only have a couple fields at most that use this, AND~~ we should be doing our own validation anyway, not relying on the browsers. I smell another PR coming....

Anyway, if you've read this far then congratulations! You've spent more time reading about this than the time it would take to actually perform the review. Sorry for wasting your time, and thanks for reviewing!

@dpford @willbarton @Scotchester 