### PR TITLE
Serialize WordPress data and make any field repeatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 2.0.0 - 2015-05-04
+
+### Changed
+- Serialize all custom meta box meta data
+- Remove `formset` type
+- Added `'repeated'` parameter for repeating a field of any type
+- Fixed some in-code documentation and README
+- Added backwards compatibility that helps phase out old data (temporary)
+- Changed most ineffective WP_Error's to call wp_die() instead
+
 ## 1.5.6 - 2015-05-06
 
 ### Changed

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,11 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
+<<<<<<< HEAD
 Version: 1.5.6
+=======
+Version: 2.0.0
+>>>>>>> Serialize data, remove formset type, make any field repeatable, add/change/remove tests
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,11 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-<<<<<<< HEAD
-Version: 1.5.6
-=======
 Version: 2.0.0
->>>>>>> Serialize data, remove formset type, make any field repeatable, add/change/remove tests
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/css/styles.css
+++ b/css/styles.css
@@ -13,15 +13,27 @@ a {
 
 .cms-toolkit-wrapper {
     margin-bottom: 0.5em;
+    margin-left: 1em;
 }
-.cms-toolkit-wrapper {
-    margin-left: .5em;
+div.form {
+    padding: .5em;
 }
-div[id*="formset"] {
-    background: #F1F2F2;
-    padding: .5em 0 .5em .5em;
+div.set {
+    border-left: 2px solid #F0F2F2;
+    /*padding: .5em;*/
 }
-.cms-toolkit-wrapper > div > .formset-header {
+h2.form-header {
+    border-bottom: 1px solid #F0F2F2;
+    padding: 0 !important;
+    margin: 0 0 2px 0 !important;
+}
+p.howto {
+    margin-bottom: 3px;
+}
+h3.set-header, label.set-header {
+    margin: 0 0 2px 1em !important;
+}
+.cms-toolkit-wrapper > div > .set-header {
     margin: 0;
     font-size: 1.2em;
 }
@@ -35,7 +47,7 @@ div[id*="formset"] {
 }
 .cms-toolkit-input,
 .cms-toolkit-textarea,
-.cms-toolkit-checkbox,
+.cms-toolkit-checkbox
 {
     margin-top: 0.5em;
     margin-left: 0.5em;

--- a/css/styles.css
+++ b/css/styles.css
@@ -71,3 +71,6 @@ h3.set-header, label.set-header {
 input:required {
     border: 1px solid red;
 }
+.toggle-repeated-field {
+cursor: pointer;
+}

--- a/inc/README.md
+++ b/inc/README.md
@@ -36,7 +36,7 @@ In this example we create a taxonomy for the 'custom_post_type's called Sub
 Category. You still need to hook `register_my_taxonomy` into `init`.
 
 Also contained here is `remove_post_term` which can be used to remove a term by
-ID or slug from a post.
+ID or key from a post.
 
 ## Simplified post type registration
 
@@ -80,23 +80,21 @@ class TestMetaBox extends \CFPB\Utils\MetaBox\Models {
     public $fields = array(
         'field_one' => array(
             'title' => 'This is a field',
-            'slug' => 'field_one',
+            'key' => 'field_one',
             'type' =>'text_area',
             'params' => array(
                 'cols' => 27,
             ),
             'placeholder' => 'Enter text',
             'howto' => 'Type some text',
-            'meta_key' => 'field_one',
         ),
         'field_two' => array(
-            'slug' => 'field_two',
+            'key' => 'field_two',
             'title' => 'This is another field',
             'type' => 'number',
             'params' => array(),
             'placeholder' => '0-100',
             'howto' => 'Type a number',
-            'meta_key' => 'category',
         ),
     );
 
@@ -155,27 +153,29 @@ This class also contains methods for validating and saving this form, too. Lines
 into `save_post` as illustrated above.
 
 Because all of these functions are contained in classes you are extending, you 
-can overwrite them if needed. Just declare a function with the same name as the 
+can overwrite them if needed. Just declare a function with the same name as the
 one in the parent class and WordPress will use yours instead of ours. If you 
-want to still run the parent's version, you can always call `parent::overwritten_function_name()`. In certain cases you can also fully replace a class from the cms-toolkit by injecting a new dependency. See the unit tests for an example of how to do this.
+want to still run the parent's version, you can always call 
+`parent::overwritten_function_name()`. In certain cases you can also fully
+replace a class from the cms-toolkit by injecting a new dependency. See the
+unit tests for an example of how to do this.
 
 ### Fields
 
 A meta box class can accept many different field types that correspond to valid
-HTML elements. Each field array should contain the following keys: 'slug', 'title' or 'label', 'type', 'params', 'placeholder', 'howto', and 'meta_key'. It can also contain 'class', which assigns a class to a div wrapping the header and fields. With the exception of 'params' these are all strings. A field array like the following:
+HTML elements. Each field array should contain the following keys: 'key', 'title' or 'label', 'type', 'params', 'placeholder', and 'howto'. It can also contain 'class', which assigns a class to a div wrapping the header and fields. With the exception of 'params' these are all strings. A field array like the following:
 
 ```php 
 <?php 
     'checkbox' => array(
         'title' => 'Checkbox',
-        'slug' => 'checkbox',
+        'key' => 'checkbox',
         'label' => 'A Checkbox',
         'class' => 'some-class',
         'type' => 'boolean',
         'params' => array(),
         'placeholder' => '',
         'howto' => 'Check the box',
-        'meta_key' => 'boolean_one',
     ),
 ?> 
 ```
@@ -201,7 +201,10 @@ correspond to IDs and classes used in the WordPress admin. Changing the value of
 below. Check the unit tests for examples of how to use each type.
 
 * `text_area` generates a text area meta box.
-* `wysiwyg` calls `wp_editor` to generate a text editor. Defaults to TinyMCE with Quicktags enabled. A `params` array is directly related to the `settings` array seen [here](http://codex.wordpress.org/Function_Reference/wp_editor) so use it the same way.
+* `wysiwyg` calls `wp_editor` to generate a text editor. Defaults to TinyMCE
+with Quicktags enabled. A `settings` array is directly related to the `settings`
+array seen [here](http://codex.wordpress.org/Function_Reference/wp_editor) so
+use it the same way.
 * `number` generates an input field with the number type, optionally add a 
 'max_num' key to the params array to limit the length of input. For example:
 `'param' => array( 'max_length' => 2),` 
@@ -212,28 +215,36 @@ the 'checkbox' type * `radio` two input fields with values 'true' and 'false'
 * `url` an input with the 'url' type 
 * `link` two inputs, one with the `url` type and another with `text`, validates 
 as an array like `array(0 => 'url', 1 => 'text')`; 
-* `file` generates a button to browse your local file directory and choose a file to upload. You can specify which file types you'd like to limit the field to accepting by creating an `'allowed_file_types'` attribute, which _must_ be an array and can only include supported file types.
+* `file` generates a button to browse your local file directory and choose a
+file to upload. You can specify which file types you'd like to limit the field
+to accepting by creating an `'allowed_file_types'` attribute, which _must_ be
+an array and can only include supported file types.
 
-	Here is a list of supported file types: PDF, PNG, GIF, JPG, CSV, ZIP, DOC(X), XLS(X), PPT(X), JSON, XML, MP(E)G, HTML, TXT, MP3, MOV, TSV
+    Here is a list of supported file types: PDF, PNG, GIF, JPG, CSV, ZIP,
+    DOC(X), XLS(X), PPT(X), JSON, XML, MP(E)G, HTML, TXT, MP3, MOV, TSV
 * `date` generates a trio of fields: a dropdown for months and two
 input fields for day and year
-* `time` generates a similar trio of fields for hour, minute, and am/pm selection.
+* `time` generates a similar trio of fields for hour, minute, and am/pm
+selection.
 * `datetime` calls both `date` and `time` to generate a datetime set of fields.
 * `select` generates a `<select>` field with options specified in the 'params' 
 array. For example `'param' => array( 'one', 'two', 'three',),` 
-* `multiselect` is identical to `select` except that it passes the 'multiple' attribute, generating a multiselect box styled with [multiselect.js](http://loudev.com) 
-* `taxonomyselect` generates a `<select>`
-field with options pulled from the terms attached to the taxonomy specified in
-`meta_key` 
-* `nonce` generates a WordPress Nonce field using 'slug' for the ID 
+* `multiselect` is identical to `select` except that it passes the 'multiple'
+attribute, generating a multiselect box styled with [multiselect.js](http://loudev.com) 
+* `taxonomyselect` generates a `<select>` field with options pulled from the
+terms attached to the taxonomy specified in `key` 
+* `nonce` generates a WordPress Nonce field using 'key' for the ID 
 * `hidden` generates a hidden field with a value you can pass in 'params' 
 * `post_select` generates a drop down menu of all posts. The array passed to
 'params' will be passed to `get_posts` and [you can use all the
 keys](http://codex.wordpress.org/Template_Tags/get_posts). 
-* `fieldset` to make a set of fields that affect the same meta key ([see  below](#fieldsets))
-* `formset` create multiple sets of fields (not necessarily `fieldset`s)([see  below](#formsets))
+* `fieldset` to make a set of fields that affect the same meta key ([see below](#fieldsets))
 
-__Note:__ invalid 'type' values will generate nothing and cause validation errors and invalid values for `$post_type` or `$context` will generate `WP_Error`s. The `date`, `time`, and `datetime` fields also generate a tag field, similar to Wordpress tags, that show the data saved from that field and can be removed to delete that data.
+__Note:__ invalid 'type' values will generate nothing and cause validation
+errors and invalid values for `$post_type` or `$context` will generate
+`WP_Error`s. The `date`, `time`, and `datetime` fields also generate a tag
+field, similar to Wordpress tags, that show the data saved from that field and
+can be removed to delete that data.
 
 ### Fieldsets
 
@@ -243,36 +254,35 @@ book and want a way to save a phone number and a description to the `phone` key
 . You'll need two fields, one text field limited to 10 characters and another 
 text_area field limited to 40 characters. The example below will save the 
 number and description to meta keys `phone_num` and `phone_desc`.
-
 ```php
 <?php 
 $this->fields = array(
     'phone' => array(
         'title' => 'Phone number',
-        'slug' => 'phone',
+        'key' => 'phone',
         'type' => 'fieldset',
         'fields' => array(
             array(
                 'type' => 'text',
                 'max_length' => 11,
                 'label' => 'Number',
-                'meta_key' => 'number',
+                'key' => 'number',
             ),
             array(
                 'type' => 'text',
                 'max_length' => 40,
                 'label' => 'Description',
-                'meta_key' => 'desc',
+                'key' => 'desc',
             ),
         ),
-        'meta_key' => 'phone',
         'howto' => '',
     ),
 ); 
 ?>
 ```
 
-That form data will be saved to the `phone_number` and `phone_desc` custom-field keys like this:
+That form data will be saved to the `phone_number` and `phone_desc`
+custom-field keys like this:
 ```php
 <?php 
 $phone_number = array( '5555555', ); 
@@ -280,59 +290,78 @@ $phone_desc = array( 'Description of the phone number', );
 ?>
 ```
 
-### Formsets
+### Repeat a Field
 
-Formset is a feature that allows you to repeat a set of fields which can be repeated up to the maximum value. Each of the fields are saved individually but have a strict naming convention to maintain uniquity. This is discussed further below.
-
-As an example of how to use them, think about this user story: As a content editor, I want to create a page that has a main header and a listing of at least one, but no more than six, articles, each of which has its own headline and description.
-
-To create the listing of articles, we could either create 6 text and text area fields within a single meta box's `fields` array with `meta_key`'s like `header_1`, `description_1`, `header_2`, `description_2`, and so on, or we could make a formset of the fields with parameters to set how many we want so we don't have to create all those fields seperately. That code looks like this:
+In the situation where it makes sense to be able to repeat a field (or even a
+`fieldset`), setting a parameter named `repeated` in the `params` array would
+meet this need.
 ```php
 <?php
     $fields =  array(
-    	'main_header' => array(
-        	'title' => 'Main Page Header',
-            'label' => 'Main Header',
-            'slug => 'main_header',
+        'main_headers' => array(
+            'title' => 'Main Page Header',
+            'label' => 'Main Page Header',
+            'plural' => 'Main Page Headers',
+            'key' => 'main_header',
             'type' => 'text',
-            'meta_key' => 'main_header',
-        ),
-        'articles' => array(
-        	'title' => 'Article',
-            'slug' => 'articles',
-            'type' => 'formset',
-            'fields' => array (
-                array (
-                    'type' => 'text',
-                    'label' => 'Headline',
-                    'meta_key' => 'headline',
-                ),
-                array (
-                    'type' => 'text_area',
-                    'label' => 'Description',
-                    'params' => array(
-                        'rows' => 5,
-                        'cols' => 100,
-                    ),
-                    'meta_key' => 'desc',
-                ),
-            ),
             'params' => array(
-                'init_num_forms' => 1,
-                'max_num_forms' => 6,
+                'repeated' => array(
+                    'min' => 1,
+                    'max' => 3
+                ),
             ),
-            'meta_key' => 'articles',
         ),
     );
 ?>
 ```
-As you can see, we have two fields in the metabox's `fields` array; one `text` field for the main page's header and another `formset` field for each article's header and description. The formset typed field has a `fields` array with more fields in it. Those fields are repeated according to the parameter's set in the `params` array. The `init_num_forms` is what controls how many of the formsets are displayed by default and `max_num_forms` is how many formsets there are total.
+The `params` array has an array set called `repeated` with two pairs named `min`
+and `max` that hold the minimum required and maximum possible fields. *Note*:
+`min` must be less than or equal to `max`.
 
-Every field type is supported for this use. That means that you could declare a _formset within a formset_. Think of each of those articles from the example before. If we wanted to have at least 2 but at most 3 links associated with each article, we could declare a formset as one of the fields of the article formset.
+_Every field type is supported for this use, even `fieldset`._
 
-The **naming convention** for formset fields are how each of the fields are saved and retrieved uniquely from the database. The `meta_key` is key that the data is associated with. The name of each field of a formset is as such: `<formset meta_key>_<formset iteration integer>_<field meta_key`. So the `meta_key` of each field of the formset in the above example would be `articles_0_headline`, `articles_0_desc`, `articles_1_headline`, `articles_1_desc`, etc until the max number of formsets. This means that _without the `meta_key`, formsets will not work at all_.
-
-**Note**: It is important to note that in the example the fields of the metabox's `fields` array are associated with a string. (In the formset example, there were two fields; one field was called `main_header` and the other was called `articles`.) This is not supported in the formset fields array. As above, each field in the `fields` array in the formset is an unnamed array.
+The **naming convention** for fields in the front-end is how each of the fields
+are declared. If a text field is declared in a fieldset, then the `key` of both
+fields will be concatenated to provide a unique key, for example: 
+`<fieldset-key>_<field-key>`. For repeated fields, the `key` of the field will
+be concatenated with the number of which it corresponds, for example: 
+`<field-key>_<repeated-number>`. So the field example above would have the
+first field's key be this: `main_header_0`. You can even have repeated
+`fieldset`s!
+```php
+<?php 
+$this->fields = array(
+    'phone' => array(
+        'title' => 'Phone number',
+        'key' => 'phone',
+        'type' => 'fieldset',
+        'fields' => array(
+            array(
+                'type' => 'text',
+                'max_length' => 11,
+                'label' => 'Number',
+                'key' => 'number',
+            ),
+            array(
+                'type' => 'text',
+                'max_length' => 40,
+                'label' => 'Description',
+                'key' => 'desc',
+            ),
+        ),
+        'howto' => '',
+        'params' => array(
+            'repeated' => array(
+                'min' => 1,
+                'max' => 3
+            )
+        )
+    ),
+); 
+?>
+```
+The _first_ text field of the _second_ fieldset would then have `phone_1_number`
+as the key.
 
 ## Capabilities
 

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -11,78 +11,91 @@ class HTML {
 		'hidden' => array( 'nonce', 'hidden', 'separator', 'fieldset' ),
 		);
 
-	public function draw( $field, $form_id = NULL ) {
+	public function draw( $field, $set_id = NULL ) {
 		if ( empty( $field ) ) {
-			return new WP_Error( 'field_required', 'You need to pass a field array to this method. You passed a '. gettype( $field ) . ' .');
+			wp_die( 'field_required', 'You need to pass a field array to this method. You passed a '. gettype( $field ) . ' .');
 		}
-		?><div class="cms-toolkit-wrapper<?php if (isset( $field['class'] )) { echo ' ' . esc_attr( $field['class'] ); } ?>"><?php
-		if ( $field['type'] !== 'formset' and isset( $field['title'] ) ) {
-			?><h4 id="<?php echo "{$field['meta_key']}"; ?>" ><?php
+		?><div class="cms-toolkit-wrapper<?php echo isset( $field['class'] ) ?  ' ' . esc_attr( $field['class'] ) : null; ?>"><?php
+		if ( !isset( $field['params']['repeated'] ) and isset( $field['title'] ) ) {
+			?><h4 id="<?php echo "{$field['key']}"; ?>" ><?php
 				echo "{$field['title']}"; 
 			?></h4><?php
 		}
-		if ( $field['type'] == 'formset' ) {
-			$this->draw_formset( $field );
-		} elseif ( $field['type'] == 'fieldset' ) {
+		if ( isset( $field['params']['repeated'] ) ) {
+			$this->draw_repeated_fields( $field );
+		} else {
+			if ( $field['type'] == 'fieldset' ) {
 			?><fieldset><?php
 				foreach ($field['fields'] as $f) {
-					$this->draw( $f, $form_id );
+					$this->draw( $f, $set_id );
 				}
 			?></fieldset><?php				
-		} elseif ( in_array( $field['type'], $this->elements['inputs'] ) ) {
-			$this->draw_input( $field, $form_id );
-		} elseif ( in_array( $field['type'], $this->elements['selects'] ) ) {
-			$this->pass_select( $field, $form_id );
-		} elseif ( $field['type'] == 'hidden' ) {
-			$this->hidden( $field['meta_key'], $field['value'], $form_id );
-		} elseif ( $field['type'] == 'nonce' ) {
-			wp_nonce_field( plugin_basename( __FILE__ ), $field['meta_key'] );
-		}
-		if ( isset( $field['howto'] ) and $field['type'] != 'formset' ) { 
-			?><p class="howto"><?php echo esc_attr( $field['howto'] ) ?></p><?php
+			} elseif ( in_array( $field['type'], $this->elements['inputs'] ) ) {
+			$this->draw_input( $field, $set_id );
+			} elseif ( in_array( $field['type'], $this->elements['selects'] ) ) {
+				$this->pass_select( $field, $set_id );
+			} elseif ( $field['type'] == 'hidden' ) {
+				$this->hidden( $field['key'], $field['value'], $set_id );
+			} elseif ( $field['type'] == 'nonce' ) {
+				wp_nonce_field( plugin_basename( __FILE__ ), $field['key'] );
+			}
+			if ( isset( $field['howto'] ) ) {
+				?><p class="howto"><?php echo esc_attr( $field['howto'] );?></p><?php
+			}
 		}
 		?></div><?php
 	}
 
-	public function draw_formset( $field ) {
-		$post_id = get_the_ID();	
-		$post_data = get_post_custom( $post_id );
-		$form_id = $this->get_formset_id( $field['meta_key'] );
-		$init = isset( $field['init'] ) ? true : false;
-		$existing = array();
-		$this->get_existing_data( $field, $existing, $post_data );
-		?><div id="<?php echo "{$field['meta_key']}_formset"; ?>"<?php
-		  if ( empty( $existing ) and ! $init ) { echo ' class="hidden new" disabled'; } ?>><?php
-			?><h4 id="<?php echo "{$field['meta_key']}_header"; ?>" class="formset-header<?php
-			if ( empty( $existing ) and ! $init ) { echo ' hidden'; } ?>"><?php 
-				echo isset( $field['title'] ) ? $field['title'] : "Formset";
-				?><a class="toggle_form_manager <?php
-					echo "{$field['meta_key']} remove {$form_id}";
-					if ( empty( $existing ) and ! $init ) { echo " hidden"; } 
-					?>" href="#remove-formset_<?php echo $form_id; ?>">Remove</a><?php
-			?></h4><?php
-				if ( isset( $field['howto'] ) ) { 
-					?><p class="howto"><?php echo esc_attr( $field['howto'] ) ?></p><?php
+	public function draw_repeated_fields( $field ) {
+		$post_id = get_the_ID();
+		?><div id="<?php echo "{$field['key']}"; ?>" class="form"><?php
+			?><h2 id="<?php echo "{$field['key']}-header"; ?>" class="form-header"><?php
+				echo isset( $field['plural'] ) ? $field['plural'] :
+						( isset( $field['title'] ) ? $field['title'] :
+							( isset( $field['label'] ) ? $field['label'] :
+								"Create a plural/title/label." ) );
+			?></h2><?php
+			if ( isset( $field['howto'] ) ) {
+				?><p class="howto"><?php echo esc_attr( $field['howto'] ); ?></p><?php
+			}
+			foreach ( $field['fields'] as $f ) {
+			?><div class="cms-toolkit-wrapper set <?php echo isset( $field['class'] ) ?  ' ' . esc_attr( $field['class'] ) : null; ?>"><?php
+				$set_id = $this->get_set_id( $f['key'] );
+				$existing = $this->get_existing_data( $f );
+				if ( isset( $f['title'] ) and !empty( $f['title'] ) ) {
+					?><h3 id="<?php echo "{$f['key']}-header"; ?>" class="set-header"><?php
+						echo esc_attr( $f['title'] );
+				} elseif ( isset( $f['label'] ) and !empty( $f['label'] ) ) {
+					?><label id="<?php echo "{$f['key']}-header"; ?>" class="cms-toolkit-file block-label set-header ?>"><?php
+						echo esc_attr( $f['label'] );
 				}
-			foreach ($field['fields'] as $f) {
-				$this->draw( $f, $form_id );
+					?><a class="toggle-repeated-field <?php echo "{$f['key']} add {$set_id}";
+						echo ( ! $existing and ! $f['init'] ) ? null : " hidden"; ?>"><?php
+						?>&nbsp;<span class="dashicons dashicons-plus-alt"></span><?php
+					?></a><?php
+					?><a class="toggle-repeated-field <?php echo "{$f['key']} remove {$set_id}";
+						echo ( ! $existing and ! $f['init'] ) ? " hidden" : null; ?>"><?php
+							?>&nbsp;<span class="dashicons dashicons-dismiss"></span><?php
+					?></a><?php
+				if ( isset( $f['title'] ) and !empty( $f['title'] ) ) {
+					?></h3><?php
+					unset( $f['title'] );
+				} elseif ( isset( $f['label'] ) and !empty( $f['label'] ) ) {
+					?></label><?php
+					unset( $f['label'] );
+				}
+				?><div id="<?php echo "{$f['key']}-set"; ?>" class=<?php
+				  echo ( ! $existing and ! $f['init'] ) ? '"hidden new" disabled' : '"expanded"';?>><?php
+					$this->draw( $f, $set_id );
+				?></div><?php
+			?></div><?php
 			}
 		?></div><?php
-		?><a class="toggle_form_manager <?php
-			echo "{$field['meta_key']} add {$form_id}";
-			if ( $existing or $init ) { echo " hidden"; } 
-			?>" href="#add-formset_<?php echo $form_id; ?>"><?php
-			if ( isset( $field['title'] ) ) {
-				echo "Add {$field['title']}";
-			} else {
-				echo "Add Formset";
-			}
-		?></a><?php
 	}
 
-	public function get_formset_id( $form_meta_key ) {
+	public function get_set_id( $set_key ) {
 		$id = "";
-		$key_parts = explode( '_', $form_meta_key );
+		$key_parts = explode( '_', $set_key );
 		foreach ( $key_parts as $part ) {
 			if ( ctype_digit( $part ) ) {
 				$id .= $part . "-";
@@ -94,111 +107,117 @@ class HTML {
 		return $id;
 	}
 
-	public function get_existing_data( $field, &$existing, $data ) {
-		foreach ( $field['fields'] as $f ) {
-			if ( $f['type'] == 'fieldset' ) {
-				$this->get_existing_data( $f, $existing, $data );
-			} else {
-				if ( array_key_exists( $f['meta_key'], $data ) ){
-					if ( ! empty( $data[$f['meta_key']] ) ) {
-						array_push( $existing, $data[$f['meta_key']] );
-					}
-				}
+	public function get_existing_data( $field ) {
+		$existing = false;
+		if ( isset( $field['params']['repeated'] ) ) {
+			foreach ( $field['fields'] as $f ) {
+				$existing = $this->get_existing_data( $f );
+			}
+		} elseif ( $field['type'] == 'fieldset' ) {
+			foreach ( $field['fields'] as $f ) {
+				$existing = $this->get_existing_data( $f );
+			}
+		} else {
+			if ( isset( $field['value'] ) and !empty( $field['value'] ) ) {
+				$existing = true;
 			}
 		}
+		return $existing;
 	}
 
-	public function pass_select( $field, $form_id = NULL ) {
+	public function pass_select( $field, $set_id = NULL ) {
+		$value    = $field['value'];
 		$taxonomy = isset( $field['taxonomy'] ) ? $field['taxonomy'] : false;
 		$required = isset( $field['required'] ) ? $field['required'] : false;
-		$multi = isset( $field['multiple'] ) ? $field['multiple'] : false;
-		$label = isset( $field['label'] ) ? $field['label'] : null;
+		$multiple = isset( $field['multiple'] ) ? $field['multiple'] : false;
+		$label    = isset( $field['label'] )    ? $field['label']    : null;
 		if ( in_array( $field['type'], array('multiselect', 'select', 'taxonomyselect' ) ) ) {
 			$this->select( 
-				$field['meta_key'], 
+				$field['key'], 
 				$field['params'], 
 				$taxonomy, 
-				$multi,
-				$field['value'],
+				$multiple,
+				$value,
 				$required,
 				$field['placeholder'],
 				$label,
-				$form_id
+				$set_id
 			);
 		} elseif ( $field['type'] == 'tax_as_meta' ) {
 			$this->taxonomy_as_meta(
-				$slug = $field['slug'],
+				$slug = $field['key'],
 				$params = $field['include'],
 				$taxonomy = $taxonomy,
-				$value = $field['value'],
-				$multi,
+				$value,
+				$multiple,
 				$required,
 				$label,
 				$placeholder = $field['placeholder'],
-				$form_id
+				$set_id
 			);
-		} elseif ( $field['type'] == 'post_select' || $field['type'] == 'post_multiselect' ) {
+		} elseif ( $field['type'] == 'post_select' or $field['type'] == 'post_multiselect' ) {
 			$post_id = get_the_ID();
 			$args = $field['params'];
 			$posts = get_posts($args);
-			$value = get_post_meta( $post_id, $field['meta_key'], $single = false );
-			$multi = $field['type'] == 'post_multiselect' ? 'multiple' : null;
+			$multiple = $field['type'] == 'post_multiselect' ? 'multiple' : null;
+			$placeholder = isset( $field['placeholder'] ) ? $field['placeholder'] : null;
 			$this->post_select(
-				$field['meta_key'],
+				$field['key'],
 				$posts,
 				$value,
-				$multi,
+				$multiple,
 				$required,
 				$label,
-				$field['placeholder'],
-				$form_id
+				$placeholder,
+				$set_id
 			);
 		}
 	}
 
-	public function draw_input( $field, $form_id = NULL ) {
-		$required = isset( $field['required'] ) ? $field['required'] : false;
-		$value = isset( $field['value'] ) ? $field['value'] : null;
-		$label = isset( $field['label'] ) ? $field['label'] : null;
-		$max_length = isset ( $field['max_length'] ) ? $field['max_length'] : null;
+	public function draw_input( $field, $set_id = NULL ) {
+		$required   = isset( $field['required'] )   ? $field['required']   : false;
+		$value      = isset( $field['value'] )      ? $field['value']      : null;
+		$label      = isset( $field['label'] )      ? $field['label']      : null;
+		$max_length = isset( $field['max_length'] ) ? $field['max_length'] : null;
+		$timezone   = ( isset( $field['value'] ) and isset( $field['value']['timezone'] ) ) ? $field['value']['timezone'] : null;
 		if ( $field['type'] == 'text_area' ) {
-			$this->text_area( $field['meta_key'], $value, $required, $field['rows'], $field['cols'], $label, $field['placeholder'], $form_id );
+			$this->text_area( $field['key'], $value, $required, $field['rows'], $field['cols'], $label, $field['placeholder'], $set_id );
 		}
 
 		if ( $field['type'] == 'wysiwyg' ) {
-			$this->wysiwyg( $value, $field['meta_key'], $field['params'], $label, $form_id );
+			$this->wysiwyg( $value, $field['key'], $field['params'], $label, $set_id );
 		}
 
 		if ( in_array( $field['type'], array( 'number', 'text', 'email', 'url' ) ) ) {
-			$this->single_input( $field['meta_key'], $value, $field['type'], $required, $max_length, $label, $field['placeholder'], $form_id );
+			$this->single_input( $field['key'], $value, $field['type'], $required, $max_length, $label, $field['placeholder'], $set_id );
 		}
 
 		if ( $field['type'] == 'date' ) {
-			$this->date( $field['taxonomy'], $field['multiple'], $required, $label, $form_id );
+			$this->date( $field['taxonomy'], $field['multiple'], $required, $label, $set_id );
 			$this->displayTags( $field['taxonomy'], $field['type'] );
 		} elseif ( $field['type'] == 'time' ) {
-			$this->time( $field['taxonomy'], $required, $label, $form_id );
-			$this->displayTags( $field['taxonomy'], $field['type'], $field['timezone'] );
+			$this->time( $field['taxonomy'], $required, $label, $set_id );
+			$this->displayTags( $field['taxonomy'], $field['type'], $timezone );
 		} elseif ( $field['type'] == 'datetime' ) {
-			$this->datetime( $field['taxonomy'], $required, $label, $form_id );
-			$this->displayTags( $field['taxonomy'], $field['type'], $field['timezone'] );
+			$this->datetime( $field['taxonomy'], $required, $label, $set_id );
+			$this->displayTags( $field['taxonomy'], $field['type'], $timezone );
 		}
 
 		if ( $field['type'] == 'radio' ) {
-			$this->single_input( $field['meta_key'], $value = 'true', $field['type'] = 'radio', $required, $max_length = null, $label, $field['placeholder'], $form_id );
-			$this->single_input( $field['meta_key'], $value = 'false', $field['type'] = 'radio', $required, $max_length = null,  $label, $field['placeholder'], $form_id );
+			$this->single_input( $field['key'], $value = 'true', $field['type'] = 'radio', $required, $max_length = null, $label, $field['placeholder'], $set_id );
+			$this->single_input( $field['key'], $value = 'false', $field['type'] = 'radio', $required, $max_length = null,  $label, $field['placeholder'], $set_id );
 		}
 
 		if ( $field['type'] == 'boolean' ) {
-			$this->boolean_input( $field['meta_key'], $value, $required, $label, $form_id );
+			$this->boolean_input( $field['key'], $value, $required, $label, $set_id );
 		}
 
 		if ( $field['type'] == 'link' ) {
-			$this->link_input($field['meta_key'], $value, $required, $label, $form_id );
+			$this->link_input($field['key'], $value, $required, $label, $set_id );
 		}
 
 		if ( $field['type'] == 'file' ) {
-			$this->file_input( $field['meta_key'], $value, $label, $required, $form_id );
+			$this->file_input( $field['key'], $value, $label, $required, $set_id );
 		}
 	}
 
@@ -212,20 +231,19 @@ class HTML {
 	 * @param array $field unused, eliminate
 	 * @param int $rows value for the rows attribute
 	 * @param int $cols value for the cols attribute
-	 * @param str $meta_key value for the 'id' and 'name' attributes
+	 * @param str $key value for the 'id' and 'name' attributes
 	 * @param str $value a default value for the <textarea>
 	 *
 	**/
-	public function text_area( $meta_key, $value, $required, $rows, $cols, $label, $placeholder, $form_id = NULL ) {
+	public function text_area( $key, $value, $required, $rows, $cols, $label, $placeholder, $set_id = NULL ) {
 		if ( $label ) {
-			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php 
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $key ) ?>"><?php 
 				echo esc_attr( $label ); if ( $required ): echo ' (required)'; endif; 
 			?></label><?php
 		}
-		// wp_editor( $value, $meta_key );
-		?><textarea id="<?php echo esc_attr( $meta_key ) 
-				  ?>" class="cms-toolkit-textarea <?php echo "form-input_{$form_id}"; 
-				  ?>" name="<?php echo esc_attr( $meta_key ) 
+		?><textarea id="<?php echo esc_attr( $key ) 
+				  ?>" class="cms-toolkit-textarea <?php echo "set-input_{$set_id}"; 
+				  ?>" name="<?php echo esc_attr( $key ) 
 				  ?>" rows="<?php echo esc_attr( $rows ) 
 				  ?>" cols="<?php echo esc_attr( $cols ) 
 				  ?>" value="<?php echo esc_attr( $value ) 
@@ -240,18 +258,19 @@ class HTML {
 	 * Uses the built in Wordpress function wp_editor to generate the field.
 	 *
 	 * @param str $value is the text within the editor that has been saved
-	 * @param str $meta_key the id associated with the HTML tag and data
+	 * @param str $key the id associated with the HTML tag and data
 	 * @param str $params are the settings for the wp_editor function
-	 * @param str $form_id the numeric id for a formset that the field could be in
+	 * @param str $set_id the numeric id for a formset that the field could be in
 	 *
 	**/
-	public function wysiwyg( $value, $meta_key, $params, $label, $form_id = NULL ) {
-		if ( isset( $form_id ) ) {
-			$params['editor_class'] .= " form-input_{$form_id}";
+	public function wysiwyg( $value, $key, $params, $label, $set_id = NULL ) {
+		if ( isset( $set_id ) ) {
+			$params['editor_class'] .= " set-input_{$set_id}";
 		}
-		?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php echo esc_attr( $label ) ?></label><?php
-		wp_editor( $value, $meta_key, $params );
-
+		if ( $label ) {
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $key ) ?>"><?php echo esc_attr( $label ) ?></label><?php
+		}
+		wp_editor( $value, $key, $params );
 	}
 
 	/**
@@ -263,7 +282,7 @@ class HTML {
 	 * public function, this method may only be called from within this
 	 * class.
 	 *
-	 * @param str $meta_key the meta_key for this field, used as 'name' and 'id'
+	 * @param str $key the key for this field, used as 'name' and 'id'
 	 * @param str $type the type of input field, use any valid HTML input type
 	 * @param int $max_length the maxlength attribute for number or text inputs
 	 * @param str $value a default value
@@ -272,77 +291,77 @@ class HTML {
 	 * @since 1.0
 	 *
 	**/
-	public function single_input( $meta_key, $value, $type, $required, $max_length, $label, $placeholder, $form_id = NULL ) {
+	public function single_input( $key, $value, $type, $required, $max_length, $label, $placeholder, $set_id = NULL ) {
 		$value       = 'value="' . $value . '"';
 		$max_length  = 'maxlength="' . $max_length . '"';
 		$placeholder = 'placeholder="' . $placeholder . '"';
 		if ( $label ) {
-			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php 
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $key ) ?>"><?php 
 				echo esc_attr( $label ); if ( $required ): echo ' (required)'; endif; 
 			?></label><?php
 		}
-		?><input id="<?php echo esc_attr( $meta_key ) 
-			   ?>" class="cms-toolkit-input <?php echo "form-input_{$form_id}"; 
-			   ?>" name="<?php echo esc_attr( $meta_key ) 
+		?><input id="<?php echo esc_attr( $key ) 
+			   ?>" class="cms-toolkit-input <?php echo "set-input_{$set_id}"; 
+			   ?>" name="<?php echo esc_attr( $key ) 
 			   ?>" type="<?php echo esc_attr( $type ) ?>"<?php 
 			   echo " $max_length $value $placeholder";
 			   if ( $required ): echo ' required '; endif; ?>/><?php
 	}
 
-	public function boolean_input( $meta_key, $value, $required, $label, $form_id = NULL ) {
-		?><input id="<?php echo esc_attr( $meta_key ) 
-			   ?>" class="cms-toolkit-checkbox <?php echo "form-input_{$form_id}"; 
-			   ?>" name="<?php echo esc_attr( $meta_key ) 
+	public function boolean_input( $key, $value, $required, $label, $set_id = NULL ) {
+		?><input id="<?php echo esc_attr( $key ) 
+			   ?>" class="cms-toolkit-checkbox <?php echo "set-input_{$set_id}"; 
+			   ?>" name="<?php echo esc_attr( $key ) 
 			   ?>" type="checkbox" <?php
 			   if ( $value == 'on' ) { echo 'checked '; }
 			   if ( $required ) { echo 'required '; } ?>/><?php
 		if ( $label ) {
-			?><label class="cms-toolkit-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php
+			?><label class="cms-toolkit-label" for="<?php echo esc_attr( $key ) ?>"><?php
 			 echo esc_attr( $label ); if ( $required ): echo ' (required)'; endif; 
 			?></label><?php
 		}
 	}
 
-	public function link_input( $meta_key, $value, $required, $label, $form_id = NULL ) {
+	public function link_input( $key, $value, $required, $label, $set_id = NULL ) {
 		$post_id = get_the_ID();
-		$existing = get_post_meta( $post_id, $meta_key, false);
-		?><div class="link-field <?php echo "{$meta_key}" ?>"><?php
+		$existing = get_post_meta( $post_id, $key, false);
+		?><div class="link-field <?php echo "{$key}" ?>"><?php
 		if ( ! isset( $existing[0] ) || ! isset( $existing[1] ) ) { 
-				$this->single_input( $meta_key . "_text", $value, 'text', $required, NULL, 'Link Text', 'Link text here', $form_id );
-				$this->single_input( $meta_key . "_url", $value, 'text', $required, NULL, 'Link URL', 'URL here', $form_id );
+				$this->single_input( $key . "_label", $value['label'], 'text', $required, NULL, 'Link Label', 'Link label here', $set_id );
+				$this->single_input( $key . "_url", $value['url'], 'text', $required, NULL, 'Link URL', 'URL here', $set_id );
 		} else { 
-				$this->single_input( $meta_key . "_text", $existing[1], 'text', $required, NULL, 'Link Text', NULL, $form_id );
-				$this->single_input( $meta_key . "_url", $existing[0], 'text', $required, NULL, 'Link URL', NULL, $form_id );
+				$this->single_input( $key . "_label", $existing[1], 'text', $required, NULL, 'Link Label', NULL, $set_id );
+				$this->single_input( $key . "_url", $existing[0], 'text', $required, NULL, 'Link URL', NULL, $set_id );
 		}
 		?></div><?php
 	}
 
-	public function file_input( $meta_key, $value = NULL, $label = NULL, $required = NULL, $form_id = NULL ) {
+	public function file_input( $key, $value = NULL, $label = NULL, $required = NULL, $set_id = NULL ) {
 		if ( $label ) {
-			?><label class="cms-toolkit-file block-label form-input_<?php echo esc_attr( $form_id ) ?>"><?php
+			?><label class="cms-toolkit-file block-label set-input_<?php echo esc_attr( $set_id ) ?>"><?php
 				echo esc_attr( $label );
 			?></label><?php
 		}
 		if ( $value ) {
 			?><div class="tagchecklist">
-				<span><a id="<?php echo esc_attr( $meta_key ) ?>" class="filedelbutton <?php echo esc_attr( $meta_key ) ?>"><?php echo esc_attr( $value['name'] ) ?></a>&nbsp;<?php echo $value['name'] ?></span><?php
-				$this->hidden( 'rm_' . $meta_key, null, null );
+				<span><a id="<?php echo esc_attr( $key ) ?>" class="filedelbutton <?php echo esc_attr( $key ) ?>"><?php echo esc_attr( $value['name'] ) ?></a>&nbsp;<?php echo $value['name'] ?></span><?php
+				$this->hidden( 'rm_' . $key, null, null );
 			?></div><?php
 		}
-		?><input id="<?php echo esc_attr( $meta_key ) 
-			   ?>" name="<?php echo esc_attr( $meta_key ) 
-			   ?>" class="cms-toolkit-input <?php echo "form-input_{$form_id}"; 
-			   ?>" type="file" value="<?php echo esc_attr( $value['url'] ) ?>"<?php
-			   if ( $required ): echo ' required '; endif; ?>/><?php
+		?><input id="<?php echo esc_attr( $key ) 
+			   ?>" name="<?php echo esc_attr( $key ) 
+			   ?>" class="cms-toolkit-input <?php echo "set-input_{$set_id}"; 
+			   ?>" type="file" value="<?php echo ( $value ) ? esc_attr( $value['url'] ) : null; ?>"<?php
+			   echo $required ? ' required ' : null; ?>/><?php
 	}
 
 	/**
 	 *  Generates a hidden field
 	**/
-	public function hidden( $meta_key, $value, $form_id ) {
-		?><input class="cms-toolkit-input <?php echo "form-input_{$form_id}";
-			   ?>" id="<?php echo esc_attr( $meta_key ) 
-			   ?>" name="<?php echo esc_attr( $meta_key ) 
+	public function hidden( $key, $value, $set_id ) {
+		?><input class="cms-toolkit-input <?php echo "set-input_{$set_id}";
+			   ?>" id="<?php echo esc_attr( $key ) 
+			   ?>" name="<?php echo esc_attr( $key ) 
 			   ?>" type="hidden" value="<?php echo esc_attr( $value ) ?>" /><?php
 	}
 
@@ -364,7 +383,7 @@ class HTML {
 	 * @uses wp_dropdown_categories
 	 *
 	 * @param array $field currently unused
-	 * @param str   $meta_key the meta-key
+	 * @param str   $key the meta-key
 	 * @param array $param an array of values for the <option> elements,
 	 *              default empty, required for non-taxonomy selections
 	 * @param str/bool $taxonomy, pass a string with a valid taxonomy name to
@@ -376,16 +395,16 @@ class HTML {
 	 *              if no value selected. Default: '--'
 	 *
 	**/
-	public function select( $meta_key, $params, $taxonomy, $multi, $value, $required, $placeholder, $label, $form_id = NULL ) {
+	public function select( $key, $params, $taxonomy, $multi, $value, $required, $placeholder, $label, $set_id = NULL ) {
 		if ( $label ) {
-			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php echo esc_attr( $label ); ?></label><?php
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $key ) ?>"><?php echo esc_attr( $label ); ?></label><?php
 		}		
 		if ( $taxonomy ) { // if a taxonomy is set, use wp_dropdown category to generate the select box
 			$IDs = wp_get_object_terms( get_the_ID(), $taxonomy, array( 'fields' => 'ids' ) );
 			wp_dropdown_categories( 'taxonomy=' . $taxonomy . '&hide_empty=0&orderby=name&name=' . $taxonomy . '&show_option_none=Select ' . $taxonomy . '&selected='. array_pop($IDs) );
 		} else {	// otherwise use all the values set in $param to generate the option
 			$multiple = isset($multi) ? 'multiple' : null;
-			?><select id="<?php echo esc_attr( $meta_key ) ?>" name="<?php echo esc_attr( $meta_key ) ?>[]" class="<?php echo "form-input_{$form_id}"; ?>" <?php echo $multiple ?> <?php if ( $required ): echo 'required'; endif; ?>><?php
+			?><select id="<?php echo esc_attr( $key ) ?>" name="<?php echo esc_attr( $key ) ?>[]" class="<?php echo "set-input_{$set_id}"; ?>" <?php echo $multiple ?> <?php if ( $required ): echo 'required'; endif; ?>><?php
 			if ( empty( $value ) ) {
 				?><option selected value=""><?php echo esc_attr( $placeholder ) ?></option><?php
 			} else {
@@ -401,13 +420,13 @@ class HTML {
 		}
 	}
 
-	public function post_select( $meta_key, $posts, $value, $multi, $required, $label, $placeholder, $form_id = NULL ) { 
+	public function post_select( $key, $posts, $value, $multi, $required, $label, $placeholder, $set_id = NULL ) { 
 		global $post;
 		$selected = null;
 		if ( $label ) {
-			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $meta_key ) ?>"><?php echo esc_attr( $label ); ?></label><?php
+			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $key ) ?>"><?php echo esc_attr( $label ); ?></label><?php
 		}
-		?><select class="<?php echo "form-input_{$form_id}"; ?>" id="<?php echo esc_attr( $meta_key ) ?>" name="<?php echo esc_attr( $meta_key ) ?>[]"<?php echo " " . $multi; if ( $required ): echo ' required '; endif; ?>><?php
+		?><select class="<?php echo "set-input_{$set_id}"; ?>" id="<?php echo esc_attr( $key ) ?>" name="<?php echo esc_attr( $key ) ?>[]"<?php echo " " . $multi; if ( $required ): echo ' required '; endif; ?>><?php
 			if ( $multi == null ) {
 				if ( empty( $value ) ) {
 					?><option selected value=""><?php echo esc_attr( $placeholder ); ?></option><?php
@@ -426,11 +445,11 @@ class HTML {
 		?></select><?php
 	}
 
-	public function taxonomy_as_meta( $slug, $params, $taxonomy, $value, $multi, $required, $label, $placeholder, $form_id= NULL ) { // keep as slug
+	public function taxonomy_as_meta( $slug, $params, $taxonomy, $value, $multi, $required, $label, $placeholder, $set_id= NULL ) { // keep as slug
 		if ( $label ) {
 			?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $slug ) ?>"><?php echo esc_attr( $label ); ?></label><?php
 		}
-		?><select class="<?php echo esc_attr($multi) . " "; echo "form-input_{$form_id}"; ?>" name="<?php echo esc_attr( $slug )?>[]" <?php echo esc_attr( $multi ) . " "; if ( $required ): echo 'required'; endif; ?>><?php
+		?><select class="<?php echo esc_attr($multi) . " "; echo "set-input_{$set_id}"; ?>" name="<?php echo esc_attr( $slug )?>[]" <?php echo esc_attr( $multi ) . " "; if ( $required ): echo 'required'; endif; ?>><?php
 			if ( isset( $value ) ) {
 				?><option selected value="<?php echo esc_attr( $value ) ?>" id="<?php echo esc_attr( $slug ) ?>" name="<?php echo esc_attr( $slug ) ?>"><?php echo esc_attr( $value ) ?></option><?php
 			} else {
@@ -464,7 +483,7 @@ class HTML {
 	 * @param str  $taxonomy      the slug of the target taxonomy for this metabox (i.e., cfpb_input_date)
 	 * @param bool $multiples     whether the term shoud append (true) or replace (false) existing terms
 	 **/
-	public function date( $taxonomy, $multiple, $required, $label, $form_id = NULL ) {
+	public function date( $taxonomy, $multiple, $required, $label, $set_id = NULL ) {
 		global $wp_locale;
 		$tax_name = stripslashes( $taxonomy );
 		global $wp_locale;
@@ -472,17 +491,17 @@ class HTML {
 			if ( $label ) {
 				?><label class="cms-toolkit-label block-label" for="<?php echo esc_attr( $taxonomy ) ?>"><?php echo esc_attr( $label ); ?></label><?php
 			}
-			?><select id="<?php echo esc_attr( $tax_name ) ?>_month" name="<?php echo esc_attr( $tax_name ) ?>_month" class="<?php echo "form-input_{$form_id}"; ?>"><option selected="selected" value="" <?php if ( $required ): echo 'required'; endif; ?>>Month</option><?php
+			?><select id="<?php echo esc_attr( $tax_name ) ?>_month" name="<?php echo esc_attr( $tax_name ) ?>_month" class="<?php echo "set-input_{$set_id}"; ?>"><option selected="selected" value="" <?php if ( $required ): echo 'required'; endif; ?>>Month</option><?php
 			for ( $i = 1; $i < 13; $i++ ) {
 				?><option value="<?php echo esc_attr( $wp_locale->get_month( $i ) ) ?>"><?php echo esc_attr( $wp_locale->get_month( $i ) )  ?></option><?php 
 			} 
 			?></select><?php
-			?><input id="<?php echo esc_attr( $tax_name ) ?>_day" type="text" name="<?php echo esc_attr( $tax_name ) ?>_day" class="<?php echo "form-input_{$form_id}"; ?>" value="" size="2" maxlength="2" placeholder="DD"/><?php
-			?><input id="<?php echo esc_attr( $tax_name ) ?>_year" type="text" name="<?php echo esc_attr( $tax_name ) ?>_year" class="<?php echo "form-input_{$form_id}"; ?>" value="" size="4" maxlength="4" placeholder="YYYY"/><?php
+			?><input id="<?php echo esc_attr( $tax_name ) ?>_day" type="text" name="<?php echo esc_attr( $tax_name ) ?>_day" class="<?php echo "set-input_{$set_id}"; ?>" value="" size="2" maxlength="2" placeholder="DD"/><?php
+			?><input id="<?php echo esc_attr( $tax_name ) ?>_year" type="text" name="<?php echo esc_attr( $tax_name ) ?>_year" class="<?php echo "set-input_{$set_id}"; ?>" value="" size="4" maxlength="4" placeholder="YYYY"/><?php
 		?></div><?php
 	}
 
-	public function time( $taxonomy, $required, $label = NULL, $form_id = NULL ) {
+	public function time( $taxonomy, $required, $label = NULL, $set_id = NULL ) {
 		foreach ( DateTimeZone::listIdentifiers(DateTimeZone::PER_COUNTRY, 'US' ) as $key => $country ) {
 			$countries[] = $country;
 		}
@@ -492,24 +511,24 @@ class HTML {
 					echo esc_attr( $label ); 
 				?></label><?php
 			}
-			$this->select( $taxonomy . "_hour", array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ), null, null, null, $required, "Hour", null, $form_id );
+			$this->select( $taxonomy . "_hour", array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ), null, null, null, $required, "Hour", null, $set_id );
 			?> : <?php
-			$this->select( $taxonomy . "_minute", array( "00", "15", "30", "45" ), null, null, null, $required, "Minute", null, $form_id );
-			$this->select( $taxonomy . "_ampm", array( "am", "pm" ), null, null, null, $required, "am/pm", null, $form_id );
-			$this->select( $taxonomy . "_timezone", $countries, null, null, null, $required, "Timezone", null, $form_id );
+			$this->select( $taxonomy . "_minute", array( "00", "15", "30", "45" ), null, null, null, $required, "Minute", null, $set_id );
+			$this->select( $taxonomy . "_ampm", array( "am", "pm" ), null, null, null, $required, "am/pm", null, $set_id );
+			$this->select( $taxonomy . "_timezone", $countries, null, null, null, $required, "Timezone", null, $set_id );
 		?></div><?php
 	}
 
-	public function datetime( $taxonomy, $required, $label = NULL, $form_id = NULL ) {
+	public function datetime( $taxonomy, $required, $label = NULL, $set_id = NULL ) {
 		?><div id="<?php echo esc_attr( $taxonomy) ?>" name="<?php echo esc_attr( $taxonomy) ?>" class="cms-toolkit-datetime" ><?php
 			if ( $label ) { 
 				?><label for="<?php echo esc_attr( $taxonomy ) ?>" class="cms-toolkit-label block-label"><?php 
 					echo esc_attr( $label ); 
 				?></label><?php
 			}
-			$this->date( $taxonomy, null, false, $required, null, $form_id );
+			$this->date( $taxonomy, null, false, $required, null, $set_id );
 			?> @ <?php
-			$this->time( $taxonomy, $required, null, $form_id );
+			$this->time( $taxonomy, $required, null, $set_id );
 		?></div><?php
 	}
 

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -42,7 +42,7 @@ class Models {
 		'link',
 		'wysiwyg',
 	);
-	private $other   = array( 'nonce', 'hidden', 'separator', 'fieldset', 'formset' );
+	private $other   = array( 'nonce', 'hidden', 'separator', 'fieldset' );
 	protected $supported_types = array(
 		'application/pdf',
 		'image/png',
@@ -161,10 +161,10 @@ class Models {
 	}
 
 	/**
-	* validate_formset validates a formset
+	* validate_repeated_field validates a formset
 	*
 	* @param  arr  $field     The formset to validate.
-	* @param  arr  $validate  The array that holds all the data to save in an
+	* @param  arr  $validated  The array that holds all the data to save in an
 	*                         associative array that is passed by reference.
 	* @param  arr  $post_ID   The post's ID
 	*
@@ -172,24 +172,22 @@ class Models {
 	*                         so data is saved through that array.
 	*/
 
-	public function validate_formset( $field, &$validate, $post_ID ) {
-		for ( $i = 0; $i < $field['params']['max_num_forms']; $i++ ) {
+	public function validate_repeated_field( $post_ID, &$field, &$validated, $saved ) {
+		$validated = array();
+		$params = $field['params']['repeated'];
+		unset( $field['params']['repeated'] );
+		for ( $i = 0; $i < $params['max']; $i++ ) {
 			$processed[$i] = $field;
-			if ( isset( $processed[$i]['meta_key'] ) ) {
-				$processed[$i]['meta_key'] .= '_' . $i;
+			$processed[$i]['key'] .= '_' . $i;
+			$validated[$i] = null;
+			$saved_field = ( $saved and isset( $saved[$i] ) ) ? $saved[$i] : null;
+			$this->validate( $post_ID, $processed[$i], $validated[$i], $saved_field );
+			if ( empty( $validated[$i] ) ) {
+				unset( $validated[$i] );
 			}
-			if ( isset( $processed[$i]['slug'] ) ) {
-				$processed[$i]['slug'] .= '_' . $i;
-			}
-			foreach ( $processed[$i]['fields'] as $f ) {
-				if ( isset( $processed[$i]['meta_key'] ) and isset( $f['meta_key'] ) ) {
-					$f['meta_key'] = "{$processed[$i]['meta_key']}_{$f['meta_key']}";
-				}
-				if ( isset( $processed[$i]['slug'] ) and isset( $f['slug'] ) ) {
-					$f['slug'] = "{$processed[$i]['slug']}_{$f['slug']}";
-				}
-				$this->validate( $post_ID, $f, $validate );
-			}
+		}
+		if ( empty( $validated ) ) {
+			unset( $validated );
 		}
 	}
 
@@ -197,7 +195,7 @@ class Models {
 	* validate_fieldset validates a fieldset
 	*
 	* @param  arr  $field     The formset to validate.
-	* @param  arr  $validate  The array that holds all the data to save in an
+	* @param  arr  $validated  The array that holds all the data to save in an
 	*                         associative array that is passed by reference.
 	* @param  arr  $post_ID   The post's ID
 	*
@@ -205,15 +203,21 @@ class Models {
 	*                         so data is saved through that array.
 	*/
 
-	public function validate_fieldset( $field, &$validate, $post_ID ) {
+	public function validate_fieldset( $post_ID, &$field, &$validated, $saved ) {
+		$validated = array();
 		foreach ( $field['fields'] as $f ) {
-			if ( isset( $field['meta_key'] ) and isset( $f['meta_key'] ) ) {
-				$f['meta_key'] = "{$field['meta_key']}_{$f['meta_key']}";
+			$field_key = $this->validate_keys( $f );
+			$f['old_key'] = $field_key;
+			$f['key'] = "{$field['key']}_{$field_key}";
+			$validated[$field_key] = null;
+			$saved_field = ( $saved and isset( $saved[$field_key] ) ) ? $saved[$field_key] : null;
+			$this->validate( $post_ID, $f, $validated[$field_key], $saved_field );
+			if ( ! $validated[$field_key] ) {
+				unset( $validated[$field_key] );
 			}
-			if ( isset( $field['slug'] ) and isset( $f['slug'] ) ) {
-				$f['slug'] = "{$field['slug']}_{$f['slug']}";
-			}
-			$this->validate( $post_ID, $f, $validate );
+		}
+		if ( empty( $validated ) ) {
+			unset( $validated );
 		}
 	}
 
@@ -227,24 +231,14 @@ class Models {
 	 *                      metadata are saved to the post as an array of the form
 	 *                      array(0 => 'url', 1 => 'text')
 	 */
-	public function validate_link( $field, $post_ID ) {
-		if ( isset( $_POST["{$field['meta_key']}_url"] )
-		 and isset( $_POST["{$field['meta_key']}_text"] ) ) {
-			$url = $_POST["{$field['meta_key']}_url"];
-			$text = $_POST["{$field['meta_key']}_text"];
-			$full_link = array( 0 => $url, 1 => $text );
-			$existing = get_post_meta( $post_ID, $field['meta_key'], $single = false );
+	public function validate_link( $key, &$validated ) {
+		if ( isset( $_POST["{$key}_label"] )
+		 and isset( $_POST["{$key}_url"] ) ) {
+			$label = $_POST["{$key}_label"];
+			$url = $_POST["{$key}_url"];
+			$full_link = array( 'label' => $label, 'url' => $url );
 
-			if ( empty( $_POST["{$field['meta_key']}_url"] )
-			  or empty( $_POST["{$field['meta_key']}_text"] ) ) {
-				delete_post_meta( $post_ID, $field['meta_key']);
-			} elseif ( empty($existing) ) {
-				add_post_meta( $post_ID, $field['meta_key'], $url, false );
-				add_post_meta( $post_ID, $field['meta_key'], $text, false );
-			} elseif ( $existing != $full_link ) {
-				update_post_meta( $post_ID, $field['meta_key'], $url, $existing[0] );
-				update_post_meta( $post_ID, $field['meta_key'], $text, $existing[1] );
-			}
+			$validated = ( empty( $label ) or empty( $url ) ) ? null : $full_link;
 		}
 	}
 
@@ -259,38 +253,16 @@ class Models {
 	 *                      deleted.
 	 */
 
-	public function validate_select( $field, $post_ID ) {
-		if ( !isset( $_POST[$field['meta_key']] ) ) {
-			delete_post_meta( $post_ID, $field['meta_key']);
-			return;
-		}
-		if ( array_key_exists($field['meta_key'], $_POST) ) {
-			$existing = get_post_meta( $post_ID, $field['meta_key'], false );
-			$data = $_POST[$field['meta_key']];
-			foreach ( (array)$data as $d ) {
-				// Adding or updating terms
-				$term = sanitize_text_field( $d );
-				$e_key = array_search($term, $existing);
-				if ( ! in_array($d, (array)$existing) ) {
-					// if the term is not in $existing, it's a new term, add it
-					// we use add_post_meta instead of update so we can have more
-					// than one value on the array
-					add_post_meta( $post_ID, $field['meta_key'], $term );
-				}
-			}
-			// delete terms if they're not in the $_POST data
-			foreach ( (array)$existing as $e ) {
-				if ( ! in_array($e, (array)$data) ) {
-					delete_post_meta( $post_ID, $field['meta_key'], $meta_value = $e );
-				}
-			}
+	public function validate_select( $key, &$validated ) {
+		if ( isset( $_POST[$key] ) ) {
+			$validated = (array)$_POST[$key];
 		}
 	}
 
-	public function validate_taxonomyselect($field, $post_ID) {
+	public function validate_taxonomyselect( $post_ID, $field, $key ) {
 		$field['multiple'] = isset( $field['multiple'] ) ? $field['multiple'] : false;
-		if ( isset($_POST[$field['slug']] )) {
-			$term = sanitize_text_field( $_POST[$field['slug']] );
+		if ( isset($_POST[$key] )) {
+			$term = sanitize_text_field( $_POST[$key] );
 			$term_exists = get_term_by('id', $term, $field['taxonomy']);
 			if ( $term_exists ){
 				wp_set_object_terms(
@@ -319,7 +291,7 @@ class Models {
 	 * @return void
 	 */
 
-	public function validate_datetime($field, $post_ID) {
+	public function validate_datetime( $post_ID, $field, &$validated ) {
 		$terms = wp_get_post_terms( $post_ID, $field['taxonomy'], array( 'fields' => 'ids' ) );
 		$terms_to_remove = array();
 		for ( $i = 0; $i < count( $terms ); $i++ ) {
@@ -366,11 +338,16 @@ class Models {
 				$data[$field['taxonomy']] .= ' ' . $_POST[$timezone][0];
 			}
 		}
+		$timezone = null;
 		if ( $field['type'] == 'date' ) {
 			$date = DateTime::createFromFormat('F j Y', $data[$field['taxonomy']]);
 		} else {
-			if ( isset( $_POST[$field['taxonomy'] . '_timezone'] ) )
+			if ( isset( $_POST[$field['taxonomy'] . '_timezone'] ) and
+				 is_array( $_POST[$field['taxonomy'] . '_timezone'] ) and
+				 !empty( $_POST[$field['taxonomy'] . '_timezone'][0] ) ) {
+				
 				date_default_timezone_set( $_POST[$field['taxonomy'] . '_timezone'][0] );
+			}
 			if ( $field['type'] == 'time' ) {
 				$date = DateTime::createFromFormat('h:ia T', $data[$field['taxonomy']]);
 			} elseif ( $field['type'] == 'datetime' ) {
@@ -379,10 +356,23 @@ class Models {
 		}
 		if ( $date ) {
 			$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $data, null );
+			if ( $field['type'] == 'date' ) {
+				$validated = array( 'date' => date( Datetime::ISO8601, strval( strtotime( $data[$field['taxonomy']] ) ) ) );
+			} elseif ( $field['type'] == 'datetime' ) {
+				$validated = array(
+					'datetime' => date( Datetime::ISO8601, strval( strtotime( $data[$field['taxonomy']] ) ) ),
+					'timezone' => $_POST[$field['taxonomy'] . '_timezone'][0]
+				);
+			} else {
+				$validated = array(
+					'time' => date( Datetime::ISO8601, strval( strtotime( $data[$field['taxonomy']] ) ) ),
+					'timezone' => $_POST[$field['taxonomy'] . '_timezone'][0]
+				);
+			}
 		}
 	}
 
-	public function validate_file( $field, $post_ID ) {
+	public function validate_file( $post_ID, $field, &$validated, $saved ) {
 		if ( isset( $field['allowed_file_types'] ) and 
 			( is_array( $field['allowed_file_types'] ) and !empty( $field['allowed_file_types'] ) ) ) {
 			foreach ( $field['allowed_file_types'] as $type ) {
@@ -395,24 +385,23 @@ class Models {
 		} else {
 			$supported_types = $this->supported_types;
 		}
-		if ( isset( $_POST['rm_' . $field['meta_key']] ) and !empty( $_POST['rm_' . $field['meta_key']] ) ) {
-			$file = get_post_meta( $post_ID, $_POST['rm_' . $field['meta_key']], true );
-			if ( unlink( $file['file'] ) ) {
-				delete_post_meta( $post_ID, $field['meta_key'] );
-			} else {
+		if ( isset( $_POST['rm_' . $field['key']] ) and !empty( $_POST['rm_' . $field['key']] ) ) {
+			if ( ! unlink( $saved['file'] ) ) {
 				wp_die('There was an error trying to delete your file.');
 			}
 		}
-		if ( !empty( $_FILES[$field['meta_key']] ) and !empty( $_FILES[$field['meta_key']]['name'] ) ) {
-			$arr_file_type = wp_check_filetype( basename( $_FILES[$field['meta_key']]['name'] ) );
+		if ( !empty( $_FILES[$field['key']] ) and !empty( $_FILES[$field['key']]['name'] ) ) {
+			$arr_file_type = wp_check_filetype( basename( $_FILES[$field['key']]['name'] ) );
 			$uploaded_type = $arr_file_type['type'];
 			if ( in_array( $uploaded_type, $supported_types ) ) {
-				$upload = wp_upload_bits( $_FILES[$field['meta_key']]['name'], null, file_get_contents( $_FILES[$field['meta_key']]['tmp_name'] ) );
+				$upload = wp_upload_bits( $_FILES[$field['key']]['name'], null, file_get_contents( $_FILES[$field['key']]['tmp_name'] ) );
 				if ( $upload['error'] ) {
 					wp_die( 'File upload error: ' . $upload['error'] );
 				} else {
-					$upload['name'] = $_FILES[$field['meta_key']]['name'];
-					update_post_meta( $post_ID, $field['meta_key'], $upload );
+					$upload['name'] = $_FILES[$field['key']]['name'];
+					$relative_url = parse_url( $upload['url'] );
+					$upload['url'] = $relative_url['path'];
+					$validated = $upload;
 				}
 			}
 			else {
@@ -432,102 +421,61 @@ class Models {
 	 * @return array A version of $_POST with cleaned data ready to be sent to a save method
 	 *               like $this->save()
 	 */
-	public function validate( $post_ID, $field, &$validate ) {
+	public function validate( $post_ID, &$field, &$validated, $saved = NULL ) {
 		if ( isset( $field['do_not_validate'] ) ) {
 			return;
 		} elseif ( ! isset( $field['type'] ) ) {
-			$error = new $this->error( 'no_type', __( 'No field type set.' ) );
-			echo $error->get_error_message('no_type');
-			return;
+			wp_die("No field type set.");
 		}
-		if ( isset( $field['meta_key'] ) ) {
-			$key = $field['meta_key'];
-		} elseif ( isset( $field['slug'] ) ) {
-			$key = $field['slug'];
-		} elseif ( isset( $field['taxonomy'] ) ) {
-			$key = $field['taxonomy'];
-		} else {
-			$error = new $this->error( 'no_slug', __( 'No meta_key/slug/taxonomy is set.' ) );
-			echo $error->get_error_message('no_slug');
-			return;
-		}
-		/* if this field is a formset, fieldset, taxonomy select, date, link or 
-		   select field, we send it out to another validator
-		*/
-		if ( $field['type'] == 'formset' ) {
-		   if ( isset( $field['params'] ) ) {
-				if ( isset( $field['params']['max_num_forms'] ) ) {
-					if ( ! is_numeric( $field['params']['max_num_forms'] ) ) {
-						$error = new $this->error( 'formset_params_max_num',
-									__( "The 'max_num_forms' in params array for the"
-										. "formset field needs to be an integer." ) );
-						return $error->get_error_message('formset_params_max_num');
-					}
-				} else {
-					$field['params']['max_num_forms'] = 1;
-				}            
-			} else {
-				$error = new $this->error( 'formset_params',
-									__( "There must be a params array set in the field"
-										 . "for a formset." ) );
-				return $error->get_error_message('formset_params');
-			}
-			$this->validate_formset( $field, $validate, $post_ID );
-			return;
+
+		// Special fields require external validators
+	   if ( isset( $field['params'] ) and isset( $field['params']['repeated'] ) ) {
+	   		$this->View->process_repeated_field_params( $field );
+			$this->validate_repeated_field( $post_ID, $field, $validated, $saved );
+
 		} elseif ( $field['type'] == 'fieldset' ) {
-			$this->validate_fieldset( $field, $validate, $post_ID );
-			return;
+			$this->validate_fieldset( $post_ID, $field, $validated, $saved );
+
 		} elseif ( $field['type'] == 'taxonomyselect') {
 			if ( ! isset( $field['taxonomy'] ) ) {
-				$error = new $this->error( 'no_taxonomy', __( 'No taxonomy set'
-										   . ' for field that requires it.' ) );
-				echo $error->get_error_message('no_taxonomy');
-				return;
+				wp_die( "No taxonomy set for field that requires it.");
 			}
-			$this->validate_taxonomyselect( $field, $post_ID );
-			return;
+			$this->validate_taxonomyselect( $post_ID, $field, $field['key'] );
+
 		} elseif ( in_array( $field['type'], $this->selects ) ) {
-			if ( ! isset( $field['meta_key'] ) ) {
-				$error = new $this->error( 'no_meta_key', __( 'No meta_key is set.' ) );
-				echo $error->get_error_message('no_meta_key');
-				return;
-			}
-			$this->validate_select( $field, $post_ID );
-			return;
+			$this->validate_select( $field['key'], $validated );
+
 		} elseif ( $field['type'] == 'date' or $field['type'] == 'time' or $field['type'] == 'datetime' ) {
 			if ( ! isset( $field['taxonomy'] ) ) {
-				$error = new $this->error( 'no_taxonomy', __( 'No taxonomy set'
-										   . ' for field that requires it.' ) );
-				echo $error->get_error_message('no_taxonomy');
-				return;
+				wp_die( "No taxonomy set for field that requires it.");
 			}
-			$this->validate_datetime( $field, $post_ID );
-			return;
+			$this->validate_datetime( $post_ID, $field, $validated );
+
 		} elseif ( $field['type'] == 'link' ) {
-			$this->validate_link($field, $post_ID);
-			return;
+			$this->validate_link( $field['key'], $validated );
+
 		} elseif ( $field['type'] == 'file' ) {
-			$this->validate_file( $field, $post_ID );
-			return;
+			$this->validate_file( $post_ID, $field, $validated, $saved );
+
 		} else {
 			/* 
 				For most field types we just need to make sure we have the data
 				we expect from the form and sanitize them before sending them to
 				save
 			*/
-			if ( ! isset( $_POST[$key] ) ) {
+			if ( ! isset( $_POST[$field['key']] ) ) {
 				/*
 					Unchecked checkboxes that were previously checked
-					need the meta_key/slug to be manually added to the
+					need the key/slug to be manually added to the
 					$_POST global to be properly saved.
 				*/
 				if ( $field['type'] == 'boolean' ) {
-					$_POST[$key] = null;
+					$_POST[$field['key']] = null;
 				} else {
 					return;
 				}
 			}
-			$value = $_POST[$key];
+			$value = $_POST[$field['key']];
 			if ( $field['type'] == 'number' ) {
 				if ( is_numeric( $value ) ) {
 					// if we're expecting a number, make sure we get a number
@@ -545,8 +493,24 @@ class Models {
 				// make sure whatever we get for anything else is a string
 				$value = (string)$value;
 			}
+			$validated = $value;
 		}
-		$validate[$key] = $value;
+	}
+
+	public function validate_keys( $field ) {
+		$field_key = null;
+		if ( isset( $field['key'] ) ) {
+			$field_key = $field['key'];
+		} elseif ( isset( $field['meta_key'] ) ) {
+			$field_key = $field['meta_key'];
+		} elseif ( isset( $field['slug'] ) ) {
+			$field_key = $field['slug'];
+		} elseif ( isset( $field['taxonomy'] ) ) {
+			$field_key = $field['taxonomy'];
+		} else {
+			wp_die( 'No meta_key/slug/taxonomy is set.' );
+		}
+		return $field_key;
 	}
 
 	/**
@@ -573,7 +537,7 @@ class Models {
 			if ( $value == null && isset( $existing ) ) {
 				delete_post_meta( $post_ID, $key );
 			} elseif ( isset( $value ) ) {
-				update_post_meta( $post_ID, $meta_key = $key, $meta_value = $value );
+				update_post_meta( $post_ID, $key = $key, $meta_value = $value );
 			} else {
 				return;
 			}
@@ -586,15 +550,36 @@ class Models {
 	 * @return void
 	 */
 	public function validate_and_save( $post_ID ) {
-		$validate = array();
 		if ( empty( $this->fields ) ) {
-			$error = new $this->error( 'empty_fields', __( 'Empty fields array' ) );
-			echo $error->get_error_message('empty_fields');
-			return;
+			wp_die("Empty fields array");
 		}
+
+		// create an array that will be saved
+		$validated = array();
+
+		// duplicate metabox's fields to modify to match with $_POST array's keys
+		$saved = array();
+
 		foreach ( $this->fields as $field ) {
-			$this->validate( $post_ID, $field, $validate );
+			
+			//verify meta_key/slug/taxonomy and assign keys
+			$field['old_key'] = $this->validate_keys( $field );
+			$field['key'] = $field['old_key'];
+			
+			//create keys in array that are to be saved
+			$validated[$field['old_key']] = null;
+
+			// retrieve saved data
+			$saved[$field['old_key']] = get_post_meta( $post_ID, $field['old_key'], $single = true );
+
+			//start validation
+			$this->validate( $post_ID, $field, $validated[$field['old_key']], $saved[$field['old_key']] );
+
+			//if no data is there to be saved then delete the entry
+			if ( empty( $validated[$field['old_key']] ) ) {
+				unset( $validated[$field['old_key']] );
+			}
 		}
-		$this->save( $post_ID, $validate );
+		$this->save( $post_ID, $validated );
 	}
 }

--- a/inc/meta-box-view.php
+++ b/inc/meta-box-view.php
@@ -1,6 +1,7 @@
 <?php
 namespace CFPB\Utils\MetaBox;
 use \CFPB\Utils\MetaBox\HTML;
+use \CFPB\Utils\MetaBox\Models;
 use \WP_Error;
 
 class View {
@@ -27,7 +28,7 @@ class View {
 		'link',
 	);
 	private $hidden  = array( 'nonce', 'hidden' );
-	private $other   = array( 'separator', 'fieldset', 'formset' );
+	private $other   = array( 'separator', 'fieldset', 'file' );
 	public $elements;
 	private $HTML;
 	private $error;
@@ -51,197 +52,118 @@ class View {
 		$this->error = $Class;
 	}
 
-	public function process_defaults( $fields ) {
-		$ready = array();
-		foreach ( $fields as $field ) {
-			// check if this post has post meta or a taxonomy term already, if it does, set that as the value
-			if ( ! in_array( $field['type'], $this->elements ) ) {
-				return new WP_Error( 'invalid_type', "Invalid type {$field['type']} given for {$field['slug']} in this model. Acceptable elements: {$this->elements}");
-			}
-			$ID = get_the_ID();
-			if ( isset($field['meta_key'] ) ) {
-				if ( ! isset( $field['slug'] ) ) {
-					$field['slug'] = $field['meta_key'];
-				}
-				$field['value'] = $this->default_value($ID, $field);
-			} elseif ( isset( $field['taxonomy'] ) ) {
-				$field['value'] = wp_get_object_terms(
-					$ID,
-					$taxonomy = $field['taxonomy'],
-					array( 'fields' => 'names' )
-				);
-			} else {
-				return new WP_Error( 'no_slug', "No meta_key/slug/taxonomy is set.");
-			}
-			if ( isset( $field['slug'] ) ) {
-				if ( ! isset( $field['meta_key'] ) ) {
-					$field['meta_key'] = $field['slug'];
-				}
-			}
-			if ( isset( $field['meta_key'] ) ) {
-				if ( $field['type'] == 'formset' ) {
-					$field = $this->assign_defaults($field);
-					$this->process_formset_defaults( $field, $ready );
-				} elseif ( $field['type'] == 'fieldset' ) {
-					$ready[$field['meta_key']] = $this->process_fieldset( $field );
-				} else {
-					$ready[$field['meta_key']] = $this->assign_defaults($field);
-				}
-			} else {
-				return new WP_Error( 'no_metakey-slug', "'meta_key' and 'slug' are not set for this field." );
-			}
+	public function process_defaults( $ID, &$field, $saved ) {
+		// check if this post has post meta or a taxonomy term already, if it does, set that as the value
+		if ( ! in_array( $field['type'], $this->elements ) ) {
+			wp_die("Invalid type {$field['type']} given for {$field['key']} in this model.");
 		}
-		return $ready;
+		if ( isset( $field['taxonomy'] ) ) {
+			$field['value'] = wp_get_object_terms(
+				$ID,
+				$taxonomy = $field['taxonomy'],
+				array( 'fields' => 'names' )
+			);
+		}
+		if ( isset( $field['params'] ) and isset( $field['params']['repeated'] ) ) {
+			$this->process_repeated_fields( $ID, $field, $saved );
+		} elseif ( $field['type'] == 'fieldset' ) {
+			$this->process_fieldset( $ID, $field, $saved );
+		} else {
+			$this->assign_defaults( $ID, $field, $saved );
+		}
 	}
 
-	public function process_formset_defaults( $field, &$ready ) {
-		$ID = get_the_ID();
+	public function process_repeated_fields( $ID, &$field, $saved ) {
+		$this->process_repeated_field_params( $field );
+		$repeated = $field['params']['repeated'];
+		unset( $field['params']['repeated'] );
 		$processed = array();
-		$key = $field['meta_key'];
-		for ( $i = 0; $i < $field['params']['max_num_forms']; $i++ ) {
+		for ( $i = 0; $i < $repeated['max']; $i++ ) {
 			$processed[$i] = $field;
-			if ( ( $i + 1 ) <= $field['params']['init_num_forms'] ) {
-				$processed[$i]['init'] = true;
-			}
-			$processed[$i]['meta_key'] .= '_' . $i;
-			$processed[$i]['slug'] .= '_' . $i;
-			$processed[$i]['title'] .= isset( $processed[$i]['title'] ) ? ' ' . ( $i + 1 ) : "";
-			for ( $j = 0; $j < count( $field['fields'] ); $j++ ) {
-				if ( isset( $processed[$i]['fields'][$j]['meta_key'] ) ) {
-					$processed[$i]['fields'][$j]['meta_key'] = "{$processed[$i]['meta_key']}_{$processed[$i]['fields'][$j]['meta_key']}";
-				}
-				if ( isset( $processed[$i]['fields'][$j]['slug'] ) ) {
-					$processed[$i]['fields'][$j]['slug'] = "{$processed[$i]['slug']}_{$processed[$i]['fields'][$j]['slug']}";
-				}
-			}
-			$processed[$i]['fields'] = $this->process_defaults( $processed[$i]['fields'] );
+			$processed[$i]['init'] = ( ( $i + 1 ) <= $repeated['min'] );
+			$processed[$i]['key'] .= '_' . $i;
+			// $processed[$i]['title'] .= isset( $processed[$i]['title'] ) ? ' ' . ( $i + 1 ) : "";
+			// $processed[$i]['label'] .= isset( $processed[$i]['label'] ) ? ' ' . ( $i + 1 ) : "";
+			$saved_field = ( $saved and isset( $saved[$i] ) ) ? $saved[$i] : null;
+			$this->process_defaults( $ID, $processed[$i], $saved_field );
 		}
-		foreach ( $processed as $f ) {
-			if ( isset( $f['meta_key'] ) ) {
-				$ready[$f['meta_key']] = $f;
-			} elseif ( isset( $f['slug'] ) ) {
-				$ready[$f['slug']] = $f;
+		$field['fields'] = $processed;
+		$field['params']['repeated'] = $repeated;
+	}
+
+	public function process_repeated_field_params( $field ) {
+		if ( is_array( $field['params']['repeated'] ) and !empty( $field['params']['repeated'] ) ) {
+			foreach ( array( 'min', 'max' ) as $limit ) {
+				if ( ! isset( $field['params']['repeated'][$limit] ) or ! is_numeric( $field['params']['repeated'][$limit] ) ) {
+					wp_die("{$field['key']} must have repeated param {$limit} set as a number.");
+				}
 			}
+			if ( intval( $field['params']['repeated']['min'] ) > intval( $field['params']['repeated']['max'] ) ) {
+				wp_die("{$field['key']} repeated param min must not be more than the repeated max param.");
+			}
+		} else {
+			wp_die("{$field['key']} must have repeated param be array and set min and max params.");
 		}
 	}
 
-	public function process_fieldset( $field ){
-		$ID = get_the_ID();
-		for ($i = 0; $i < count( $field['fields'] ); $i++ ) {
-			if ( isset( $field['fields'][$i]['meta_key'] ) ) {
-				$field['fields'][$i]['meta_key'] = "{$field['meta_key']}_{$field['fields'][$i]['meta_key']}";
-			}
-			if ( isset( $field['fields'][$i]['slug'] ) ) {
-				$field['fields'][$i]['slug'] = "{$field['slug']}_{$field['fields'][$i]['slug']}";
-			}
-			if ( $field['fields'][$i]['type'] == 'fieldset' ) {
-				$field['fields'][$i] = $this->process_fieldset( $field['fields'][$i] );
-			} else {
-				$field['fields'][$i] = $this->assign_defaults( $field['fields'][$i] );
-				$field['fields'][$i]['value'] = $this->default_value( $ID, $field['fields'][$i] );
-			}
+	public function process_fieldset( $ID, &$field, $saved ) {
+		if ( ! isset( $field['fields'] ) or ! is_array( $field['fields'] ) ) {
+			wp_die("{$field['old_key']} must have a fields array.");
 		}
-		return $field;
+		foreach ( array_keys( $field['fields'] ) as $key ) {
+			$field['fields'][$key]['old_key'] = Models::validate_keys( $field['fields'][$key] );
+			$field['fields'][$key]['key'] = "{$field['key']}_{$field['fields'][$key]['old_key']}";
+			$saved_field = ( $saved and isset( $saved[$field['fields'][$key]['old_key']] ) ) ? $saved[$field['fields'][$key]['old_key']] : null;
+			$this->process_defaults( $ID, $field['fields'][$key], $saved_field );
+		}
 	}
 
-	public function assign_defaults( $field ) {
-		$field['label'] = $this->default_label($field);
-		if ( ! in_array( $field['type'], $this->hidden ) ) {
-			$field['max_length'] = $this->default_max_length($field);
-			$field['placeholder'] = $this->default_placeholder($field);
+	public function assign_defaults( $ID, &$field, $saved ) {
+		$field['label'] = isset( $field['label'] ) ? $field['label'] : null;
+		if ( $field['type'] == 'text' or $field['type'] == 'text_area' ) {
+			$field['max_length'] = isset( $field['max_length'] ) ? $field['max_length'] : 255;
+			$field['placeholder'] = isset( $field['placeholder'] ) ? $field['placeholder'] : "";
 		}
 		if ( $field['type'] == 'text_area') {
-			$field['rows'] = $this->default_rows($field);
-			$field['cols'] = $this->default_cols($field);
+			$field['rows'] = isset( $field['params']['rows'] ) ? intval( $field['params']['rows'] ) : 2;
+			$field['cols'] = isset( $field['params']['cols'] ) ? intval( $field['params']['cols'] ) : 27;
 		}
 		if ( $field['type'] == 'tax_as_meta') {
-			$field['include'] = $this->default_options( $field );
+			$field['include'] = isset( $field['params']['include'] ) ? $field['params']['include'] : array();
 			unset($field['params']);
 		}
-		if ( $field['type'] == 'multiselect' ) {
-			$field['multiselect'] = true;
-		} else {
-			$field['multiselect'] = false;
+		if ( in_array($field['type'], $this->selects ) ) {
+			$field['multiselect'] = ( $field['type'] == 'multiselect' ) ? true : false;
 		}
 		if ( ! in_array($field['type'], array( 'taxonomyselect', 'tax_as_meta', 'date', 'time', 'datetime' ) ) ) {
 			$field['taxonomy'] = false;
 		}
-		if ( $field['type'] == 'formset' ) {
-			$field = $this->default_formset_params( $field );
-		}
 		if ( $field['type'] == 'wysiwyg' ) {
 			if ( ! isset( $field['params'] ) or empty( $field['params'] ) ) {
-				$field['params'] = array( 'textarea_rows' => 5, 'editor_class' => "cms-toolkit-wysiwyg" );
+				$field['params'] = array(
+					'textarea_rows' => 5,
+					'editor_class' => "cms-toolkit-wysiwyg",
+					'wpautop' => false
+				);
 			} else {
 				$field['params']['editor_class'] .= " cms-toolkit-wysiwyg";
+				if ( ! isset( $field['params']['wpautop'] ) ){
+					$field['params']['wpautop'] = false;
+				}
 			}
 		}
-		if ( $field['type'] == 'time' or $field['type'] == 'datetime' ) {
-			$timezone = get_post_meta( get_the_ID(), $field['taxonomy'] . '_timezone', true );
-			$field['timezone'] = empty( $timezone ) ? null : $timezone[0];
-		}
-		return $field;
-	}
-
-	public function default_value( $ID, $field, $index = 0 ) {
-		if ( $field['type'] == 'formset' or $field['type'] == 'fieldset' or
-			 $field['type'] == 'link' or $field['type'] == 'time' or
-			 $field['type'] == 'datetime' or $field['type'] == 'date' ) {
-			$default = null;
-		} else {
-			$existing = get_post_meta( $ID, $field['meta_key'], false );
-			$value = isset( $field['value'] ) ? $field['value'] : '';
-			$default = array_key_exists( $index, $existing ) ? $existing[$index] : $value;
-		}
-		return $default;
-	}
-
-	public function default_label( $field ) {
-		$default = empty( $field['label'] ) ? '' : $field['label'];
-		return $default;
-	}
-
-	public function default_max_length( $field ) {
-		$default  = empty( $field['max_length'] ) ? 255 : $field['max_length'];
-		return $default;
-	}
-
-	public function default_placeholder( $field ) {
-		$default = empty( $field['placeholder'] ) ? '' : $field['placeholder'];
-		return $default;
-	}
-
-	public function default_rows( $field ) {
-		$default = ! isset( $field['params']['rows'] ) ? 2 : intval( $field['params']['rows'] );
-		return $default;
-	}
-
-	public function default_cols( $field ) {
-		$default = ! isset( $field['params']['cols'] ) ? 27 : intval( $field['params']['cols'] );
-		return $default;
-	}
-	public function default_options( $field ) {
-		$default = ! isset( $field['params']['include'] ) ? array() : $field['params']['include'];
-		return $default;
-	}
-	public function default_formset_params( $field ) {
-		if ( isset( $field['params'] ) ) {
-			if ( ! isset( $field['params']['init_num_forms'] ) ) {
-				$field['params']['init_num_forms'] = 1;
-			}
-			if ( ! isset( $field['params']['max_num_forms'] ) ) {
-				$field['params']['max_num_forms'] = 1;
-			}
-		} else {
-			$field['params'] = array( 'init_num_forms' => 1, 'max_num_forms' => 1 );
-		}
-		return $field;
+		$field['value'] = $saved;
 	}
 
 	public function ready_and_print_html( $post, $fields ) {
+		$ID = get_the_ID();
 		$fields = $fields['args'];
-		$ready  = $this->process_defaults( $fields );
-		foreach ( $ready as $field ) {
+		$saved = array();
+		foreach ( $fields as $field ) {
+			$field['old_key'] = Models::validate_keys( $field );
+			$field['key'] = $field['old_key'];
+			$saved[$field['old_key']] = get_post_meta( $ID, $field['old_key'], $single = true );
+			$this->process_defaults( $ID, $field, $saved[$field['old_key']] );
 			$this->HTML->draw( $field );
 		}
 	}

--- a/js/functions.js
+++ b/js/functions.js
@@ -1,5 +1,5 @@
 function delete_form_data(slug, form_id) {
-    var selectorBase = "*[id='" + slug + "_formset'] *[class*='form-input_" + form_id + "']";
+    var selectorBase = "*[id='" + slug + "-set'] *[class*='set-input_" + form_id + "']";
 
     // Clear text fields
     jQuery(selectorBase).each( function(index) {
@@ -8,14 +8,6 @@ function delete_form_data(slug, form_id) {
         var contents = jQuery(iframe).contents();
         var wysiwyg = contents.find("body");
         wysiwyg.html("");
-        // var wysiwyg = 
-
-        // console.log(wysiwyg);
-        // Clear WYSIWYG
-        // jQuery(wysiwyg).each( function(index) {
-        //     console.log(this);
-            // jQuery(this).html("");
-        // });
     });
     // Clear checkboxes & radio buttons
     jQuery(selectorBase + ':checked').each( function(index) {
@@ -27,19 +19,19 @@ function delete_form_data(slug, form_id) {
     });
 }
 
-function toggle_fieldset_of_formset(element) {
+function toggle_repeated_field(element) {
     var classes = jQuery(element).attr('class').split(/\s+/);
     var form_id = classes[3];
     var action = classes[2];
     var slug = classes[1];
-    var header = jQuery('#' + slug + '_header');
-    var targeted_input = jQuery('#' + slug + '_formset');
+    var header = jQuery('#' + slug + '-header');
+    var targeted_input = jQuery('#' + slug + '-set');
     if ( action == 'add') {
         // Enable and show the fieldset
         jQuery(targeted_input).toggleClass('new');
         jQuery(targeted_input).toggleClass('expanded');
+        jQuery(targeted_input).toggleClass('hidden');
         jQuery(targeted_input).attr('disabled', false);
-        jQuery(targeted_input).toggle();
 
         // Hide the add link
         jQuery(element).toggleClass('hidden');
@@ -52,30 +44,28 @@ function toggle_fieldset_of_formset(element) {
 
         // Show the header
         jQuery(header).removeClass('hidden');
+
     } else if ( action == 'remove' ) {
         // Delete form data, and hide the fieldset
         delete_form_data(slug, form_id);
         jQuery(targeted_input).toggleClass('expanded');
         jQuery(targeted_input).toggleClass('new');
-        jQuery(targeted_input).css(' display: none; ');
-        jQuery(targeted_input).toggle();
+        jQuery(targeted_input).toggleClass('hidden');
 
-        // Hide the remove link
+        // // Hide the remove link
         jQuery(element).toggleClass('hidden');
         jQuery(element).attr('disabled', true);
 
-        // Show add link
+        // // Show add link
         var add_link = jQuery("." + slug + ".add");
         jQuery(add_link).toggleClass('hidden');
         jQuery(add_link).attr('disabled', false);
 
-        // Hide the header
-        jQuery(header).addClass('hidden');
     }
 }
 
-jQuery('a.toggle_form_manager').click( function() {
-    toggle_fieldset_of_formset(this);
+jQuery('a.toggle-repeated-field').click( function() {
+    toggle_repeated_field(this);
 });
 
 jQuery(document).ready(function($){

--- a/js/functions.js
+++ b/js/functions.js
@@ -1,10 +1,9 @@
 function delete_form_data(slug, form_id) {
-    var selectorBase = "*[id='" + slug + "-set'] *[class*='set-input_" + form_id + "']";
-
+    var selectorBase = '#' + slug + '-set .set-input_' + form_id;
     // Clear text fields
     jQuery(selectorBase).each( function(index) {
         jQuery(this).val("");
-        var iframe = "iframe[id=" + this.id + "_ifr";
+        var iframe = '#' + this.id + '_ifr';
         var contents = jQuery(iframe).contents();
         var wysiwyg = contents.find("body");
         wysiwyg.html("");
@@ -52,11 +51,11 @@ function toggle_repeated_field(element) {
         jQuery(targeted_input).toggleClass('new');
         jQuery(targeted_input).toggleClass('hidden');
 
-        // // Hide the remove link
+        // Hide the remove link
         jQuery(element).toggleClass('hidden');
         jQuery(element).attr('disabled', true);
 
-        // // Show add link
+        // Show add link
         var add_link = jQuery("." + slug + ".add");
         jQuery(add_link).toggleClass('hidden');
         jQuery(add_link).attr('disabled', false);

--- a/tests/test-meta_box_html.php
+++ b/tests/test-meta_box_html.php
@@ -27,35 +27,33 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testDrawWithEmptyFieldExpectsWPErrorReturned() {
 		// arrange
-		$field = array();
+		$field = array('type'=>'none');
 		$HTML = new HTML();
-		$mock = $this->getMock('WP_Error');
+		\WP_Mock::wpFunction('wp_die');
 
 		//act
 		$error = $HTML->draw( $field );
 
 		//assert
-		$this->assertInstanceOf( 'WP_Error', $error );
 	}
 	/**
-	 * Tests that the draw method will call draw_formset() if given field of
+	 * Tests that the draw method will call draw_repeated_fields() if given field of
 	 * of type 'formset'.
 	 *
 	 * @group stable
 	 * @group formset
 	 */
-	function testDrawWithFieldTypeFormsetCallsDrawFormset() {
+	function testDrawRepeatedFields() {
 		//arrange
-		$TestValidBox = new \TestValidBox;
-		$TestValidBox->fields['field_one']['type'] = 'formset';
-		$field = $TestValidBox->fields['field_one'];
+		$TestRepeatedFields = new \TestRepeatedFields;
+		$field = $TestRepeatedFields->fields['fields'];
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'draw_formset', ) )
+					 ->setMethods( array( 'draw_repeated_fields', ) )
 					 ->getMock();
 		$HTML->expects( $this->once() )
-			 ->method( 'draw_formset' )
+			 ->method( 'draw_repeated_fields' )
 			 ->will( $this->returnValue( true ) );
-		\WP_Mock::wpFunction( 'esc_attr' );
+		// \WP_Mock::wpFunction( 'esc_attr' );
 
 		//act
 		$HTML->draw( $field );
@@ -139,9 +137,10 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testDrawWithHiddenFieldCallsHidden() {
 		//arrange
-		$TestValidBox = new TestValidBox();
-		$TestValidBox->fields['field_one']['type'] = 'hidden';
-		$field = $TestValidBox->fields['field_one'];
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields['field']['type'] = 'hidden';
+		$TestValidTextField->fields['field']['value'] = 'data';
+		$field = $TestValidTextField->fields['field'];
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'hidden', ) )
 					 ->getMock();
@@ -165,9 +164,9 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testDrawWithNonceFieldCallsWPNonceField() {
 		//arrange
-		$TestValidBox = new TestValidBox();
-		$TestValidBox->fields['field_one']['type'] = 'nonce';
-		$field = $TestValidBox->fields['field_one'];
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields['field']['type'] = 'nonce';
+		$field = $TestValidTextField->fields['field'];
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
@@ -182,103 +181,9 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		// Passes when called for nonce type
 	}
 	/**
-	 * Tests that the draw_formset() method will call get_the_ID().
+	 * Tests that the get_set_id() method will return expected output.
 	 *
-	 * @group stable
-	 * @group wp_function
-	 */
-	function testDrawFormsetShouldCallGetTheID() {
-		//arrange
-		$Formset = new TestValidFormsetField();
-		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'draw' ) )
-					 ->getMock();
-		\WP_Mock::wpFunction( 'get_the_ID', array( 'times' => 1 ) );
-		\WP_Mock::wpFunction( 'get_post_custom' );
-
-		//act
-		$HTML->draw_formset( $Formset->fields['field'] );
-
-		//assert
-		// Passes if get_the_ID() is called once.
-	}
-	/**
-	 * Tests that the draw_formset() method will call get_post_custom().
-	 *
-	 * @group stable
-	 * @group wp_function
-	 */
-	function testDrawFormsetShouldCallGetPostCustom() {
-		//arrange
-		$Formset = new TestValidFormsetField();
-		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'draw' ) )
-					 ->getMock();
-		\WP_Mock::wpFunction( 'get_the_ID' );
-		\WP_Mock::wpFunction( 'get_post_custom', array( 'times' => 1 ) );
-
-		//act
-		$HTML->draw_formset( $Formset->fields['field'] );
-
-		//assert
-		// Passes if get_post_custom() is called once.
-	}
-	/**
-	 * Tests that the draw_formset() method will call get_formset_id().
-	 *
-	 * @group stable
-	 */
-	function testDrawFormsetShouldCallGetFormsetID() {
-		//arrange
-		$field = array(
-			'meta_key' => 'test_0',
-			'fields' => array(),
-		);
-		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
-					 ->getMock();
-		$HTML->expects( $this->once() )
-			 ->method( 'get_formset_id' )
-			 ->	will( $this->returnValue( true ) );
-		\WP_Mock::wpFunction( 'get_the_ID' );
-		\WP_Mock::wpFunction( 'get_post_custom' );
-
-		//act
-		$HTML->draw_formset( $field );
-
-		//assert
-		// Passes if get_formset_id() is called once.
-	}
-	/**
-	 * Tests that the draw_formset() method will call get_existing_data().
-	 *
-	 * @group stable
-	 */
-	function testDrawFormsetShouldCallGetExistingData() {
-		//arrange
-		$field = array(
-			'meta_key' => 'test_0',
-			'fields' => array(),
-		);
-		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
-					 ->getMock();
-		$HTML->expects( $this->once() )
-			 ->method( 'get_existing_data' )
-			 ->	will( $this->returnValue( true ) );
-		\WP_Mock::wpFunction( 'get_the_ID' );
-		\WP_Mock::wpFunction( 'get_post_custom' );
-
-		//act
-		$HTML->draw_formset( $field );
-
-		//assert
-		// Passes if get_existing_data() is called once.
-	}
-	/**
-	 * Tests that the get_formset_id() method will return expected output.
-	 *
-	 * get_formset_id() works by looking for a digit surrounded by underscores
+	 * get_set_id() works by looking for a digit surrounded by underscores
 	 * and then concatenates each digit by a '-' and returns it. This is used
 	 * for the front-end "Remove" button function to remove only a specific
 	 * formset.
@@ -286,16 +191,16 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 * @group stable
 	 * @group formset
 	 */
-	function testGetFormsetIDReturnsExpectedOutput() {
+	function testGetSetIDReturnsExpectedOutput() {
 		// arrange
-		$form_meta_key = 'test_0_3';
+		$form_key = 'test_0_3';
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
 		$expected = '0-3';
 
 		//act
-		$actual = $HTML->get_formset_id( $form_meta_key );
+		$actual = $HTML->get_set_id( $form_key );
 
 		//assert
 		$this->assertEquals( $actual, $expected );
@@ -308,20 +213,16 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testGetExistingDataWithNonFieldsetFieldAddsExistingDataToArray() {
 		//arrange
-		$field = array(
-			'fields' => array(
-				array( 'type' => 'text', 'meta_key' => 'field'),
-			),
-		);
-		$existing = array();
-		$data = array( 'field' => 'data' );
+		$TestValidTextField = new TestValidTextField();
+		$field = $TestValidTextField->fields['field'];
+		$field['value'] = 'data';
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
-		$expected = array( 0 => 'data' );
+		$expected = true;
 
 		// act
-		$HTML->get_existing_data( $field, $existing, $data );
+		$existing = $HTML->get_existing_data( $field );
 
 		// assert
 		$this->assertEquals( $existing, $expected );
@@ -338,21 +239,21 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$selections = array(
 			array(
 				'type' => 'select',
-				'meta_key' => 'select',
+				'key' => 'select',
 				'params' => array(),
 				'value' => '',
 				'placeholder' => '',
 			),
 			array(
 				'type' => 'multiselect',
-				'meta_key' => 'multiselect',
+				'key' => 'multiselect',
 				'params' => array(),
 				'value' => '',
 				'placeholder' => '',
 			),
 			array(
 				'type' => 'taxonomyselect',
-				'meta_key' => 'taxonomyselect',
+				'key' => 'taxonomyselect',
 				'params' => array(),
 				'value' => '',
 				'placeholder' => '',
@@ -382,13 +283,14 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testPassSelectCallsTaxonomyAsMetaForTaxAsMetaType() {		
 		//arrange
-		$field = array( 'type' => 'tax_as_meta', 'slug' => '', 'include' => '', 'value' => '', 'placeholder' => '' );
+		$field = array( 'type' => 'tax_as_meta', 'key' => '', 'include' => '', 'value' => '', 'placeholder' => '' );
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'taxonomy_as_meta', ) )
 					 ->getMock();
 		$HTML->expects( $this->once() )
 			 ->method( 'taxonomy_as_meta' )
 			 ->will( $this->returnValue( true ) );
+		\WP_Mock::wpFunction( 'get_the_ID' );
 
 		//act
 		$HTML->pass_select( $field );
@@ -409,13 +311,15 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 			array(
 				'type' => 'post_select',
 				'params' => '',
-				'meta_key' => '',
+				'key' => '',
+				'value' => '',
 				'placeholder' => ''
 			),
 			array(
 				'type' => 'post_multiselect',
 				'params' => '',
-				'meta_key' => '',
+				'key' => '',
+				'value' => '',
 				'placeholder' => ''
 			),
 		);
@@ -427,6 +331,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 			 ->will( $this->returnValue( true ) );
 		\WP_Mock::wpPassthruFunction( 'get_posts' );
 		\WP_Mock::wpPassthruFunction( 'get_post_meta' );
+		\WP_Mock::wpFunction( 'get_the_ID' );
 
 		//act
 		foreach ( $selections as $selection ) {
@@ -448,14 +353,13 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$field = array(
 			'type' => 'post_select',
 			'params' => '',
-			'meta_key' => '',
-			'placeholder' => ''
+			'key' => '',
+			'placeholder' => '',
+			'value' => '',
 		);
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'post_select', ) )
 					 ->getMock();
-		\WP_Mock::wpPassthruFunction( 'get_posts', array( 'times' => 1 ) );
-		\WP_Mock::wpPassthruFunction( 'get_post_meta' );
 
 		//act
 		$HTML->pass_select( $field );
@@ -475,14 +379,13 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$field = array(
 			'type' => 'post_select',
 			'params' => '',
-			'meta_key' => '',
-			'placeholder' => ''
+			'key' => '',
+			'placeholder' => '',
+			'value' => '',
 		);
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'post_select', ) )
 					 ->getMock();
-		\WP_Mock::wpPassthruFunction( 'get_posts' );
-		\WP_Mock::wpPassthruFunction( 'get_post_meta', array( 'times' => 1 ) );
 
 		//act
 		$HTML->pass_select( $field );
@@ -499,7 +402,10 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testDrawInputCallsTextAreaForTextAreaType() {
 		//arrange
-		$TestValidTextAreaField = new TestValidTextAreaField();
+		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField->fields['field']['type'] = 'text_area';
+		$TestValidTextField->fields['field']['rows'] = 2;
+		$TestValidTextField->fields['field']['cols'] = 27;
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'text_area', ) )
 					 ->getMock();
@@ -508,7 +414,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 			 ->will( $this->returnValue( true ) );
 
 		//act
-		$HTML->draw_input( $TestValidTextAreaField->fields['one'] );
+		$HTML->draw_input( $TestValidTextField->fields['field'] );
 
 		//assert
 		// Passes when text_area() is called once
@@ -533,8 +439,8 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 
 		//act
 		foreach ( $types as $type ) {
-			$field->fields['one']['type'] = $type;
-			$HTML->draw_input( $field->fields['one'] );
+			$field->fields['field']['type'] = $type;
+			$HTML->draw_input( $field->fields['field'] );
 		}
 
 		//assert
@@ -620,7 +526,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	function testDrawInputCallsSingleInputForRadioTypeTwice() {
 		//arrange
 		$field = new TestValidTextField();
-		$field->fields['one']['type'] = 'radio';
+		$field->fields['field']['type'] = 'radio';
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'single_input', ) )
 					 ->getMock();
@@ -629,7 +535,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 			 ->will( $this->returnValue( true ) );
 
 		//act
-		$HTML->draw_input( $field->fields['one'] );
+		$HTML->draw_input( $field->fields['field'] );
 
 		//assert
 		// Passes when single_input() is called twice
@@ -643,7 +549,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testDrawInputCallsBooleanInputForBooleanType() {
 		//arrange
-		$field = array( 'type' => 'boolean', 'meta_key' => '' );
+		$field = array( 'type' => 'boolean', 'key' => '' );
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'boolean_input', ) )
 					 ->getMock();
@@ -666,7 +572,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testDrawInputCallsURLInputForLinkType() {
 		//arrange
-		$field = array( 'type' => 'link', 'meta_key' => '' );
+		$field = array( 'type' => 'link', 'key' => '' );
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'link_input', ) )
 					 ->getMock();
@@ -761,7 +667,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		\WP_Mock::wpFunction( 'wp_editor', array( 'times' => 1 ) );
 
 		//act
-		$HTML->wysiwyg( 'content', 'meta_key', array(), null, null);
+		$HTML->wysiwyg( 'content', 'key', array(), null, null);
 	}
 	/***************************
 	 * HTML output tests *
@@ -778,7 +684,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$field = array(
 			'type' => 'text',
 			'title' => 'Test Title',
-			'meta_key' => 'field'
+			'key' => 'field'
 		);
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'draw_input', ) )
@@ -803,7 +709,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		//arrange
 		$field = array(
 			'type' => 'text',
-			'meta_key' => 'field'
+			'key' => 'field'
 		);
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( array( 'draw_input', ) )
@@ -825,15 +731,21 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 * @group unstable
 	 * @group draw
 	 */
-	function testDrawFormsetWithTitleExpectsNoTitle() {
+	function testDrawRepeatedFieldsWithTitleExpectsNoTitle() {
 		//arrange
 		$field = array(
-			'type' => 'formset',
+			'type' => 'text',
 			'title' => 'Test Title',
-			'meta_key' => 'field'
+			'key' => 'field',
+			'params' => array(
+				'repeated' => array(
+					'min' => 1,
+					'max' => 2
+				),
+			),
 		);
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'draw_formset', ) )
+					 ->setMethods( array( 'draw_repeated_fields', ) )
 					 ->getMock();
 		$needle = '<h4 id="field" >Test Title</h4>';
 
@@ -862,7 +774,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 
 		//act
 		ob_start();
-		$HTML->draw( $TestValidTextField->fields['one'] );
+		$HTML->draw( $TestValidTextField->fields['field'] );
 		$haystack = ob_get_flush();
 
 		//assert
@@ -876,7 +788,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testDrawFieldDoesNotHaveHowToSetDoesNotGetEchoed() {
 		//arrange
-		$field = array();
+		$field = array('type'=>'none');
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
@@ -908,207 +820,40 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 
 		//act
 		ob_start();
-		$HTML->draw( $TestValidTextField->fields['one'] );
+		$HTML->draw( $TestValidTextField->fields['field'] );
 		$haystack = ob_get_flush();
 
 		//assert
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-	 * Tests that the draw_formset() method will output div with field meta_key
+	 * Tests that the draw_repeated_fields() method will output div with field key
 	 * as html attribute id and concatenates it with 'formset'.
 	 *
 	 * @group unstable
-	 * @group draw_formset
+	 * @group draw_repeated_fields
 	 */
-	function testDrawFormsetShowsNewInitialField() {
+	function testDrawRepeatedFieldsShowsNewInitialField() {
 		//arrange
 		$field = array( 
 			'init' => true,
-			'meta_key' => 'test',
+			'key' => 'test',
 			'fields' => array(),
 		);
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
+					 ->setMethods( array( 'get_existing_data', 'get_set_id' ) )
 					 ->getMock();
 		\WP_Mock::wpFunction( 'get_post_custom' );
 		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
-		$needle = '<div id="test_formset">';
+		$needle = '<div id="test" class="form">';
 
 		//act
 		ob_start();
-		$HTML->draw_formset( $field );
+		$HTML->draw_repeated_fields( $field );
 		$haystack = ob_get_flush();
 
 		//assert
 		$this->assertContains( $needle, $haystack );
-	}
-	/**
-	 * Tests that the draw_formset() method will output a hidden div because when
-	 * it is not an initial field and data does not exist for it.
-	 *
-	 * @group unstable
-	 * @group draw_formset
-	 */
-	function testDrawFormsetHidesNonexistentNoninitialField() {
-		//arrange
-		$field = array( 'meta_key' => 'test', 'fields' => array() );
-		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'get_existing_data', 'get_formset_id' ) )
-					 ->getMock();
-		\WP_Mock::wpFunction( 'get_post_custom' );
-		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
-		$needle = '<div id="test_formset" class="hidden new" disabled>';
-
-		//act
-		ob_start();
-		$HTML->draw_formset( $field );
-		$haystack = ob_get_flush();
-
-		//assert
-		$this->assertContains( $needle, $haystack );
-	}
-	/**
-	 * Tests that the draw_formset() method will output a hidden div because when
-	 * it is not an initial field and data does not exist for it.
-	 *
-	 * @group unstable
-	 * @group draw_formset
-	 */
-	function testDrawFormsetHidesHeaderForInvisibleField() {
-		//arrange
-		$field = array(
-			'title' => 'Test Title',
-			'fields' => array(
-				array(
-					'meta_key' => 'test_field',
-				),
-			),
-			'meta_key' => 'test' 
-		);
-		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'draw' ) )
-					 ->getMock();
-		\WP_Mock::wpPassthruFunction( 'get_post_custom' );
-		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		$needle = '<h4 id="test_header" class="formset-header hidden">';
-		
-		//act
-		ob_start();
-		$HTML->draw_formset( $field );
-		$haystack = ob_get_flush();
-
-		//assert
-		$this->assertContains( $needle, $haystack );
-	}
-	/**
-	 * Tests that the draw_formset() method will output a header.
-	 *
-	 * @group unstable
-	 * @group draw_formset
-	 */
-	function testDrawFormsetShowsHeaderForVisibleField() {
-		//arrange
-		$field = array(
-			'title' => 'Test Title',
-			'fields' => array(
-				array(
-					'meta_key' => 'test_field',
-				),
-			),
-			'meta_key' => 'test',
-			'init' => true
-		);
-		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'draw' ) )
-					 ->getMock();
-		\WP_Mock::wpPassthruFunction( 'get_post_custom' );
-		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		$needle = '<h4 id="test_header" class="formset-header">';
-		
-		//act
-		ob_start();
-		$HTML->draw_formset( $field );
-		$haystack = ob_get_flush();
-
-		//assert
-		$this->assertContains( $needle, $haystack );
-	}
-	/**
-	 * Tests that the draw_formset() method will show remove link and hide add
-	 * link when field has data and/or is an initial field.
-	 *
-	 * @group unstable
-	 * @group draw_formset
-	 */
-	function testDrawFormsetShowsRemoveButtonAndHidesAddButtonForVisibleField() {
-		//arrange
-		$field = array(
-			'title' => 'Test Title',
-			'fields' => array(
-				array(
-					'type' => 'text',
-					'meta_key' => 'test_field',
-				),
-			),
-			'meta_key' => 'test' 
-		);
-		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'get_formset_id', 'draw' ) )
-					 ->getMock();
-		\WP_Mock::wpFunction( 'get_post_custom', array( 'return' => array('test_field' => 'data' ) ) );
-		\WP_Mock::wpPassthruFunction( 'esc_attr', array( 'return' => 'test') );
-		$needle = '<div id="test_formset">';
-		$remove_button = '<a class="toggle_form_manager test remove " href="#remove-formset_">Remove</a>';
-		$add_button = '<a class="toggle_form_manager test add  hidden" href="#add-formset_">Add Test Title</a>';
-		
-		//act
-		ob_start();
-		$HTML->draw_formset( $field );
-		$haystack = ob_get_flush();
-
-		//assert
-		$this->assertContains( $needle, $haystack );
-		$this->assertContains( $remove_button, $haystack );
-		$this->assertContains( $add_button, $haystack );
-	}	
-	/**
-	 * Tests that the draw_formset() method will hide remove link and show add
-	 * link when field has no data and is not an initial field.
-	 *
-	 * @group unstable
-	 * @group draw_formset
-	 */
-	function testDrawFormsetHidesRemoveButtonAndShowsAddButtonForInvisibleField() {
-		//arrange
-		$field = array(
-			'title' => 'Test Title',
-			'fields' => array(
-				array(
-					'meta_key' => 'test_field',
-				),
-			),
-			'meta_key' => 'test' 
-		);
-		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( array( 'get_existing_data', 'get_formset_id', 'draw' ) )
-					 ->getMock();
-		$HTML->method( 'get_formset_id' )
-			 ->will( $this->returnValue( 1 ) );
-		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		$needle = '<div id="test_formset" class="hidden new" disabled>';
-		$remove_button = '<a class="toggle_form_manager test remove 1 hidden" href="#remove-formset_1">Remove</a>';
-		$add_button = '<a class="toggle_form_manager test add 1" href="#add-formset_1">Add Test Title</a>';
-		
-		//act
-		ob_start();
-		$HTML->draw_formset( $field );
-		$haystack = ob_get_flush();
-
-		//assert
-		$this->assertContains( $needle, $haystack );
-		$this->assertContains( $remove_button, $haystack );
-		$this->assertContains( $add_button, $haystack );
 	}
 	/**
 	 * Tests that the text_area() method will draw label.
@@ -1144,7 +889,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 					 ->setMethods( null )
 					 ->getMock();
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		$needle = '<textarea id="field_key" class="cms-toolkit-textarea form-input_12" name="field_key" rows="10" cols="40" value="This is the text." placeholder="Placeholder text." required>This is the text.</textarea>';
+		$needle = '<textarea id="field_key" class="cms-toolkit-textarea set-input_12" name="field_key" rows="10" cols="40" value="This is the text." placeholder="Placeholder text." required>This is the text.</textarea>';
 
 		//act
 		ob_start();
@@ -1188,7 +933,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 					 ->setMethods( null )
 					 ->getMock();
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		$needle = '<input id="field" class="cms-toolkit-input form-input_12" name="field" type="text" maxlength="30" value="The text." placeholder="placeholder" required />';
+		$needle = '<input id="field" class="cms-toolkit-input set-input_12" name="field" type="text" maxlength="30" value="The text." placeholder="placeholder" required />';
 
 		//act
 		ob_start();
@@ -1232,7 +977,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 					 ->setMethods( null )
 					 ->getMock();
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		$needle = '<input id="field" class="cms-toolkit-checkbox form-input_12" name="field" type="checkbox" checked required />';
+		$needle = '<input id="field" class="cms-toolkit-checkbox set-input_12" name="field" type="checkbox" checked required />';
 
 		//act
 		ob_start();
@@ -1276,7 +1021,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 					 ->setMethods( null )
 					 ->getMock();
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		$needle = '<input class="cms-toolkit-input form-input_12" id="field_key" name="field_key" type="hidden" value="value" />';
+		$needle = '<input class="cms-toolkit-input set-input_12" id="field_key" name="field_key" type="hidden" value="value" />';
 
 		//act
 		ob_start();
@@ -1321,7 +1066,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 					 ->setMethods( null )
 					 ->getMock();
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		$needle = '<select id="field_key" name="field_key[]" class="form-input_12" multiple required>';
+		$needle = '<select id="field_key" name="field_key[]" class="set-input_12" multiple required>';
 		$needle .= '<option selected value="">--</option></select>';
 
 		//act
@@ -1415,7 +1160,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 					 ->setMethods( null )
 					 ->getMock();
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		$needle = '<select class="form-input_12" id="field_key" name="field_key[]" multi required >';
+		$needle = '<select class="set-input_12" id="field_key" name="field_key[]" multi required >';
 
 		//act
 		ob_start();
@@ -1492,7 +1237,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 					 ->setMethods( null )
 					 ->getMock();
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		$needle = '<select class="multi form-input_12" name="field_slug[]" multi required>';
+		$needle = '<select class="multi set-input_12" name="field_slug[]" multi required>';
 
 		//act
 		ob_start();
@@ -1581,7 +1326,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
 		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
 		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( $term ) ) );
-		$needle = '<select id="tax_month" name="tax_month" class="form-input_12">';
+		$needle = '<select id="tax_month" name="tax_month" class="set-input_12">';
 		$needle .= '<option selected="selected" value="" >Month</option>';
 
 		//act
@@ -1644,8 +1389,8 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
 		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
 		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( $term ) ) );
-		$needle = '<input id="tax_day" type="text" name="tax_day" class="form-input_12" value="" size="2" maxlength="2" placeholder="DD"/>';
-		$needle .= '<input id="tax_year" type="text" name="tax_year" class="form-input_12" value="" size="4" maxlength="4" placeholder="YYYY"/>';
+		$needle = '<input id="tax_day" type="text" name="tax_day" class="set-input_12" value="" size="2" maxlength="2" placeholder="DD"/>';
+		$needle .= '<input id="tax_year" type="text" name="tax_year" class="set-input_12" value="" size="4" maxlength="4" placeholder="YYYY"/>';
 
 		//act
 		ob_start();

--- a/tests/test-meta_box_models.php
+++ b/tests/test-meta_box_models.php
@@ -11,24 +11,23 @@ class TestValidBox extends Models {
 	public $fields = array(
 		'field_one' => array(
 			'title' => 'This is a field',
-			'slug' => 'field_one',
+			'key' => 'field_one',
 			'type' => 'text_area',
 			'params' => array(
 				'cols' => 27,
 			),
 			'placeholder' => 'Enter text',
 			'howto' => 'Type some text',
-			'meta_key' => 'field_one',
 			'value' => '',
 		),
 		'field_two' => array(
-			'slug' => 'field_two',
+			'key' => 'field_two',
 			'title' => 'This is another field',
 			'type' => 'number',
 			'params' => array(),
 			'placeholder' => '0-100',
 			'howto' => 'Type a number',
-			'meta_key' => 'field_two',
+			'key' => 'field_two',
 			'value' => '',
 		),
 	);
@@ -41,13 +40,12 @@ class TestNumberField extends Models {
 	public $context = 'side';
 	public $fields = array(
 		'field_one' => array(
-			'slug' => 'field_one',
+			'key' => 'field_one',
 			'title' => 'This is another field',
 			'type' => 'number',
 			'params' => array(),
 			'placeholder' => '0-100',
 			'howto' => 'Type a number',
-			'meta_key' => 'field_one',
 		),
 	);
 }
@@ -55,15 +53,14 @@ class TestNumberField extends Models {
 class TestValidTextField extends Models {
 	public $post_type = 'post';
 	public $fields = array(
-		'one' => array(
+		'field' => array(
 			'title' => 'Text Field',
-			'slug' => 'one',
+			'key' => 'field',
 			'label' => 'Text Label',
 			'type' => 'text',
 			'params' => array('max_length' => 255),
 			'placeholder' => 'Type some text',
 			'howto' => 'Up to 255 characters',
-			'meta_key' => 'one',
 		),
 	);
 }
@@ -71,9 +68,9 @@ class TestValidTextField extends Models {
 class TestValidTextAreaField extends Models {
 	public $post_type = 'post';
 	public $fields = array(
-		'one' => array(
+		'field' => array(
 			'title' => 'Text Area Field',
-			'slug' => 'one',
+			'key' => 'field',
 			'label' => 'Text Label',
 			'type' => 'text_area',
 			'params' => array('max_length' => 255),
@@ -81,7 +78,6 @@ class TestValidTextAreaField extends Models {
 			'cols' => 5,
 			'placeholder' => 'Type some text',
 			'howto' => 'Up to 255 characters',
-			'meta_key' => 'one',
 		),
 	);
 }
@@ -89,15 +85,14 @@ class TestValidTextAreaField extends Models {
 class TestValidEmailField extends Models {
 	public $post_type = 'post';
 	public $fields = array(
-		'one' => array(
+		'field' => array(
 			'title' => 'Email Field',
-			'slug' => 'one',
+			'key' => 'field',
 			'label' => 'Email Label',
 			'type' => 'email',
 			'params' => array(),
 			'placeholder' => 'Type some text',
 			'howto' => 'Up to 255 characters',
-			'meta_key' => 'one',
 		),
 	);
 }
@@ -107,7 +102,7 @@ class TestValidDateField extends Models {
 	public $fields = array(
 		'category' => array(
 			'title' => 'Issued date:',
-			'slug' => 'category',
+			'key' => 'category',
 			'label' => '',
 			'type' => 'date',
 			'params' => array(),
@@ -127,36 +122,36 @@ class TestValidFieldsetField extends Models {
 			'fields' => array(
 				array(
 					'type' => 'text',
-					'meta_key' => 'num',
+					'key' => 'num',
+					'key' => 'num',
 				),
 				array(
 					'type' => 'text',
-					'meta_key' => 'desc',
+					'key' => 'desc',
+					'key' => 'desc',
 				),
 			),
 			'params' => array(),
-			'meta_key' => 'field',
+			'key' => 'field',
+			'key' => 'field',
 		),
 	);
 }
 
-class TestValidFormsetField extends Models {
+class TestRepeatedFields extends Models {
 	public $post_type = 'post';
 	public $fields = array(
-		'field' => array(
-			'type' => 'formset',
-			'fields' => array(
-				array(
-					'title' => 'Title',
-					'type' => 'text',
-					'meta_key' => 'title',
+		'fields' => array(
+			'type' => 'text',
+			'key' => 'field',
+			'key' => 'field',
+			'label' => 'Text',
+			'params' => array(
+				'repeated' => array(
+					'min' => 1,
+					'max' => 2,
 				),
 			),
-			'params' => array(
-				'init_num_forms' => 1,
-				'max_num_forms' => 2,
-			),
-			'meta_key' => 'field',
 		),
 	);
 }
@@ -192,14 +187,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		global $post;
 		$TestValidTextField = new TestValidTextField();
 		$TestValidTextField->fields = array();
-		$stub = $this->getMockBuilder( '\WP_Error' )
-					 ->setMethods( array('get_error_message') )
-					 ->getMock();
-		$TestValidTextField->error_handler($stub);
-		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-		$TestValidTextField->error->expects( $this->once() )
-			 ->method( 'get_error_message' )
-			 ->will( $this->returnValue( true ) );
+		\WP_Mock::wpFunction( 'wp_die', array( 'times' => 1 ) );
 
 		// act
 		$TestValidTextField->validate_and_save( $post->ID );
@@ -221,25 +209,20 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		// arrange
 		global $post;
 		$TestValidTextField = new TestValidTextField();
-		$TestValidTextField->fields['one']['type'] = null;
-		$stub = $this->getMockBuilder( '\WP_Error' )
-					 ->setMethods( array('get_error_message') )
-					 ->getMock();
-		$TestValidTextField->error_handler($stub);
-		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-		$TestValidTextField->error->expects( $this->once() )
-			 ->method( 'get_error_message' )
-			 ->will( $this->returnValue( true ) );
+		$TestValidTextField->fields['field']['type'] = null;
+		\WP_Mock::wpFunction( 'wp_die', array( 'times' => 1 ) );
+		$validated = array();
+		$saved = array();
 
 		// act
-		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
+		$TestValidTextField->validate( $post->ID, $TestValidTextField->fields['field'], $validated, $saved );
 
 		// assert
 		// Passes when error is called
 	}
 	/**
-	 * Tests if the validate method will throw an error if the field does not have
-	 * the meta_key, slug, or taxonomy set.
+	 * Tests if the validate_keys method will throw an error if the field does not have
+	 * the key, key, or taxonomy set.
 	 *
 	 *
 	 * @group stable
@@ -251,20 +234,13 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		// arrange
 		global $post;
 		$TestValidTextField = new TestValidTextField();
-		$TestValidTextField->fields['one']['meta_key'] = null;
-		$TestValidTextField->fields['one']['slug'] = null;
-		$TestValidTextField->fields['one']['taxonomy'] = null;
-		$stub = $this->getMockBuilder( '\WP_Error' )
-					 ->setMethods( array('get_error_message') )
-					 ->getMock();
-		$TestValidTextField->error_handler($stub);
-		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-		$TestValidTextField->error->expects( $this->once() )
-			 ->method( 'get_error_message' )
-			 ->will( $this->returnValue( true ) );
+		$TestValidTextField->fields['field']['key'] = null;
+		$TestValidTextField->fields['field']['key'] = null;
+		$TestValidTextField->fields['field']['taxonomy'] = null;
+		\WP_Mock::wpFunction( 'wp_die', array( 'times' => 1 ) );
 
 		// act
-		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
+		$TestValidTextField->validate_keys( $TestValidTextField->fields['field'] );
 
 		// assert
 		// Passes when error is called
@@ -283,19 +259,14 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		// arrange
 		global $post;
 		$TestValidTextField = new TestValidTextField();
-		$TestValidTextField->fields['one']['taxonomy'] = null;
-		$TestValidTextField->fields['one']['type'] = 'taxonomyselect';
-		$stub = $this->getMockBuilder( '\WP_Error' )
-					 ->setMethods( array('get_error_message') )
-					 ->getMock();
-		$TestValidTextField->error_handler($stub);
-		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-		$TestValidTextField->error->expects( $this->once() )
-			 ->method( 'get_error_message' )
-			 ->will( $this->returnValue( true ) );
+		$TestValidTextField->fields['field']['taxonomy'] = null;
+		$TestValidTextField->fields['field']['type'] = 'taxonomyselect';
+		\WP_Mock::wpFunction( 'wp_die', array( 'times' => 1 ) );
+		$validated = array();
+		$saved = array();
 
 		// act
-		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
+		$TestValidTextField->validate( $post->ID, $TestValidTextField->fields['field'], $validated, $saved );
 
 		// assert
 		// Passes when error is called
@@ -313,109 +284,17 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 	function testFieldTypeDateWhereTaxonomyIsNotSetExpectsError() {
 		// arrange
 		global $post;
-		$TestValidTextField = new TestValidTextField();
-		$TestValidTextField->fields['one']['taxonomy'] = null;
-		$TestValidTextField->fields['one']['type'] = 'date';
-		$stub = $this->getMockBuilder( '\WP_Error' )
-					 ->setMethods( array('get_error_message') )
+		$TestValidTextField = $this->getMockBuilder( 'TestValidTextField' )
+					 ->setMethods( array('validate_datetime') )
 					 ->getMock();
-		$TestValidTextField->error_handler($stub);
-		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-		$TestValidTextField->error->expects( $this->once() )
-			 ->method( 'get_error_message' )
-			 ->will( $this->returnValue( true ) );
+		$TestValidTextField->fields['field']['taxonomy'] = null;
+		$TestValidTextField->fields['field']['type'] = 'date';
+		\WP_Mock::wpFunction( 'wp_die', array( 'times' => 1 ) );
+		$validated = array();
+		$saved = array();
 
 		// act
-		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
-
-		// assert
-		// Passes when error is called
-	}
-	/**
-	 * Tests if the validate method will throw an error if the field does not have
-	 * the meta_key set when required for select field(s). This will only test
-	 * one of the fields of the selects array.
-	 *
-	 * @group stable
-	 * @group empty_data
-	 * @group isolated
-	 * @group validation
-	 */
-	function testFieldTypeOfSelectsArrayWhereMetakeyIsNotSetExpectsError() {
-		// arrange
-		global $post;
-		$TestValidTextField = new TestValidTextField();
-		$TestValidTextField->fields['one']['meta_key'] = null;
-		$TestValidTextField->fields['one']['type'] = 'select';
-		$stub = $this->getMockBuilder( '\WP_Error' )
-					 ->setMethods( array('get_error_message') )
-					 ->getMock();
-		$TestValidTextField->error_handler($stub);
-		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-		$TestValidTextField->error->expects( $this->once() )
-			 ->method( 'get_error_message' )
-			 ->will( $this->returnValue( true ) );
-
-		// act
-		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['one'] ), $actual );
-
-		// assert
-		// Passes when error is called
-	}
-	/**
-	 * Tests if the validate method will throw an error if the field of formset
-	 * type does not have a params array set.
-	 *
-	 * @group stable
-	 * @group empty_data
-	 * @group isolated
-	 * @group validation
-	 */
-	function testFieldTypeFormsetWhereParamsArrayIsNotSetExpectsError() {
-		// arrange
-		global $post;
-		$TestValidTextField = new TestValidFormsetField();
-		$TestValidTextField->fields['field']['params'] = null;
-		$stub = $this->getMockBuilder( '\WP_Error' )
-					 ->setMethods( array('get_error_message') )
-					 ->getMock();
-		$TestValidTextField->error_handler($stub);
-		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-		$TestValidTextField->error->expects( $this->once() )
-			 ->method( 'get_error_message' )
-			 ->will( $this->returnValue( true ) );
-
-		// act
-		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['field'] ), $actual );
-
-		// assert
-		// Passes when error is called
-	}
-	/**
-	 * Tests if the validate method will throw an error if the field of formset
-	 * type does not have a max_num_forms set in the params array.
-	 *
-	 * @group stable
-	 * @group empty_data
-	 * @group isolated
-	 * @group validation
-	 */
-	function testFieldTypeFormsetWhereMaxNumFormsInParamsArrayIsNotSetExpectsError() {
-		// arrange
-		global $post;
-		$TestValidTextField = new TestValidFormsetField();
-		$TestValidTextField->fields['field']['params']['max_num_forms'] = null;
-		$stub = $this->getMockBuilder( '\WP_Error' )
-					 ->setMethods( array('get_error_message') )
-					 ->getMock();
-		$TestValidTextField->error_handler($stub);
-		$TestValidTextField->error = new $TestValidTextField->error( 'TEST' );
-		$TestValidTextField->error->expects( $this->once() )
-			 ->method( 'get_error_message' )
-			 ->will( $this->returnValue( true ) );
-
-		// act
-		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields['field'] ), $actual );
+		$TestValidTextField->validate( $post->ID, $TestValidTextField->fields['field'], $validated, $saved );
 
 		// assert
 		// Passes when error is called
@@ -423,6 +302,30 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 /***************************
  * Validation method tests *
  ***************************/
+	/**
+	 * Tests whether the validate_and_save method will call validate_keys()
+	 *
+	 *
+	 * @group stable
+	 * @group isolated
+	 * @group validation
+	 */
+	function testValidateAndSaveCallsValidateKeys() {
+		// arrange
+		global $post;
+		$stub = $this->getMockBuilder( 'TestValidTextField' )
+					 ->setMethods( array('validate_keys') )
+					 ->getMock();
+		$stub->expects($this->once())
+			 ->method('validate_keys');
+		\WP_Mock::wpPassthruFunction('get_post_meta');
+
+		// act
+		$stub->validate_and_save( $post->ID );
+
+		// assert
+		// Passes when error is called
+	}
 	/**
 	 * Tests whether the validate method will save a null value to the array if
 	 * data from $_POST is missing
@@ -443,11 +346,14 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		$_POST = array();
 		global $post;
 		$TestValidTextField = new TestValidTextField();
-		$actual = array();
+		$validated = array();
+		$saved = array();
+
 		// act
-		$TestValidTextField->validate( $post->ID, array_pop( $TestValidTextField->fields ), $actual );
+		$TestValidTextField->validate( $post->ID, $TestValidTextField->fields['field'], $validated, $saved );
+
 		// assert
-		$this->assertTrue( empty( $actual ) );
+		$this->assertTrue( empty( $validated ) );
 	}
 	/**
 	 * Tests whether the validate method when called on an email field calls
@@ -465,11 +371,11 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		\WP_Mock::wpPassthruFunction('sanitize_email', array('times' => 1));
 		$TestValidEmailField = new TestValidEmailField();
 		$_POST = array(
-			'one' => 'foo@bar.baz',
+			'field' => 'foo@bar.baz',
 		);
 		$actual = array();
 		// act
-		$TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual);
+		$TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['field'], $actual);
 	}
 
 	/**
@@ -487,16 +393,16 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'post_ID' => 1,
 			'field_one' => 2,
 		);
-		$actual = array();
+		$validated = array();
 
 		// act
-		$TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual);
+		$TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $validated['field_one'], array());
 
 		// assert
 		$expected = 2;
 		$this->assertEquals(
 			$expected,
-			$actual['field_one'],
+			$validated['field_one'],
 			'Numeric strings should be accepted and converted to a number.');
 	}
 
@@ -518,15 +424,15 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'post_ID' => 1,
 			'field_one' => 'Two',
 		);
-		$actual = array();
+		$validated = array();
 
 		// act
-		$TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $actual);
+		$TestNumberField->validate($_POST['post_ID'], $TestNumberField->fields['field_one'], $validated['field_one'], array());
 		// assert
 		$expected = null;
 		$this->assertEquals(
 			$expected,
-			$actual['field_one'],
+			$validated['field_one'],
 			'Non-numeric strings should not be accepted for a number input type.'
 		);
 	}
@@ -544,20 +450,20 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 
 		// arrange
 		$TestValidTextField = new TestValidTextField();
-		$TestValidTextField->fields['one']['type'] = 'text';
+		$TestValidTextField->fields['field']['type'] = 'text';
 		$_POST = array(
 			'post_ID' => 1,
-			'one' => 'Text field expects a string',
+			'field' => 'Text field expects a string',
 		);
-		$actual = array();
+		$validated = array();
 
 		// act
-		$TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['one'], $actual);
+		$TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['field'], $validated['field'], array());
 
 		// assert
 		$this->assertEquals(
 			'Text field expects a string',
-			$actual['one']
+			$validated['field']
 		);
 	}
 
@@ -575,18 +481,18 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		// arrange
 		global $post;
 		$TestValidTextField = new TestValidTextField();
-		$TestValidTextField->fields['one']['type'] = 'text';
+		$TestValidTextField->fields['field']['type'] = 'text';
 		$_POST = array(
 			'post_ID' => 1,
-			'one' => 1,
+			'field' => 1,
 		);
-		$actual = array();
+		$validated = array();
 
 		// act
-		$TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['one'], $actual);
+		$TestValidTextField->validate($_POST['post_ID'], $TestValidTextField->fields['field'], $validated['field'], array());
 
 		// assert
-		$this->assertEquals('1', $actual['one']);
+		$this->assertEquals('1', $validated['field']);
 	}
 
 	/**
@@ -605,21 +511,17 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		$post->ID = 1;
 		$post->post_type = 'post';
 		$TestValidTextAreaField = new TestValidTextAreaField();
-		// \WP_Mock::wpFunction(
-		//  'get_post',
-		//  array('times' => 1, 'returns' => $post)
-		// );
 		$_POST = array(
 			'post_ID' => 1,
-			'one' => 'Foo',
+			'field' => 'Foo',
 		);
-		$actual = array();
+		$validated = array();
 
 		// act
-		$TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
+		$TestValidTextAreaField->validate($_POST['post_ID'], $TestValidTextAreaField->fields['field'], $validated['field'], array());
 
 		//assert
-		$this->assertEquals('Foo', $actual['one']);
+		$this->assertEquals('Foo', $validated['field']);
 	}
 
 	/**
@@ -634,26 +536,18 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 	function testTextAreaFieldNonStringExpectsNullReturned() {
 		// arrange
 		global $post;
-		// $post = new StdClass;
-		// $post->post_type = 'post';
-		// $post->ID = 1;
-		$stub = $this->getMock('\WP_Error', array('get_error_message'));
-		// \WP_Mock::wpFunction(
-		//  'get_post',
-		//  array('times' => 1, 'return' => $post));
 		$TestValidTextAreaField = new TestValidTextAreaField();
-		$TestValidTextAreaField->error_handler($stub);
 		$_POST = array(
 			'post_ID' => 1,
-			'one' => null,
+			'field' => null,
 		);
-		$actual = array();
+		$validated = array();
 
 		// act
-		$TestValidTextAreaField->validate($post->ID, $TestValidTextAreaField->fields['one'], $actual);
+		$TestValidTextAreaField->validate($_POST['post_ID'], $TestValidTextAreaField->fields['field'], $validated['field'], array());
 
 		// assert
-		$this->assertTrue( ! isset( $actual['one'] ) );
+		$this->assertTrue( ! isset( $validated['field'] ) );
 	}
 
 	/**
@@ -672,22 +566,18 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'esc_url_raw',
 			array('times' => 1, 'return' => 'http://google.com')
 		);
-		// \WP_Mock::wpFunction(
-		//  'get_post',
-		//  array('times' => 1,'return' => $post,)
-		// );
 		$TestValidEmailField = new TestValidEmailField();
-		$TestValidEmailField->fields['one']['type'] = 'url';
+		$TestValidEmailField->fields['field']['type'] = 'url';
 		$_POST = array(
-			'one' => 'http://google.com',
+			'field' => 'http://google.com',
 		);
-		$actual = array();
+		$validated = array();
 
 		// act
-		$TestValidEmailField->validate($post->ID, $TestValidEmailField->fields['one'], $actual );
+		$TestValidEmailField->validate(1, $TestValidEmailField->fields['field'], $validated['field'], array());
 
 		// assert
-		$this->assertEquals($actual['one'], 'http://google.com');
+		$this->assertEquals($validated['field'], 'http://google.com');
 	}
 
 	/**
@@ -830,32 +720,38 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		// Test will fail if validate_fieldset isn't executed once and only once
 	}
 	/**
-	 * Tests whether the validate_formset method is called when validating a
-	 * field of type 'formset'
+	 * Tests whether the validate_repeated_field method is called when validating a
+	 * field that has a 'repeated' parameter set
 	 *
 	 * @group stable
-	 * @group formset
+	 * @group fieldset
 	 * @group isolated
-	 * @group validate_formset
+	 * @group validate_fieldset
 	 */
-	function testValidFormsetExpectsValidateToBeCalled() {
+	function testValidRepeatedFieldToCallFunctions() {
 		// arrange
 		global $post;
-		$factory = $this->getMockBuilder('TestValidFormsetField')
-						->setMethods( array( 'validate_formset', ) )
+		$factory = $this->getMockBuilder('TestRepeatedFields')
+						->setMethods( array( 'validate_repeated_field', ) )
 						->getMock();
 		$factory->expects($this->once())
-				->method('validate_formset')
+				->method('validate_repeated_field')
 				->will($this->returnValue(true));
+		$View = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
+						->setMethods( array( 'process_repeated_field_params', ) )
+						->getMock();
+		$View->expects($this->once())
+				->method('process_repeated_field_params')
+				->will($this->returnValue(true));
+		$factory->set_view($View);
 		$validate = array();
 
 		// act
-		$factory->validate( $post->ID, $factory->fields['field'], $validate );
+		$factory->validate( $post->ID, $factory->fields['fields'], $validate );
 
 		// assert
-		// Test will fail if validate_formset isn't executed once and only once
+		// Test will fail if validate_fieldset isn't executed once and only once
 	}
-
 /***************
  * Save method *
  ***************/
@@ -872,7 +768,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		// arrange
 		$post_id = 100;
 		$postvalues = array(
-			'one' => 'Some text',
+			'field' => 'Some text',
 		);
 		\WP_Mock::wpFunction( 'get_post_meta', array(
 			'times' => 1,
@@ -884,7 +780,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'return' => true,
 			'with' => array(
 				$post_id,
-				'one',
+				'field',
 				'Some text',
 			),
 			)
@@ -936,11 +832,11 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 
 		// arrange
 		$post_id = 100;
-		$postvalues = array('one' => null);
+		$postvalues = array('field' => null);
 		\WP_Mock::wpFunction( 'get_post_meta', array(
 			'times' => 1,
 			'return' => false,
-			'with' => array( $post_id, 'one')
+			'with' => array( $post_id, 'field')
 			)
 		);
 		\WP_Mock::wpFunction( 'delete_post_meta', array(
@@ -965,7 +861,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 	function testEmptyKeyValueExpectsDeletePostMeta() {
 		// arrange
 		$post_id = 1;
-		$postvalues = array('one' => null);
+		$postvalues = array('field' => null);
 		$existing = 'exists';
 		\WP_Mock::wpFunction(
 			'get_post_meta',
@@ -979,7 +875,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			array(
 				'times' => 1,
 				'return' => true,
-				'with' => array('post_ID' => 1, 'meta_key' => 'one'),
+				'with' => array('post_ID' => 1, 'key' => 'field'),
 			)
 		);
 		$form = new TestValidTextField();
@@ -998,18 +894,17 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 	function testVerifyAndSaveExpectsSuccess() {
 		// arrange
 		$_POST = array('post_ID' => 1, 'field_one' => 'value');
-		$actual = array();
+		$validated = array();
 		$factory = $this->getMockBuilder('TestNumberField')
 						->setMethods( array( 'validate', 'save' ) )
 						->getMock();
-
+		$factory->fields['field_one']['old_key'] = $factory->fields['field_one']['key'];
 		$factory->expects($this->once())
 				->method('validate')
-				->will($this->returnValue(true))
-				->with(1, $factory->fields['field_one'], $actual);
+				->will($this->returnValue(true));
 		$factory->expects($this->once())
 				->method('save')
-				->with(1, $actual);
+				->with(1, $validated);
 
 		// act
 		$factory->validate_and_save( 1 );
@@ -1048,7 +943,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_day' => '01');
 
 		// act
-		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
 	}
 	/**
 	 * Tests whether the validate_datetime method when called on an invalid field
@@ -1082,7 +977,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_day' => '01');
 
 		// act
-		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
 	}
 	/**
 	 * Tests whether the validate_datetime method when called on a time field calls the
@@ -1119,7 +1014,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			);
 
 		// act
-		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
 	}
 	/**
 	 * Tests whether the validate_datetime method when called on an invalid time 
@@ -1156,7 +1051,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		);
 
 		// act
-		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
 	}
 	/**
 	 * Tests whether the validate_datetime method when called on a datetime field calls the
@@ -1195,9 +1090,9 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_day' => '01');
 
 		// act
-		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
 	}
-	/**
+	/*
 	 * Tests whether the validate_datetime method when called on an invalid datetime 
 	 * does not call the date callback method.
 	 *
@@ -1234,7 +1129,7 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_day' => '01');
 
 		// act
-		$form->validate_datetime( $form->fields['category'], $_POST['post_ID']);
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
 	}
 
 	/**
@@ -1269,170 +1164,12 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		);
 
 		// act
-		$form->validate_taxonomyselect($form->fields['field_one'], $_POST['post_ID']);
+		$form->validate_taxonomyselect($_POST['post_ID'], $form->fields['field_one'], 'field_one');
 
 		// Assert: test will fail if wp_set_object_terms, get_term_by or
 		// sanitize_text_field do not fire or fire more than once
 	}
 
-	/**
-	 * Tests whether validate_link will call add post meta with the correct values
-	 *
-	 * @group isolated
-	 * @group stable
-	 * @group validate_link
-	**/
-	function testValidateLinkExpectsAddPostMetaTwice() {
-		$_POST = array(
-			'link_url' => 'http://example.com',
-			'link_text' => 'example.com',
-		);
-		$field = array(
-			'slug' => 'link',
-			'type' => 'link',
-			'params' => array(),
-			'meta_key' => 'link',
-			'howto' => "Some howto text",
-		);
-		$form = new TestNumberField();
-		global $post;
-		$post = new StdClass();
-		$post_id = 1;
-		$form->fields = $field;
-		\WP_Mock::wpFunction(
-			'add_post_meta',
-			array( 'times' => 2, 'return' => true )
-		);
-		$post = new \StdClass;
-		\WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
-		\WP_Mock::wpFunction('delete_post_meta', array('times' => 0));
-		$form->validate_link( $field, $post_id);
-	}
-
-	/**
-	* Tests whether count will default to 1 if none is passed in the model
-	*
-	* @group stable
-	* @group isolated
-	* @group validate_link
-	**/
-	function testValidateLinkCountNotGivenExpectsUpdatePostMetaCalledOnce() {
-		// arrange
-		$_POST = array(
-			'link_url' => 'http://example.com',
-			'link_text' => 'example.com',
-		);
-		$field = array(
-			'slug' => 'link',
-			'type' => 'link',
-			'params' => array(),
-			'meta_key' => 'link',
-			'howto' => "Some howto text",
-		);
-		$form = new TestNumberField();
-		$post_id = 1;
-		$form->fields = $field;
-		\WP_Mock::wpFunction(
-			'add_post_meta',
-			array( 'times' => 2, 'return' => true )
-		);
-		$post = new \StdClass;
-		\WP_Mock::wpFunction('get_post_meta', array( 'times' => 1, 'return' => false) );
-
-		// act
-		$form->validate_link( $field, $post_id);
-
-		// assert: Test will fail if get_ or update_post_meta called more than once.
-	}
-	/**
-	 * Tests whether validate_link will use the $existing variable if it is set
-	 *
-	**/
-	function testValidateLinkWithExistingDataExpectsDataDeletedAndReplaced() {
-		// arrange
-		$_POST = array(
-			'link_url' => 'http://example.com',
-			'link_text' => 'example.com',
-		);
-		$field = array(
-			'slug' => 'link',
-			'type' => 'link',
-			'params' => array(),
-			'meta_key' => 'link',
-			'howto' => "Some howto text",
-		);
-		$existing = array( 'http://google.com', 'Google');
-		$form = new TestNumberField();
-		$post_id = 1;
-		$form->fields = $field;
-		// \WP_Mock::wpFunction(
-		//  'delete_post_meta',
-		//  array( 'times' => 1, 'return' => true)
-		// );
-		// \WP_Mock::wpFunction(
-		//  'add_post_meta',
-		//  array( 'times' => 2, 'return' => true)
-		// );
-		\WP_Mock::wpFunction(
-			'update_post_meta',
-			array( 'times' => 2, 'return' => true)
-		);
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array( 'times' => 1, 'return' => $existing )
-		);
-
-
-		// act
-		$form->validate_link( $field, $post_id );
-
-		// assert
-		// Test will fail if add_post_meta is called more than twice, and if
-		// get_post_meta or delete_post_meta are called more than once.
-	}
-
-	/**
-	* Tests whether validate_link will return rather than re-save existing data
-	*
-	* @group stable
-	* @group link_validate
-	*
-	**/
-	function testValidateLinkWithExistingDataMatchingSubmittedExpectsNoaction() {
-		// arrange
-		$_POST = array(
-			'link_url' => 'http://example.com',
-			'link_text' => 'example.com',
-		);
-		$field = array(
-			'slug' => 'link',
-			'type' => 'link',
-			'params' => array(),
-			'meta_key' => 'link',
-			'howto' => "Some howto text",
-		);
-		$existing = array( 'http://example.com', 'example.com');
-		$form = new TestNumberField();
-		$post_id = 1;
-		$form->fields = $field;
-		\WP_Mock::wpFunction(
-			'add_post_meta',
-			array( 'times' => 0 )
-		);
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array( 'times' => 1, 'return' => $existing )
-		);
-		\WP_Mock::wpFunction(
-			'update_post_meta',
-			array( 'times' => 0)
-		);
-		// act
-		$form->validate_link( $field, $post_id );
-		// assert
-		// Test will fail if add_post_meta or delete_post_meta is called and if
-		// get_post_meta is called more than once.
-	}
 	/**
 	 * Tests whether taxonomyselect will use the term object when a term exists
 	 *
@@ -1457,156 +1194,12 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		\WP_Mock::wpFunction('wp_set_object_terms', array( 'times' => 1 ) );
 
 		// act
-		$form->validate_taxonomyselect($form->fields['field_one'], $post->ID);
+		$form->validate_taxonomyselect(1, $form->fields['field_one'], 'field_one');
 
 		// Assert: test will fail if wp_set_object_terms, get_term_by or
 		// sanitize_text_field do not fire or fire more than once
 	}
 
-	/**
-	 * Tests whether if no existing metadata, add_post_meta is called by validate_select
-	 *
-	 * @group stable
-	 * @group select
-	 * @group isolated
-	**/
-	function testNoExistingDataValidateSelectExpectsAddPostMetaFiredOnce() {
-		// Arrange
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'select';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array( 'field_one' => 'metadata');
-		\WP_Mock::wpFunction('sanitize_text_field', array('times' => 1));
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 1, 'return' => array() )
-		);
-		\WP_Mock::wpFunction('add_post_meta', array( 'times' => 1 ) );
-
-		// act
-		$form->validate_select($form->fields['field_one'],$post->ID);
-	}
-
-	/**
-	 * Tests whether if no existing metadata, add_post_meta will be called twice by 
-	 * validate_select if multiple values are in $_POST
-	 *
-	 * A multi select field will pass an array of values to the $_POST array, we 
-	 * expect cms-toolkit to iterate over that array adding new post data for each
-	 * entry.
-	 *
-	 * @group stable
-	 * @group select
-	 * @group isolated
-	 */
-	function testNoExistingDataValidateSelectExpectsAddPostMetaTwice() {
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'select';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array( 'field_one' => array( 'metadata', 'otherdata' ) );
-		\WP_Mock::wpFunction('sanitize_text_field', array('times' => 2));
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 1, 'return' => array() )
-		);
-		\WP_Mock::wpFunction('add_post_meta', array( 'times' => 2 ) );
-
-		// act
-		$form->validate_select($form->fields['field_one'],$post->ID);
-
-	}
-
-	/**
-	 * Tests whether, if post has existing custom data but those data are
-	 * not in the $_POST array, delete_post_meta will be called on each
-	 * existing value.
-	 *
-	 * When a select field is submitted it will may contian values that 
-	 * exist already for this post in addition to new ones the user wants
-	 * to add. If a term is in both arrays ($existing and $_POST), we 
-	 * should keep it. If the term is in $existing but not $_POST, then a
-	 * user has removed it or chosen a different value and we should 
-	 * delete the previously stored metadata. This test verifies the latter
-	 * condition specifically where there is no _POST data set at all (a user
-	 * has set the <select> to a null value indicating they wish to delete 
-	 * the value and not replace it.
-	 *
-	 * @group stable
-	 * @group select
-	 * @group isolated
-	 */
-	function testExistingDataButEmptyPostValidateSelectExpectsDeletePostMetaOnce() {
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'select';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array( 'field_one' => array( ) );
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 1, 'return' => array('existing') )
-		);
-		\WP_Mock::wpFunction('delete_post_meta', array( 'times' => 1 ) );
-
-		// act
-		$form->validate_select($form->fields['field_one'],$post->ID);
-
-	}
-
-	/**
-	 * Tests whether, if $_POST contains non-identical values to $existing delete_post_meta
-	 * will be called on each existing value. Similar to L978 _supra_
-	 *
-	 * @group stable
-	 * @group select
-	 * @group isolated
-	 */
-	function testExistingDataMismatchPostValidateSelectExpectsDeletePostMetaAndAddPostMetaOnceEach() {
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'select';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array( 'field_one' => array( 'non-existent' ) );
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 1, 'return' => array('existing') )
-		);
-		\WP_Mock::wpFunction( 'sanitize_text_field', array( 'times' => 1 ) );
-		\WP_Mock::wpFunction( 'delete_post_meta', array( 'times' => 1 ) );
-		\WP_Mock::wpFunction( 'add_post_meta', array( 'times' => 1 ) );
-
-		// act
-		$form->validate_select($form->fields['field_one'],$post->ID);
-
-	}
-
-	/**
-	 * Tests whether, if $_POST is completley empty delete_post_meta will be called
-	 * on each existing value. Similar to L978 _supra_
-	 *
-	 * @group stable
-	 * @group select
-	 * @group isolated
-	 */
-	function testExistingDataEmptyPostValidateSelectExpectsDeletePostMetaAndAddPostMetaOnceEach() {
-		global $post;
-		$form = new TestNumberField();
-		$form->fields['field_one']['type'] = 'select';
-		$form->fields['field_one']['multiple'] = false;
-		$_POST = array();
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 0, 'return' => array('existing') )
-		);
-		\WP_Mock::wpFunction( 'sanitize_text_field', array( 'times' => 0 ) );
-		\WP_Mock::wpFunction( 'delete_post_meta', array( 'times' => 1 ) );
-		\WP_Mock::wpFunction( 'add_post_meta', array( 'times' => 0 ) );
-
-		// act
-		$form->validate_select($form->fields['field_one'],$post->ID);
-
-	}
 	/**
 	* Tests a fieldset to make sure that validate is called for each of the 
 	* fieldset's fields.
@@ -1626,10 +1219,10 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		$factory->expects( $this->exactly( 2 ) )
 				->method( 'validate' )
 				->will( $this->returnValue( true ) );
-		$expected = array();
+		$validated = array();
 
 		//act
-		$factory->validate_fieldset( $factory->fields['field'], $expected, $post->ID );
+		$factory->validate_fieldset(  $post->ID, $factory->fields['field'], $validated, array());
 
 		//assert
 		// Test will fail if only each of the fields in the fieldset are validated
@@ -1650,63 +1243,37 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 		$_POST = array( 'field_num' => '0123456789', 'field_desc' => 'description' );
 		$testValidFieldsetField = new TestValidFieldsetField();
 		$actual = array();
-		$expected = array( 'field_num' => '0123456789', 'field_desc' => 'description' );
+		$expected = array( 'num' => '0123456789', 'desc' => 'description' );
 
 		//act
-		$testValidFieldsetField->validate_fieldset( $testValidFieldsetField->fields['field'], $actual, $post->ID );
+		$testValidFieldsetField->validate_fieldset( $post->ID, $testValidFieldsetField->fields['field'], $actual, array() );
 
 		//assert
 		$this->assertEquals( $expected, $actual );
 	}
 	/**
-	* Tests a formset to make sure that validate is called for each of the 
-	* formset's fields.
+	* Tests a repeated field to make sure that validate is called for each repetition
 	*
 	 * @group stable
 	 * @group validate
 	 * @group fieldset
-	 * @group validate_formset
-	 * @group isolated
-	*/
-	function testValidFormsetOfTwoFieldsCallsValidateTwice() {
-		//arrange
-		global $post;
-		$factory = $this->getMockBuilder('TestValidFormsetField')
-						->setMethods( array( 'validate', ) )
-						->getMock();
-		$factory->expects( $this->exactly( 2 ) )
-				->method( 'validate' )
-				->will( $this->returnValue( true ) );
-		$actual = array();
-
-		//act
-		$factory->validate_formset( $factory->fields['field'], $actual, $post->ID );
-
-		//assert
-	}
-	/**
-	* Tests a formset to make sure that validate adds validated values to the 
-	* array that was passed in by reference.
-	*
-	 * @group stable
-	 * @group validate
-	 * @group formset
 	 * @group validate_fieldset
 	 * @group isolated
 	*/
-	function testValidateAddsValidatedValuesToPassedInArrayByValidateFormset() {
+	function testValidateRepeatedFieldCallsValidateOnEachRepetition() {
 		// arrange
 		global $post;
-		$_POST = array( 'field_0_title' => 'Title 1', 'field_1_title' => 'Title 2' );
-		$testValidFormsetField = new TestValidFormsetField();
-		$actual = array();
-		$expected = array( 'field_0_title' => 'Title 1', 'field_1_title' => 'Title 2' );
+		$TestRepeatedFields = $this->getMockBuilder('TestRepeatedFields')
+						->setMethods( array( 'validate' ) )
+						->getMock();
+		$TestRepeatedFields->expects($this->exactly(2))
+						    ->method('validate');
+		$validated = array();
 
 		//act
-		$testValidFormsetField->validate_formset( $testValidFormsetField->fields['field'], $actual, $post->ID );
+		$TestRepeatedFields->validate_repeated_field( $post->ID, $TestRepeatedFields->fields['fields'], $validated, array() );
 
 		//assert
-		$this->assertEquals( $expected, $actual );
 	}
 /**************
  * Generators *

--- a/tests/test-meta_box_models.php
+++ b/tests/test-meta_box_models.php
@@ -185,7 +185,9 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 	function testEmptyFieldsArrayExpectsError() {
 		// arrange
 		global $post;
-		$TestValidTextField = new TestValidTextField();
+		$TestValidTextField = $this->getMockBuilder( 'TestValidTextField' )
+					 ->setMethods( array('delete_old_data') )
+					 ->getMock();
 		$TestValidTextField->fields = array();
 		\WP_Mock::wpFunction( 'wp_die', array( 'times' => 1 ) );
 
@@ -302,30 +304,6 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 /***************************
  * Validation method tests *
  ***************************/
-	/**
-	 * Tests whether the validate_and_save method will call validate_keys()
-	 *
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group validation
-	 */
-	function testValidateAndSaveCallsValidateKeys() {
-		// arrange
-		global $post;
-		$stub = $this->getMockBuilder( 'TestValidTextField' )
-					 ->setMethods( array('validate_keys') )
-					 ->getMock();
-		$stub->expects($this->once())
-			 ->method('validate_keys');
-		\WP_Mock::wpPassthruFunction('get_post_meta');
-
-		// act
-		$stub->validate_and_save( $post->ID );
-
-		// assert
-		// Passes when error is called
-	}
 	/**
 	 * Tests whether the validate method will save a null value to the array if
 	 * data from $_POST is missing
@@ -839,9 +817,6 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'with' => array( $post_id, 'field')
 			)
 		);
-		\WP_Mock::wpFunction( 'delete_post_meta', array(
-			'times' => 1)
-		);
 		\WP_Mock::wpFunction( 'update_post_meta', array(
 			'times' => 0,)
 		);
@@ -870,14 +845,6 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 				'return' => $existing,
 			)
 		);
-		\WP_Mock::wpFunction(
-			'delete_post_meta',
-			array(
-				'times' => 1,
-				'return' => true,
-				'with' => array('post_ID' => 1, 'key' => 'field'),
-			)
-		);
 		$form = new TestValidTextField();
 		// act
 		$form->save( $post_id, $postvalues);
@@ -893,19 +860,13 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testVerifyAndSaveExpectsSuccess() {
 		// arrange
-		$_POST = array('post_ID' => 1, 'field_one' => 'value');
-		$validated = array();
 		$factory = $this->getMockBuilder('TestNumberField')
-						->setMethods( array( 'validate', 'save' ) )
+						->setMethods( array( 'validate', 'delete_old_data' ) )
 						->getMock();
 		$factory->fields['field_one']['old_key'] = $factory->fields['field_one']['key'];
 		$factory->expects($this->once())
 				->method('validate')
-				->will($this->returnValue(true));
-		$factory->expects($this->once())
-				->method('save')
-				->with(1, $validated);
-
+				->will($this->returnValue(null));
 		// act
 		$factory->validate_and_save( 1 );
 	}
@@ -941,9 +902,10 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_year' => '1970' ,
 			'category_month' => 'January',
 			'category_day' => '01');
+		$anything = $this->anything();
 
 		// act
-		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $anything);
 	}
 	/**
 	 * Tests whether the validate_datetime method when called on an invalid field
@@ -975,9 +937,10 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_year' => '' ,
 			'category_month' => 'January',
 			'category_day' => '01');
+		$anything = $this->anything();
 
 		// act
-		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $anything);
 	}
 	/**
 	 * Tests whether the validate_datetime method when called on a time field calls the
@@ -1012,9 +975,10 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_ampm' => array('am'),
 			'category_timezone' => array('America/New_York'),
 			);
+		$anything = $this->anything();
 
 		// act
-		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $anything);
 	}
 	/**
 	 * Tests whether the validate_datetime method when called on an invalid time 
@@ -1049,9 +1013,10 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_ampm' => array(''),
 			'category_timezone' => array('America/New_York'),
 		);
+		$anything = $this->anything();
 
 		// act
-		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $anything);
 	}
 	/**
 	 * Tests whether the validate_datetime method when called on a datetime field calls the
@@ -1088,9 +1053,10 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_year' => '2014' ,
 			'category_month' => 'January',
 			'category_day' => '01');
+		$anything = $this->anything();
 
 		// act
-		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $anything);
 	}
 	/*
 	 * Tests whether the validate_datetime method when called on an invalid datetime 
@@ -1127,9 +1093,10 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'category_year' => '' ,
 			'category_month' => 'January',
 			'category_day' => '01');
+		$anything = $this->anything();
 
 		// act
-		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $this->anything());
+		$form->validate_datetime($_POST['post_ID'], $form->fields['category'], $anything);
 	}
 
 	/**

--- a/tests/test-meta_box_view.php
+++ b/tests/test-meta_box_view.php
@@ -12,14 +12,14 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	* Tests whether a field given minimal details is assigned certain defaults
+	* Tests whether one field is calls assign_defaults()
 	* @group stable
 	* @group isolated
 	* @group process_defaults
 	* @group defaults
 	*
 	**/
-	function testHiddenFieldExpectsDefaults() {
+	function testHiddenFieldExpectsAssignDefaultsToBeCalled() {
 		// Arrange
 		$fields = array(
 			'field_one' => array(
@@ -31,158 +31,14 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 				'meta_key' => 'field_one',
 				),
 			);
-		// version 1.1, change: get_post_meta called later in the
-		// stack, see it in default_value now
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 0,
-				'return' => array()
-				)
-			);
-
-		\WP_Mock::wpFunction('get_the_ID', array('times' => 1));
 		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
-			->setMethods( array( 'default_value', ) )
-			->getMock();
+					 ->setMethods(array('assign_defaults'))
+					 ->getMock();
 		$stub->expects($this->once())
-			->method('default_value')
-			->will($this->returnValue(''));
-		$View = new View();
-		$expected = array(
-			'field_one' => array(
-				'title' => 'First',
-				'slug' => 'field_one',
-				'type' => 'hidden',
-				'meta_key' => 'field_one',
-				'value' => '',
-				'params' => array(),
-				'howto' => 'hidden',
-				'label' => '',
-				'multiselect' => false,
-				'taxonomy' => false,
-				),
-			);
+			 ->method('assign_defaults');
+		
 		// Act
-		$cleaned = $stub->process_defaults($fields);
-
-		// Assert
-		$this->assertEquals($expected, $cleaned, 'Defaults were not assigned for some elements.');
-	}
-
-	/**
-	 * Tests whether when given a value, process_defaults will use that value and
-	 * not the default empty value
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group process_defaults
-	 * @group defaults
-	 *
-	 */
-	function testHiddenFieldValueGivenExpectsDrawCalledValueUnchanged() {
-		// Arrange
-		$fields = array(
-			'field_one' => array(
-				'title' => 'First',
-				'slug' => 'field_one',
-				'type' => 'hidden',
-				'params' => array(),
-				'howto' => 'hidden',
-				'meta_key' => 'field_one',
-				'value' => 'Default',
-				),
-			);
-
-		\WP_Mock::wpFunction('get_post_meta', array('times' => 1, 'return' => array()));
-		\WP_Mock::wpFunction('get_the_ID', array('times' => 1));
-		$View = new View();
-		$expected = array(
-			'field_one' => array(
-				'title' => 'First',
-				'slug' => 'field_one',
-				'type' => 'hidden',
-				'meta_key' => 'field_one',
-				'value' => 'Default',
-				'params' => array(),
-				'howto' => 'hidden',
-				'label' => '',
-				'multiselect' => false,
-				'taxonomy' => false,
-				),
-			);
-		// Act
-		$cleaned = $View->process_defaults($fields);
-
-		// Assert
-		$actual = $cleaned['field_one']['value'];
-		$this->assertEquals(
-			$expected,
-			$cleaned,
-			'Draw value was changed from Default to ' . $actual
-		);
-	}
-
-	/**
-	 * Tests the 'meta data exists' path of the View\default_value method
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group defaults
-	 *
-	 */
-	function testExistingDataDefaultValueExpectsExistingDataUsed() {
-		// arrange
-		$field['meta_key'] = 'key';
-		$field['type'] = 'text';
-		$ID = 1;
-		\WP_Mock::wpFunction('get_post_meta', array('times' => 1, 'return' => array('data')));
-		$View = new View();
-		$expected = 'data';
-
-		// act
-		$actual = $View->default_value($ID, $field);
-
-		// assert
-		$this->assertEquals($expected, $actual, 'Expected value was ' . $expected . ' but returned ' . $actual);
-	}
-
-	/**
-	 * Tests the 'meta data does not exist' path of the View\default_value method
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group defaults
-	 *
-	 */
-	function testNoExistingDataDefaultValueExpectsDefaultUsed() {
-		// arrange
-		$field['meta_key'] = 'key';
-		$field['type'] = 'text';
-		$ID = 1;
-		\WP_Mock::wpFunction('get_post_meta', array('times' => 1, 'return' => array()));
-		$View = new View();
-		$expected = '';
-
-		// act
-		$actual = $View->default_value($ID, $field);
-
-		// assert
-		$this->assertEquals($expected, $actual, 'Expected value was ' . $expected . ' but returned ' . $actual);
-	}
-
-	function testFieldTypeLinkExpectsDefaultValueNull() {
-		// arrange
-		$field['type'] = 'link';
-		$field['meta_key'] = 'foo';
-		$ID = 1;
-		$expected = null;
-		$View = new View();
-
-		// act
-		$actual = $View->default_value( $ID, $field );
-
-		// assert
-		$this->assertEquals( $expected, $actual, 'Expected value was ' . $expected . ' but returned ' . $actual );
+		$stub->process_defaults(1, $fields['field_one'], array());
 	}
 	/**
 	 * Tests whether default values are given when user does not supply a value
@@ -194,13 +50,13 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testNoRowsExpects2RowsAdded() {
 		// Arrange
-		$field = array();
+		$field = array('type'=>'text_area');
 		$expected = 2;
 		// Act
 		$View = new View();
-		$actual = $View->default_rows($field);
+		$View->assign_defaults( 1, $field, null);
 		// Assert
-		$this->assertEquals($expected, $actual, 'Default value for rows should be 2');
+		$this->assertEquals($expected, $field['rows'], 'Default value for rows should be 2');
 	}
 
 	/**
@@ -213,15 +69,15 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testRowsGivenDefaultRowsExpectsGivenValuesUsed() {
 		// Arrange
-		$field = array('params' => array('rows' => 1));
+		$field = array('type'=>'text_area','params' => array('rows' => 1));
 		$expected = 1;
 
 		// Act
 		$View = new View();
-		$actual = $View->default_rows($field);
+		$View->assign_defaults(1,$field,null);
 
 		// Assert
-		$this->assertEquals($expected, $actual, 'Number of rows should be 1');
+		$this->assertEquals($expected, $field['rows'], 'Number of rows should be 1');
 	}
 
 /**
@@ -234,34 +90,15 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testNoColsExpects27ColsAdded() {
 		// Arrange
-		$field = array();
-		$expected = 27;
-		// Act
-		$View = new View();
-		$actual = $View->default_cols($field);
-		// Assert
-		$this->assertEquals($expected, $actual, 'Default value for columns should be 27');
-	}
-
-	/**
-	 * Tests whether given values are used for default_cols
-	 *
-	 * @group stable
-	 * @group defaults
-	 * @group isolated
-	 *
-	 */
-	function testColsGivenDefaultColsExpectsGivenValuesUsed() {
-		// Arrange
-		$field['params'] = array('cols' => 1);
+		$field = array('type'=>'text_area','params' => array('cols' => 1));
 		$expected = 1;
 
 		// Act
 		$View = new View();
-		$actual = $View->default_cols($field);
+		$View->assign_defaults(1,$field,null);
 
 		// Assert
-		$this->assertEquals($expected, $actual, 'Number of columns should be ' . $expected . ' but was ' . $actual);
+		$this->assertEquals($expected, $field['cols'], 'Number of rows should be 1');
 	}
 
 	/**
@@ -273,15 +110,15 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testIncludedOptionsEmptyDefaultOptionsExpectsEmptyIncludeKey () {
 		// Arrange
-		$field = array();
+		$field = array('type'=>'tax_as_meta');
 		$expected = array();
 
 		// Act
 		$View = new View();
-		$actual = $View->default_options($field);
+		$actual = $View->assign_defaults(1,$field, null);
 
 		// Assert
-		$this->assertEquals($expected, $actual, 'Options array should be empty but isn\'t');
+		$this->assertEquals($expected, $field['include'], 'Options array should be empty but isn\'t');
 	}
 
 	/**
@@ -293,156 +130,16 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	 * @group defaults
 	 */
 	function testDefaultOptionsExpectsGivenArrayReturned() {
-		$field['params'] = array('include' => array(1,2,3,4,5));
+		$field = array('type'=>'tax_as_meta','params'=>array('include' => array(1,2,3,4,5)));
 		$expected = array(1,2,3,4,5,);
 
 		// Act
 		$View = new View();
-		$actual = $View->default_options($field);
+		$View = new View();
+		$actual = $View->assign_defaults(1,$field, null);
 
 		// Assert
-		$this->assertEquals($expected, $actual, 'The given array should have been assigned');
-	}
-
-	/**
-	 * Tests whether a field passed to default_formset_params will set params if
-	 * none are given.
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group defaults
-	 */
-	function testDefaultFormsetParamsWillSetParamsArrayWhenNotSet() {
-		// arrange
-		$View = new View();
-		$field['params'] = null;
-		$expected = array( 'init_num_forms' => 1, 'max_num_forms' => 1 );
-
-		// Act
-		$actual = $View->default_formset_params( $field );
-
-		// Assert
-		$this->assertEquals($expected, $actual['params'], 'The params array should have been set');
-	}
-
-	/**
-	 * Tests whether when more than one field is passed and one is hidden if both
-	 * fields are generated with the correct values.
-	 * @group maybe_delete
-	 * @group defaults
-	 * @group incomplete
-	 *
-	 */
-	function testHiddenAndNonHiddenFieldsPassedExpectsWPAPIMethodsTwice() {
-		// Arrange
-		$fields = array(
-			'field_one' => array(
-				'title' => 'First',
-				'slug' => 'field_one',
-				'type' => 'text',
-				'params' => array(),
-				'howto' => 'hidden',
-				'meta_key' => 'field_one',
-				),
-			'field_two' => array(
-				'title' => 'First',
-				'slug' => 'field_two',
-				'type' => 'hidden',
-				'params' => array(),
-				'howto' => 'hidden',
-				'meta_key' => 'field_two',
-				),
-			);
-
-		\WP_Mock::wpFunction('get_post_meta', array('times' => 2, 'return' => array()));
-		\WP_Mock::wpFunction('get_the_ID', array('times' => 2));
-		$HTML = $this->getMock('HTML');
-		$View = new View();
-		$View->replace_HTML($HTML);
-		$expected = array(
-			'field_one' => array(
-				'title' => 'First',
-				'slug' => 'field_one',
-				'type' => 'text',
-				'params' => array(),
-				'howto' => 'hidden',
-				'meta_key' => 'field_one',
-				'max_length' => 255,
-				'placeholder' => '',
-				'label' => '',
-				'value' => '',
-				'multiselect' => false,
-				'taxonomy' => false,
-			),
-			'field_two' => array(
-				'title' => 'First',
-				'slug' => 'field_two',
-				'type' => 'hidden',
-				'params' => array(),
-				'howto' => 'hidden',
-				'meta_key' => 'field_two',
-				'value' => '',
-				'label' => '',
-				'multiselect' => false,
-				'taxonomy' => false,
-			),
-		);
-		// Act
-		$cleaned = $View->process_defaults($fields);
-
-		// Assert
-		$this->assertEquals($expected, $cleaned);
-	}
-	/**
-	 * Tests whether an invalid input type generates a WordPress error
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group defaults
-	 */
-	function testInvalidInputExpectsWPError() {
-		$fields= array(
-			0 => array(
-				'type' => 'foo',
-			)
-		);
-
-		$mock = $this->getMock('WP_Error');
-		$HTML = $this->getMock('HTML');
-		$View = new View();
-		$View->replace_HTML($HTML);
-
-		$cleaned = $View->process_defaults($fields);
-
-		$this->assertInstanceOf('WP_Error', $cleaned);
-	}
-
-	/**
-	 * Tests whether no meta_key or slug returns error
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group defaults
-	 */
-	function testNoMetakeyOrSlugExpectsWPError() {
-		$fields= array(
-			0 => array(
-				'type' => 'text',
-				'taxonomy' => 'tax',
-			)
-		);
-
-		$mock = $this->getMock('WP_Error');
-		$HTML = $this->getMock('HTML');
-		$View = new View();
-		$View->replace_HTML($HTML);
-		\WP_Mock::wpFunction(
-			'wp_get_object_terms',
-			array('times'=>1, 'return' => 'term'));
-
-		$cleaned = $View->process_defaults($fields);
-
-		$this->assertInstanceOf('WP_Error', $cleaned);
+		$this->assertEquals($expected, $field['include'], 'The given array should have been assigned');
 	}
 
 	/**
@@ -488,114 +185,17 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 					->getMock();
 		$ready->replace_HTML($HTML);
 		$returned = $ready->expects($this->once())
-			->method('process_defaults')
-			// ->with($fields)
-			->will($this->returnValue($expected));
+						  ->method('process_defaults');
+		\WP_Mock::wpPassThruFunction('get_post_meta');
+		\WP_Mock::wpFunction('get_the_ID');
 		$post = new StdClass;
-		// print_r($HTML);
-		// $HTML->expects($this->once())
-		// 	->method('draw')
-		// 	->with($returned);
+		$HTML->expects($this->once())
+					->method('draw');
 		// Act
 		$ready->ready_and_print_html($post, $fields);
 
 		// Assert
 
-	}
-
-	/**
-	 * If not given a meta_key, the metabox should use the object terms attached
-	 * to $field['taxonomy']
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group defaults
-	 *
-	 */
-	function testProcessDefaultsTaxonomyGivenWithoutMetaKeyExpectsGetObjectTermsReturned() {
-		// Arrange
-		$fields = array(
-			'field' => array(
-				'type' => 'taxonomyselect',
-				'taxonomy' => 'category',
-				'slug' => 'field'),
-			);
-		$expected = array(
-			'field' => array(
-				'type' => 'taxonomyselect',
-				'taxonomy' => 'category',
-				'slug' => 'field',
-				'max_length' => 255,
-				'value' => 'term',
-				'label' => '',
-				'placeholder' => '',
-				'multiselect' => false,
-				'meta_key' => 'field',
-			),
-		);
-		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
-			->setMethods(array('default_max_length',
-				'default_placeholder',
-				'default_label',
-				'default_value',)
-			)
-			->getMock();
-		$stub->expects($this->once())
-			->method('default_max_length')
-			->will($this->returnValue(255));
-		$stub->expects($this->once())
-			->method('default_label')
-			->will($this->returnValue(''));
-		$stub->expects($this->once())
-			->method('default_placeholder')
-			->will($this->returnValue(''));
-		\WP_Mock::wpFunction(
-			'wp_get_object_terms',
-			array('times'=>1, 'return' => 'term'));
-		\WP_Mock::wpFunction(
-			'get_the_ID',
-			array('times' => 1, 'return' => 1));
-		// Act
-		$actual = $stub->process_defaults($fields);
-
-		// Assert
-		$this->assertEquals($expected, $actual);
-	}
-
-	function testFormsetFieldExpectsProcessFormsetDefaultsCalled() {
-		// arrange
-		$fields = array(
-			'field' => array(
-				'type' => 'formset',
-				'fields' => array(
-					array(
-						'title' => 'Title',
-						'type' => 'text',
-						'meta_key' => 'title',
-					),
-				),
-				'params' => array(
-					'init_num_forms' => 1,
-					'max_num_forms' => 2,
-				),
-				'meta_key' => 'field',
-			),
-		);
-		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
-					 ->setMethods( array( 'process_formset_defaults', 'default_value' ) )
-					 ->getMock();
-		$stub->expects( $this->once() )
-			 ->method( 'process_formset_defaults' )
-			 ->will( $this->returnValue( true ) );
-		$stub->expects( $this->once() )
-			 ->method( 'default_value' )
-			 ->will( $this->returnValue( array() ) );
-
-		// act
-		$stub->process_defaults( $fields );
-
-		// assert
-		// Passes when process_formset_defaults and default_value are called
 	}
 
 	function testFieldsetFieldCallsAssignDefaultsAndDefaultValuePerField() {
@@ -614,21 +214,18 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 					),
 				),
 				'params' => array(),
-				'meta_key' => 'field',
+				'key' => 'field',
 			),
 		);
 		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
-					 ->setMethods( array( 'assign_defaults', 'default_value' ) )
+					 ->setMethods( array( 'assign_defaults', ) )
 					 ->getMock();
 		$stub->expects( $this->exactly( 2 ) )
 			 ->method( 'assign_defaults' )
 			 ->will( $this->returnValue( array() ) );
-		$stub->expects( $this->exactly( 3 ) )
-			 ->method( 'default_value' )
-			 ->will( $this->returnValue( array() ) );
 
 		// act
-		$stub->process_defaults( $fields );
+		$stub->process_defaults( 1, $fields['field'], null );
 
 		// assert
 		// Passes when each field (including the fieldset field) gets a call to assign_defaults and default_value
@@ -652,10 +249,9 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		$stub->expects( $this->once() )
 			 ->method( 'assign_defaults' )
 			 ->will( $this->returnValue( true ) );
-		\WP_Mock::wpFunction('get_post_meta', array('times' => 1, 'return' => array()));
 
 		//act
-		$stub->process_defaults( $fields );
+		$stub->process_defaults( 1, $fields['field'], null );
 
 		//assert
 		// Passes when process_defaults is called on field
@@ -678,10 +274,9 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		$stub->expects( $this->once() )
 			 ->method( 'assign_defaults' )
 			 ->will( $this->returnValue( true ) );
-		// \WP_Mock::wpFunction('get_post_meta', array('times' => 0, 'return' => array()));
 
 		//act
-		$stub->process_defaults( $fields );
+		$stub->process_defaults( 1, $fields['field'], null );
 
 		//assert
 		// Passes when process_defaults is called on field
@@ -691,257 +286,29 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		// arrange
 		$fields = array(
 			'field' => array(
-				'type' => 'formset',
-				'title' => 'title',
-				'fields' => array(
-					array(
-						'title' => 'Title',
-						'type' => 'text',
-						'meta_key' => 'title',
-						'slug' => 'title',
+				'title' => 'Title',
+				'type' => 'text',
+				'key' => 'title',
+				'params' => array(
+					'repeated' => array(
+						'min'=>1,
+						'max'=>2
 					),
 				),
-				'params' => array(
-					'init_num_forms' => 1,
-					'max_num_forms' => 2,
-				),
-				'meta_key' => 'field',
-				'slug' => 'field',
 			),
 		);
 		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
-					 ->setMethods( array( 'process_defaults', ) )
+					 ->setMethods( array( 'process_repeated_field_params' ) )
 					 ->getMock();
-		$stub->expects( $this->exactly( 2 ) )
-			 ->method( 'process_defaults' )
-			 ->will( $this->returnValue( true ) );
+		$stub->expects( $this->exactly( 1 ) )
+			 ->method( 'process_repeated_field_params' );
 		$ready = array();
 
 		// act
-		$stub->process_formset_defaults( $fields['field'], $ready );
+		$stub->process_defaults( 1, $fields['field'], null );
 
 		//assert
 		// Passes when each field of each formset calls process_defaults
-	}
-
-	function testProcessFormsetDefaultsAssignsCorrectValuesToEachField() {
-		//arrange
-		$fields = array(
-			'field' => array(
-				'type' => 'formset',
-				'title' => 'title',
-				'fields' => array(
-					array(
-						'title' => 'Title',
-						'type' => 'text',
-						'meta_key' => 'title',
-						'slug' => 'title',
-					),
-				),
-				'params' => array(
-					'init_num_forms' => 1,
-					'max_num_forms' => 2,
-				),
-				'meta_key' => 'field',
-				'slug' => 'field',
-			),
-		);
-		$View = new View();
-		\WP_Mock::wpFunction('get_post_meta', array('times' => 2, 'return' => array()));
-		$actual = array();
-		$expected = array(
-			'field_0' => array(
-				'type' => 'formset',
-				'fields' => array(
-					'field_0_title' => array(
-						'title' => 'Title',
-						'type' => 'text',
-						'meta_key' => 'field_0_title',
-						'slug' => 'field_0_title',
-						'value' => '',
-						'label' => '',
-						'max_length' => 255,
-						'placeholder' => '',
-						'multiselect' => false,
-						'taxonomy' => false,
-					),
-				),
-				'params' => array(
-						'init_num_forms' => 1,
-						'max_num_forms' => 2,
-				),
-				'meta_key' => 'field_0',
-				'init' => true,
-				'slug' => 'field_0',
-				'title' => 'title 1',
-			),
-			'field_1' => array(
-				'type' => 'formset',
-				'fields' => array(
-					'field_1_title' => array(
-						'title' => 'Title',
-						'type' => 'text',
-						'meta_key' => 'field_1_title',
-						'slug' => 'field_1_title',
-						'value' => '',
-						'label' => '',
-						'max_length' => 255,
-						'placeholder' => '',
-						'multiselect' => false,
-						'taxonomy' => false,
-					),
-				),
-				'params' => array(
-						'init_num_forms' => 1,
-						'max_num_forms' => 2,
-				),
-				'meta_key' => 'field_1',
-				'slug' => 'field_1',
-				'title' => 'title 2',
-			),
-		);
-		//act
-		$View->process_formset_defaults( $fields['field'], $actual );
-
-		//assert
-		$this->assertEquals( $expected, $actual );
-	}
-	/**
-	 * Tests that a text_area field calls for default_rows and default_cols
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group defaults
-	 *
-	 */
-	function testTextAreaProcessDefaultsExpectsRowsAndCols() {
-		// Arrange
-		$fields = array(
-			'cfpb' => array(
-				'slug' => 'field',
-				'type' => 'text_area',
-				'meta_key' => 'cfpb',
-				),
-			);
-		$expected = array(
-			'cfpb' => array(
-				'slug' => 'field',
-				'type' => 'text_area',
-				'meta_key' => 'cfpb',
-				'max_length' => 255,
-				'placeholder' => '',
-				'label' => '',
-				'rows' => 2,
-				'cols' => 27,
-				'value' => '',
-				'taxonomy' => false,
-				'multiselect' => false,
-				),
-			);
-		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
-			->setMethods(array('default_max_length',
-				'default_placeholder',
-				'default_label',
-				'default_value',
-				'default_rows',
-				'default_cols',
-				))
-			->getMock();
-		$stub->expects($this->once())
-			->method('default_max_length')
-			->will($this->returnValue(255));
-		$stub->expects($this->once())
-			->method('default_label')
-			->will($this->returnValue(''));
-		$stub->expects($this->once())
-			->method('default_placeholder')
-			->will($this->returnValue(''));
-		$stub->expects($this->once())
-			->method('default_value')
-			->will($this->returnValue(''));
-		$stub->expects($this->once())
-			->method('default_rows')
-			->will($this->returnValue(2));
-		$stub->expects($this->once())
-			->method('default_cols')
-			->will($this->returnValue(27));
-		\WP_Mock::wpFunction(
-			'get_the_ID',
-			array('times' => 1, 'return' => 1));
-		// Act
-		$actual = $stub->process_defaults($fields);
-
-		// Assert
-		$this->assertTrue($expected == $actual);
-	}
-
-	/**
-	 * Tests that a tax_as_meta field calls for default_rows and default_cols
-	 *
-	 * @group stable
-	 * @group isolated
-	 * @group defaults
-	 *
-	 */
-	function testTaxAsMetaProcessDefaultsExpectsDefaultOptions() {
-		// Arrange
-		$fields = array(
-			'cfpb' => array(
-				'slug' => 'field',
-				'type' => 'tax_as_meta',
-				'meta_key' => 'cfpb',
-				),
-			);
-		$expected = array(
-			'cfpb' => array(
-				'slug' => 'field',
-				'type' => 'tax_as_meta',
-				'meta_key' => 'cfpb',
-				'max_length' => 255,
-				'placeholder' => '',
-				'label' => '',
-				'value' => '',
-				'include' => '',
-				'multiselect' => false,
-				),
-			);
-		$stub = $this->getMockBuilder('\CFPB\Utils\MetaBox\View')
-			->setMethods(array('default_max_length',
-				'default_placeholder',
-				'default_label',
-				'default_value',
-				'default_options',
-				))
-			->getMock();
-		$stub->expects($this->once())
-			->method('default_max_length')
-			->will($this->returnValue(255));
-		$stub->expects($this->once())
-			->method('default_label')
-			->will($this->returnValue(''));
-		$stub->expects($this->once())
-			->method('default_placeholder')
-			->will($this->returnValue(''));
-		$stub->expects($this->once())
-			->method('default_value')
-			->will($this->returnValue(''));
-		$stub->expects($this->once())
-			->method('default_options')
-			->will($this->returnValue(''));
-		\WP_Mock::wpFunction(
-			'get_the_ID',
-			array('times' => 1, 'return' => 1));
-		// new v1.1, change: get_post_meta is now called later, during default
-		// value, mocked here, tested elsewhere
-		\WP_Mock::wpFunction(
-			'get_post_meta',
-			array('times' => 0, 'return' => array('one', 'two'))
-		);
-		// Act
-		$actual = $stub->process_defaults($fields);
-
-		// Assert
-		$this->assertTrue($expected == $actual);
 	}
 
 	function testAssignDefaultsSetsParamArrayIfNotSet() {
@@ -950,7 +317,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		$field = array( 'type' => 'wysiwyg', 'params' => null );
 
 		//act
-		$field = $View->assign_defaults( $field );
+		$View->assign_defaults( 1, $field, null );
 
 		// assert
 		$this->assertTrue( isset( $field['params'] ) );
@@ -962,7 +329,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		$field = array( 'type' => 'wysiwyg', 'params' => array( 'editor_class' => 'class') );
 
 		//act
-		$field = $View->assign_defaults( $field );
+		$View->assign_defaults( 1, $field, null );
 
 		// assert
 		$this->assertEquals( $field['params']['editor_class'], "class cms-toolkit-wysiwyg" );
@@ -977,25 +344,9 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		//act
 		foreach ( $types as $type ) {
 			$field['type'] = $type;		
-			$default = $View->assign_defaults( $field );
+			$View->assign_defaults( 1, $field, null );
 			// assert
 			$this->assertEquals( $field['taxonomy'], true );
-		}
-	}
-
-	function testAssignDefaultsGetsTimezoneForTimeOrDatetimeFieldIfOneIsSaved() {
-		// arrange
-		$View = new View();
-		$field = array( 'taxonomy' => 'tax' );
-		$types = array( 'time', 'datetime' );
-		\WP_Mock::wpFunction( 'get_post_meta', array( 'times' => 2, 'return' => 'something' ) );
-
-		//act
-		foreach ( $types as $type ) {
-			$field['type'] = $type;
-			$default = $View->assign_defaults( $field );
-			// assert
-			$this->assertEquals( isset( $default['timezone'] ), true );
 		}
 	}
 
@@ -1009,7 +360,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		foreach ( $types as $type ) {
 			$field['type'] = $type;		
 			// act
-			$default = $View->default_value( $post->ID, $field );
+			$View->assign_defaults( 1, $field, null );
 			// assert
 			$this->assertEquals( isset( $field['value'] ), false );
 		}

--- a/tests/test-meta_box_view.php
+++ b/tests/test-meta_box_view.php
@@ -50,7 +50,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testNoRowsExpects2RowsAdded() {
 		// Arrange
-		$field = array('type'=>'text_area');
+		$field = array('key' => 'key', 'type'=>'text_area');
 		$expected = 2;
 		// Act
 		$View = new View();
@@ -69,7 +69,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testRowsGivenDefaultRowsExpectsGivenValuesUsed() {
 		// Arrange
-		$field = array('type'=>'text_area','params' => array('rows' => 1));
+		$field = array('key' => 'key', 'type'=>'text_area','params' => array('rows' => 1));
 		$expected = 1;
 
 		// Act
@@ -90,7 +90,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testNoColsExpects27ColsAdded() {
 		// Arrange
-		$field = array('type'=>'text_area','params' => array('cols' => 1));
+		$field = array('key' => 'key', 'type'=>'text_area','params' => array('cols' => 1));
 		$expected = 1;
 
 		// Act
@@ -110,7 +110,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	 */
 	function testIncludedOptionsEmptyDefaultOptionsExpectsEmptyIncludeKey () {
 		// Arrange
-		$field = array('type'=>'tax_as_meta');
+		$field = array('key' => 'key', 'type'=>'tax_as_meta');
 		$expected = array();
 
 		// Act
@@ -130,7 +130,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 	 * @group defaults
 	 */
 	function testDefaultOptionsExpectsGivenArrayReturned() {
-		$field = array('type'=>'tax_as_meta','params'=>array('include' => array(1,2,3,4,5)));
+		$field = array('key' => 'key', 'type'=>'tax_as_meta','params'=>array('include' => array(1,2,3,4,5)));
 		$expected = array(1,2,3,4,5,);
 
 		// Act
@@ -311,34 +311,34 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		// Passes when each field of each formset calls process_defaults
 	}
 
-	function testAssignDefaultsSetsParamArrayIfNotSet() {
+	function testAssignDefaultsSetsWYSIWYGSettingsArrayIfNotSet() {
 		//arrange
 		$View = new View();
-		$field = array( 'type' => 'wysiwyg', 'params' => null );
+		$field = array('key' => 'key', 'type' => 'wysiwyg', 'settings' => null );
 
 		//act
 		$View->assign_defaults( 1, $field, null );
 
 		// assert
-		$this->assertTrue( isset( $field['params'] ) );
+		$this->assertTrue( isset( $field['settings'] ) );
 	}
 
-	function testAssignDefaultsAddsClassToEditorClassParam() {
+	function testAssignDefaultsAddsClassToWYSIWYGEditorClassSetting() {
 		//arrange
 		$View = new View();
-		$field = array( 'type' => 'wysiwyg', 'params' => array( 'editor_class' => 'class') );
+		$field = array('key' => 'key', 'type' => 'wysiwyg', 'settings' => array( 'editor_class' => 'class') );
 
 		//act
 		$View->assign_defaults( 1, $field, null );
 
 		// assert
-		$this->assertEquals( $field['params']['editor_class'], "class cms-toolkit-wysiwyg" );
+		$this->assertEquals( $field['settings']['editor_class'], "class cms-toolkit-wysiwyg" );
 	}
 
 	function testAssignDefaultsDoesNotSetTaxonomyToFalseForGivenFields() {
 		// arrange
 		$View = new View();
-		$field = array( 'type' => '', 'taxonomy' => true );
+		$field = array('key' => 'key', 'type' => '', 'taxonomy' => true );
 		$types = array( 'taxonomyselect', 'tax_as_meta', 'date', 'time', 'datetime' );
 
 		//act
@@ -354,7 +354,7 @@ class MetaBoxGeneratorTest extends PHPUnit_Framework_TestCase {
 		// arrange
 		global $post;
 		$View = new View();
-		$field = array( 'type' => '' );
+		$field = array('key' => 'key', 'type' => '' );
 		$types = array( 'link', 'date', 'time', 'datetime' );
 
 		foreach ( $types as $type ) {


### PR DESCRIPTION
# Overview
This changes the way WordPress saves data. Previously, each field was saved individually, regardless of if it was inside a formset or a fieldset. The `meta_key`/`slug` of each field was concatenated with the `meta_key`/`slug` of the fieldset or formset that contains it. This caused the output of the wp-json-api plugin to have many long and unwieldy key names to access data, and required the use of logic to wrestle a sensical dictionary from the output.

Now, the data is saved in multi-dimensional arrays and then serialized giving a cleaner output in JSON after deserialization (deserialization happens in a [PR](https://github.com/cfpb/wp-json-api/pull/5) for wp-json-api using the the function named `maybe_unserialize`. Bonus points to someone that can tell me which spelling is correct). However, the old technique of concatenation remains for the front-end to maintain unique $_POST key/value pairs. 

This will also remove the type `formset`. The `formset` type was only used to contain a field or set of fields to be repeatable. Now, doing this in any field will repeat the field:
```php
'field' => array(
   'params' => array(
      'repeated' => array(
          'min' => #,
          'max' => #
      ),
   ),
)
```
Finally, this consolidates the key names from `meta_key`/`slug` to just `key` for simpler access and backend logic.

## Caveat
To adequately test that the data is saving properly, you must have [this PR](https://github.com/cfpb/wp-json-api/pull/5) code for wp-json-api so it can deserialize the data properly.

### Review
@Scotchester  @willbarton @dpford @cfarm 