### PR TITLE
Try to fix missing post types again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 2.2.3 - 2015-06-23
+
+### Changed
+- Post type `menu-position` changed to 100 to move them down to the bottom
+
 ## 2.2.2 - 2015-06-30
 
 ### Changed

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 2.2.2
+Version: 2.2.3
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -53,7 +53,7 @@ class PostType {
 			'exclude_from_search' => false,
 			'show_ui'             => true,
 			'show_in_menu'        => true,
-			'menu_position'       => 20,
+			'menu_position'       => 100,
 			'capability_type'     => 'post',
 			'hierarchical'        => false,
 			'supports'            => array( 'title', 'author', 'editor', 'revisions', 'page-attributes', 'custom-fields', ),


### PR DESCRIPTION
Sets menu position to 100 for it to be below the second visual separator, and more importantly below every other option. [Here's the doc explaining the menu position parameter.](http://codex.wordpress.org/Function_Reference/register_post_type)