### PR TITLE
Custom file fields now use attachments

### DIFF
--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 2.0.2
+Version: 2.1.0
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -348,16 +348,28 @@ class HTML {
 				echo esc_attr( $label );
 			?></label><?php
 		}
+		$hidden_value = null;
 		if ( $value ) {
-			?><div class="tagchecklist">
-				<span><a id="<?php echo esc_attr( $key ) ?>" class="filedelbutton <?php echo esc_attr( $key ) ?>"><?php echo esc_attr( $value['name'] ) ?></a>&nbsp;<?php echo $value['name'] ?></span><?php
-				$this->hidden( 'rm_' . $key, null, null );
+			if ( ! get_post( $value['id'] ) ) {
+				$hidden_value = $value['url'];
+			}
+			?><div class="tagchecklist"><?php
+			if ( ! isset( $hidden_value ) ) {
+				?><span>
+				  <a id="<?php echo esc_attr( $key ) ?>" class="filedelbutton <?php
+				   echo esc_attr( $key ); ?>"><?php
+					echo esc_attr( $value['name'] );
+				  ?></a>&nbsp;<?php
+				  echo esc_attr( $value['name'] );
+				?></span><?php
+			}
+				$this->hidden( 'rm_' . $key, $hidden_value, null );
 			?></div><?php
 		}
 		?><input id="<?php echo esc_attr( $key ) 
 			   ?>" name="<?php echo esc_attr( $key ) 
 			   ?>" class="cms-toolkit-input <?php echo "set-input_{$set_id}"; 
-			   ?>" type="file" value="<?php if ( $value ) echo esc_attr( $value['url'] ); ?>"<?php
+			   ?>" type="file" value="<?php if ( $value and isset( $value['url'] ) ) echo esc_attr( $value['url'] ); ?>"<?php
 			   if ( $required ) echo ' required '; ?>/><?php
 	}
 


### PR DESCRIPTION
Previously, the custom file upload field would upload a field to the uploads directory specified in Wordpress and save the data about the file in a custom field. The problem with this is when RAMP is looking for things to move to production, it won't look in the custom fields for the file data and the file won't get RAMP'd over.

The solution to this is to have the file to be uploaded create an attachment to the post. RAMP recognizes attachments and will move them over.

Having it upload as an attachment gives the added benefit of controlling the uploaded media in the Media section of the WP-Admin. Additionally, deleting a post won't result in a loss of the meta-data for the attachment, as the attachment will not be deleted, but will be sitting in the Media library waiting to be attached to another post once again.

#### Immediate need for this
The Event post type uses this custom upload file field several times so this needs to be working for that post type to be in 100% working order.

@dpford @Scotchester @willbarton 