### PR TITLE
Change the way link is saved for better json output.

### DIFF
--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -305,14 +305,14 @@ class HTML {
 
 	public function link_input( $meta_key, $value, $required, $label, $form_id = NULL ) {
 		$post_id = get_the_ID();
-		$existing = get_post_meta( $post_id, $meta_key, false);
+		$existing = get_post_meta( $post_id, $meta_key, true);
 		?><div class="link-field <?php echo "{$meta_key}" ?>"><?php
-		if ( ! isset( $existing[0] ) || ! isset( $existing[1] ) ) { 
+		if ( ! isset( $existing['url'] ) || ! isset( $existing['text'] ) ) {
 				$this->single_input( $meta_key . "_text", $value, 'text', $required, NULL, 'Link Text', 'Url text here', $form_id );
 				$this->single_input( $meta_key . "_url", $value, 'text', $required, NULL, 'Link URL', 'Url here', $form_id );
 		} else { 
-				$this->single_input( $meta_key . "_text", $existing[1], 'text', $required, NULL, 'Link Text', NULL, $form_id );
-				$this->single_input( $meta_key . "_url", $existing[0], 'text', $required, NULL, 'Link URL', NULL, $form_id );
+				$this->single_input( $meta_key . "_text", $existing['text'], 'text', $required, NULL, 'Link Text', NULL, $form_id );
+				$this->single_input( $meta_key . "_url", $existing['url'], 'text', $required, NULL, 'Link URL', NULL, $form_id );
 		}
 		?></div><?php
 	}

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -232,18 +232,16 @@ class Models {
 		 and isset( $_POST["{$field['meta_key']}_text"] ) ) {
 			$url = $_POST["{$field['meta_key']}_url"];
 			$text = $_POST["{$field['meta_key']}_text"];
-			$full_link = array( 0 => $url, 1 => $text );
-			$existing = get_post_meta( $post_ID, $field['meta_key'], $single = false );
+			$full_link = array( 'url' => $url, 'text' => $text );
+			$existing = get_post_meta( $post_ID, $field['meta_key'], $single = true );
 
 			if ( empty( $_POST["{$field['meta_key']}_url"] )
 			  or empty( $_POST["{$field['meta_key']}_text"] ) ) {
 				delete_post_meta( $post_ID, $field['meta_key']);
 			} elseif ( empty($existing) ) {
-				add_post_meta( $post_ID, $field['meta_key'], $url, false );
-				add_post_meta( $post_ID, $field['meta_key'], $text, false );
+				add_post_meta( $post_ID, $field['meta_key'], $full_link, false );
 			} elseif ( $existing != $full_link ) {
-				update_post_meta( $post_ID, $field['meta_key'], $url, $existing[0] );
-				update_post_meta( $post_ID, $field['meta_key'], $text, $existing[1] );
+				update_post_meta( $post_ID, $field['meta_key'], $full_link, $existing );
 			}
 		}
 	}

--- a/tests/test-meta_box_models.php
+++ b/tests/test-meta_box_models.php
@@ -1301,7 +1301,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		$form->fields = $field;
 		\WP_Mock::wpFunction(
 			'add_post_meta',
-			array( 'times' => 2, 'return' => true )
+			array( 'times' => 1, 'return' => true )
 		);
 		$post = new \StdClass;
 		\WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
@@ -1334,7 +1334,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		$form->fields = $field;
 		\WP_Mock::wpFunction(
 			'add_post_meta',
-			array( 'times' => 2, 'return' => true )
+			array( 'times' => 1, 'return' => true )
 		);
 		$post = new \StdClass;
 		\WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
@@ -1375,7 +1375,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		// );
 		\WP_Mock::wpFunction(
 			'update_post_meta',
-			array( 'times' => 2, 'return' => true)
+			array( 'times' => 1, 'return' => true)
 		);
 		\WP_Mock::wpFunction(
 			'get_post_meta',
@@ -1411,7 +1411,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'meta_key' => 'link',
 			'howto' => "Some howto text",
 		);
-		$existing = array( 'http://example.com', 'example.com');
+		$existing = array( 'url' => 'http://example.com', 'text' => 'example.com');
 		$form = new TestNumberField();
 		$post_id = 1;
 		$form->fields = $field;


### PR DESCRIPTION
A request for the output of a link was made to change it from this:
```
link : {
   'http://example.com',
   'sample text'
}
```
to this:
```
link : {
   url: 'http://example.com',
   text: 'sample text'
}
```

## Removals

- Additional calls to `add_post_meta` and `update_post_meta` that were unnecessary with the new setup.

## Changes

- Data received from `get_post_meta` is now using the argument `$single = true` because the data saved is a serialized array.
- How the received data is accessed/saved/rendered
- Associated tests

## Testing

- `phpunit` or `./vendor/bin/phpunit`

## Review

- @willbarton 
- @dpford 
- @Scotchester 

## Notes

- This will not output the correct values in the json output without first having [this PR used.](https://github.com/cfpb/wp-json-api/pull/5)