### PR TITLE
Set menu names for custom post types to be plural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,42 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
-## 1.3.0 - 2015-01-15
+## 1.5.3 - 2015-04-01
+
+### Changed
+- `url` field output (in the meta box) from `tpe="url"` to `type="text"`,
+  so that relative URLs will not fail native browser validation.
+
+
+## 1.5.2 - 2015-03-30
+
+### Fixed
+- Version number correction
+
+
+## 1.5.1 - 2015-03-26
+
+### Added
+- labeling to link and "how to" to formsets
+
+### Changed
+- Refactored some code
+
+### Fixed
+- A bug that ignored validation for some field types under certain circumstances
+
+
+## 1.5.0 - 2015-03-24
+
+### Changed
+- Where and how date/time/datetime is saved
+- Refactored tests
+
+### Removed
+- Obsolete tests
+
+
+## 1.4.0 - 2015-03-20
 
 ### Added
 - Meta-data saving of `date`, `time`, `datetime` fields
@@ -12,3 +47,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Fixed
 - Readability of those field's taxonomy tags
 - Format of how each field is saved
+
+
+## 1.3.0 - 2015-01-15
+
+### Added
+- Arbitrary formset functionality
+
+### Fixed
+- Lots of issues with saving and removing fields
+- Some visual issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## 1.5.2 - 2015-03-30
 
-### Fixed
-- Version number correction
+### Changed
+- Version number due to confusion about misplaced tags.
+
+**This version provides no functional changes over 1.5.1.**
+It is only being included here so it doesn't appear that we skipped a version.
 
 
 ## 1.5.1 - 2015-03-26
@@ -42,10 +45,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## 1.4.0 - 2015-03-20
 
 ### Added
-- Meta-data saving of `date`, `time`, `datetime` fields
+- Meta-data saving of `wysiwyg`, `date`, `time`, `datetime` fields
 
 ### Fixed
-- Readability of those field's taxonomy tags
+- Readability of the date/time fields' taxonomy tags
 - Format of how each field is saved
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 1.5.4 - 2015-04-15
+
+### Changed
+- Names of our custom post types in the sidebar to be plural, matching the
+  standard for default WordPress post types.
+
+
 ## 1.5.3 - 2015-04-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## 1.5.3 - 2015-04-01
 
 ### Changed
-- `url` field output (in the meta box) from `tpe="url"` to `type="text"`,
+- `url` field output (in the meta box) from `type="url"` to `type="text"`,
   so that relative URLs will not fail native browser validation.
 
 

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 1.5.3
+Version: 1.5.4
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -308,8 +308,8 @@ class HTML {
 		$existing = get_post_meta( $post_id, $meta_key, false);
 		?><div class="link-field <?php echo "{$meta_key}" ?>"><?php
 		if ( ! isset( $existing[0] ) || ! isset( $existing[1] ) ) { 
-				$this->single_input( $meta_key . "_text", $value, 'text', $required, NULL, 'Link Text', 'Url text here', $form_id );
-				$this->single_input( $meta_key . "_url", $value, 'text', $required, NULL, 'Link URL', 'Url here', $form_id );
+				$this->single_input( $meta_key . "_text", $value, 'text', $required, NULL, 'Link Text', 'Link text here', $form_id );
+				$this->single_input( $meta_key . "_url", $value, 'text', $required, NULL, 'Link URL', 'URL here', $form_id );
 		} else { 
 				$this->single_input( $meta_key . "_text", $existing[1], 'text', $required, NULL, 'Link Text', NULL, $form_id );
 				$this->single_input( $meta_key . "_url", $existing[0], 'text', $required, NULL, 'Link URL', NULL, $form_id );

--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -43,7 +43,7 @@ class PostType {
 			'not_found' => 'No ' . $plural . ' found.',
 			'not_found_in_trash' => 'No ' . $plural . ' found.',
 			'parent_item_colon' => 'Parent ' . $name . ':',
-			'menu_name' => $name,
+			'menu_name' => $plural,
 		);
 		$defaults = array(
 			'labels'              => $labels,


### PR DESCRIPTION
The WordPress standard for post type names in the sidebar is to use the
plural form of the name. This corrects our custom post types to match
that standard.

Also includes a big CHANGELOG catch-up.

Review:
- @kurtw