### PR TITLE
Fix menu position to show hidden post types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 1.5.6 - 2015-05-06
+
+### Changed
+- Fix menu position parameter for custom post types
+
 ## 1.5.5 - 2015-04-21
 
 ### Changed

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 1.5.5
+Version: 1.5.6
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -53,7 +53,7 @@ class PostType {
 			'exclude_from_search' => false,
 			'show_ui'             => true,
 			'show_in_menu'        => true,
-			'menu_position'       => 20.1,
+			'menu_position'       => 20,
 			'capability_type'     => 'post',
 			'hierarchical'        => false,
 			'supports'            => array( 'title', 'author', 'editor', 'revisions', 'page-attributes', 'custom-fields', ),


### PR DESCRIPTION
The menu position parameter in `register_post_type()` requires an integer and the one that's currently in the code is a floating point number. This fixes that and *hopefully* will fix the issue of missing post types in the content Wordpress admin console.

@dpford @Scotchester 