### PR TITLE
Fix saving bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 2.0.2 - 2015-06-09
+
+### Changed
+- Fix bug that caused empty links to interrupt saving of fields that followed
+
 ## 2.0.1 - 2015-06-02
 
 ### Changed

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 2.0.1
+Version: 2.0.2
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -239,7 +239,7 @@ class Models {
 			$url = $_POST["{$key}_url"];
 			$full_link = array( 'label' => $label, 'url' => $url );
 
-			$validated = ( empty( $label ) or empty( $url ) ) ? null : $full_link;
+			$validated = ( empty( $label ) or empty( $url ) ) ? "" : $full_link;
 		}
 	}
 
@@ -551,8 +551,6 @@ public function delete_old_data( $post_ID, $fields ) {
 			$existing = get_post_meta( $post_ID, $key, $single = true );
 			if ( isset( $value ) ) {
 				update_post_meta( $post_ID, $key = $key, $meta_value = $value );
-			} else {
-				return;
 			}
 		}
 	}
@@ -580,7 +578,7 @@ public function delete_old_data( $post_ID, $fields ) {
 			$this->fields[$key]['key'] = $this->fields[$key]['old_key'];
 			
 			//create keys in array that are to be saved
-			$validated[$this->fields[$key]['old_key']] = null;
+			$validated[$this->fields[$key]['old_key']] = "";
 
 			// retrieve saved data
 			$saved[$this->fields[$key]['old_key']] = get_post_meta( $post_ID, $this->fields[$key]['old_key'], $single = true );


### PR DESCRIPTION
So it turns out that if you have a link that has no data in it, that link's meta_key will be assigned a null value on saving. When a null meta_key is encountered, the `save()` function, (rather stupidly) returns. We don't want the `save()` function to return unless it has finished going through all the keys that are passed to it. Furthermore, we want link fields to be assigned an empty string so when a link field is deleted on a post that is then RAMP'd, the post on production will replace the link's data with an empty string, which effectively deletes it.

### Reproducing the bug
**Before you pull this code in:** if you go into the oah-journey-step post type and and save the wysiwyg fields and not the `key_tool` link field, the wysiwyg fields won't save!

### Testing
Run `phpunit` or `./vendor/bin/phpunit` if you don't have phpunit installed on your PATH.

**P.S.** Without this code, OAH's post type is breaking and cannot enter content without that link field entered.

@dpford @Scotchester 

