### PR TITLE
Fix checkbox saving bug

### DIFF
--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -516,6 +516,11 @@ class Models {
 				save
 			*/
 			if ( ! isset( $_POST[$key] ) ) {
+				/*
+					Unchecked checkboxes that were previously checked
+					need the meta_key/slug to be manually added to the
+					$_POST global to be properly saved.
+				*/
 				if ( $field['type'] == 'boolean' ) {
 					$_POST[$key] = null;
 				} else {

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -516,7 +516,11 @@ class Models {
 				save
 			*/
 			if ( ! isset( $_POST[$key] ) ) {
-				return;
+				if ( $field['type'] == 'boolean' ) {
+					$_POST[$key] = null;
+				} else {
+					return;
+				}
 			}
 			$value = $_POST[$key];
 			if ( $field['type'] == 'number' ) {


### PR DESCRIPTION
Fields of type `boolean` are rendered as a checkbox. The checkbox saves as intended when it is selected and then saved but then cannot be unchecked and then saved. This is a quick fix for that.

@dpford @Scotchester @willbarton 