### PR TITLE
Fix key bug in repeated field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 2.0.1 - 2015-06-02
+
+### Changed
+- Fix bug that caused numeric indexes to be off
+
 ## 2.0.0 - 2015-05-04
 
 ### Changed

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 2.0.0
+Version: 2.0.1
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -189,6 +189,8 @@ class Models {
 		}
 		if ( empty( $validated ) ) {
 			unset( $validated );
+		} else {
+			$validated = array_values( $validated );
 		}
 		$field['fields'] = $processed;
 	}


### PR DESCRIPTION
Repeated fields that do not have data in the first field of the set of fields that are repeated cause the keys that each one is saved under to be numbered. This fixes it so the key's are reset after assignment.

@Scotchester 