### PR TITLE
Fixes date bug when date fields are repeated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 2.2.0 - 2015-06-23
+
+### Changed
+- `date`/`time`/`datetime` fields can be repeated but only single date fields
+    are saved into a taxonomy (plans to remove date types from a taxonomy are
+    being considered)
+
+## 2.1.0 - 2015-06-22
+
+### Changed
+- Uploading a file through the custom file upload field creates an attachment
+
 ## 2.0.2 - 2015-06-09
 
 ### Changed

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 2.1.0
+Version: 2.2.0
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/inc/meta-box-callbacks.php
+++ b/inc/meta-box-callbacks.php
@@ -37,21 +37,16 @@ class Callbacks {
 	 * @param boolean $multiples, Determines whether the term shoud append (true) or replace (false) existing terms
 	 * @return identical to wp_set_object_terms
 	 */
-	public function date( $post_id, $taxonomy, $multiples = false, $data = array(), $term_num = null ) {
+	public function date( $post_id, $taxonomy, $multiples = false, $date = array(), $term_num = null ) {
 		global $post;
-		
-		$rmTerm     = 'rm_' . $taxonomy . '_' . $term_num;
+		$rmTerm = 'rm_' . $taxonomy . '_' . $term_num;
 		if ( isset( $_POST[$rmTerm] ) and !empty( $_POST[$rmTerm] ) ) {
 			$tounset = get_term_by( 'name', $_POST[$rmTerm], $taxonomy );
 			if ( $tounset ) {
 				$this->Taxonomy->remove_post_term( $post_id, $tounset->term_id, $taxonomy );
 			}
-			if ( isset( $data[$taxonomy] ) ) {
-				Models::save( $post_id, array( $taxonomy => strval( strtotime( $data[$taxonomy] ) ) ) );
-			}
-		} elseif ( isset( $data[$taxonomy] ) and !empty( $data[$taxonomy] ) ) {
-			wp_set_object_terms( $post_id, $data[$taxonomy], $taxonomy, $append = $multiples );
-			Models::save( $post_id, array( $taxonomy => date( Datetime::ISO8601, strval( strtotime( $data[$taxonomy] ) ) ) ) );
+		} elseif ( isset( $date ) ) {
+			wp_set_object_terms( $post_id, $date->format('c'), $taxonomy, $append = $multiples );
 		}
 	}
 }

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -293,80 +293,70 @@ class Models {
 		$terms = wp_get_post_terms( $post_ID, $field['taxonomy'], array( 'fields' => 'ids' ) );
 		$terms_to_remove = array();
 		for ( $i = 0; $i < count( $terms ); $i++ ) {
-			if ( isset( $_POST['rm_' . $field['taxonomy'] . '_' . $i ] ) ) {
+			if ( isset( $_POST['rm_' . $field['key'] . '_' . $i ] ) ) {
 				array_push( $terms_to_remove, $i );
 			}
 		}
 		foreach ( $terms_to_remove as $t ) {
 			$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], null, $t );
 		}
-		$data = array($field['taxonomy'] => '');
+		$data = array($field['key'] => '');
 		if ( $field['type'] != 'time') {
-			$month = $field['taxonomy'] . '_month';
-			$day = $field['taxonomy'] . '_day';
-			$year = $field['taxonomy'] . '_year';
+			$month = $field['key'] . '_month';
+			$day = $field['key'] . '_day';
+			$year = $field['key'] . '_year';
 			if ( isset($_POST[$month]) ) {
-				$data[$field['taxonomy']] .= $_POST[$month];
+				$data[$field['key']] .= $_POST[$month];
 			}
 			if ( isset( $_POST[$day] ) ) {
-				$data[$field['taxonomy']] .= ' ' . $_POST[$day];
+				$data[$field['key']] .= ' ' . $_POST[$day];
 			}
 			if ( isset( $_POST[$year] ) ) {
-				$data[$field['taxonomy']] .= ' ' . $_POST[$year];
+				$data[$field['key']] .= ' ' . $_POST[$year];
 			}
 		}
 		if ( $field['type'] == 'datetime' ) {
-			$data[$field['taxonomy']] .= ' ';
+			$data[$field['key']] .= ' ';
 		}
 		if ( $field['type'] != 'date') {
-			$hour = $field['taxonomy'] . '_hour';
-			$minute = $field['taxonomy'] . '_minute';
-			$ampm = $field['taxonomy'] . '_ampm';
-			$timezone = $field['taxonomy'] . '_timezone';
+			$hour = $field['key'] . '_hour';
+			$minute = $field['key'] . '_minute';
+			$ampm = $field['key'] . '_ampm';
+			$timezone = $field['key'] . '_timezone';
 			if ( isset($_POST[$hour]) ) {
-				$data[$field['taxonomy']] .= $_POST[$hour][0];
+				$data[$field['key']] .= $_POST[$hour][0];
 			}
 			if ( isset( $_POST[$minute] ) ) {
-				$data[$field['taxonomy']] .= ':' . $_POST[$minute][0];
+				$data[$field['key']] .= ':' . $_POST[$minute][0];
 			}
 			if ( isset( $_POST[$ampm] ) ) {
-				$data[$field['taxonomy']] .= $_POST[$ampm][0];
+				$data[$field['key']] .= $_POST[$ampm][0];
 			}
 			if ( isset( $_POST[$timezone] ) ) {
-				$data[$field['taxonomy']] .= ' ' . $_POST[$timezone][0];
+				$data[$field['key']] .= ' ' . $_POST[$timezone][0];
 			}
 		}
 		$timezone = null;
 		if ( $field['type'] == 'date' ) {
-			$date = DateTime::createFromFormat('F j Y', $data[$field['taxonomy']]);
+			$date = DateTime::createFromFormat('F j Y', $data[$field['key']]);
 		} else {
-			if ( isset( $_POST[$field['taxonomy'] . '_timezone'] ) and
-				 is_array( $_POST[$field['taxonomy'] . '_timezone'] ) and
-				 !empty( $_POST[$field['taxonomy'] . '_timezone'][0] ) ) {
+			if ( isset( $_POST[$field['key'] . '_timezone'] ) and
+				 is_array( $_POST[$field['key'] . '_timezone'] ) and
+				 !empty( $_POST[$field['key'] . '_timezone'][0] ) ) {
 				
-				date_default_timezone_set( $_POST[$field['taxonomy'] . '_timezone'][0] );
+				date_default_timezone_set( $_POST[$field['key'] . '_timezone'][0] );
 			}
 			if ( $field['type'] == 'time' ) {
-				$date = DateTime::createFromFormat('h:ia T', $data[$field['taxonomy']]);
+				$date = DateTime::createFromFormat('h:ia T', $data[$field['key']]);
 			} elseif ( $field['type'] == 'datetime' ) {
-				$date = DateTime::createFromFormat('F j Y h:ia T', $data[$field['taxonomy']]);
+				$date = DateTime::createFromFormat('F j Y h:ia T', $data[$field['key']]);
 			}
 		}
 		if ( $date ) {
-			$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $data, null );
-			if ( $field['type'] == 'date' ) {
-				$validated = array( 'date' => date( Datetime::ISO8601, strval( strtotime( $data[$field['taxonomy']] ) ) ) );
-			} elseif ( $field['type'] == 'datetime' ) {
-				$validated = array(
-					'datetime' => date( Datetime::ISO8601, strval( strtotime( $data[$field['taxonomy']] ) ) ),
-					'timezone' => $_POST[$field['taxonomy'] . '_timezone'][0]
-				);
-			} else {
-				$validated = array(
-					'time' => date( Datetime::ISO8601, strval( strtotime( $data[$field['taxonomy']] ) ) ),
-					'timezone' => $_POST[$field['taxonomy'] . '_timezone'][0]
-				);
+			if ( $field['key'] == $field['taxonomy'] ) {
+				$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $date, null );
 			}
+			$validated = array( 'date' => $date->format( Datetime::ISO8601 ), 'timezone' => $_POST[$field['key'] . '_timezone'][0] );
 		}
 	}
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -19,10 +19,9 @@ function delete_form_data(slug, form_id) {
 }
 
 function toggle_repeated_field(element) {
-    var classes = jQuery(element).attr('class').split(/\s+/);
-    var form_id = classes[3];
-    var action = classes[2];
-    var slug = classes[1];
+    var slug = jQuery(element).attr('data-term');
+    var action = jQuery(element).attr('data-action-term');
+    var form_id = jQuery(element).attr('data-term-id');
     var header = jQuery('#' + slug + '-header');
     var targeted_input = jQuery('#' + slug + '-set');
     if ( action == 'add') {
@@ -37,7 +36,7 @@ function toggle_repeated_field(element) {
         jQuery(element).attr('disabled', true);
         
         // show the remove link
-        var remove_link = jQuery("." + slug + ".remove");
+        var remove_link = jQuery("[data-term='" + slug +"'][data-action-term='remove']");
         jQuery(remove_link).toggleClass('hidden');
         jQuery(remove_link).attr('disabled', false);
 
@@ -56,7 +55,8 @@ function toggle_repeated_field(element) {
         jQuery(element).attr('disabled', true);
 
         // Show add link
-        var add_link = jQuery("." + slug + ".add");
+        var add_link = jQuery("[data-term='" + slug +"'][data-action-term='add']");
+        console.log(add_link.html());
         jQuery(add_link).toggleClass('hidden');
         jQuery(add_link).attr('disabled', false);
 
@@ -75,10 +75,9 @@ jQuery(document).ready(function($){
 } );
 
 jQuery('.tagdelbutton').click( function() {
-    var taxAndTagNum = jQuery(this).attr('id').split('-');
-    var taxonomy = taxAndTagNum[0];
-    var tagNum = taxAndTagNum[3];
-    var term = jQuery(this).attr('class').split('-')[1];
+    var taxonomy = jQuery(this).attr('id');
+    var tagNum = jQuery(this).attr('data-term-tag-num');
+    var term = jQuery(this).attr('data-term');
     jQuery('input[id=rm_' + taxonomy + '_' + tagNum + ']').val(term);
     jQuery(this).parent().html('');
 });

--- a/tests/test-meta-box-callbacks.php
+++ b/tests/test-meta-box-callbacks.php
@@ -2,6 +2,7 @@
 namespace CFPB\Tests;
 use \CFPB\Utils\MetaBox\Callbacks;
 use \CFPB\Utils\Taxonomy;
+use \DateTime;
 
 function strtotime() {
 	return MetaBoxCallbacksTest::$now ?: time('now');
@@ -36,7 +37,7 @@ class MetaBoxCallbacksTest extends \PHPUnit_Framework_TestCase {
 		\WP_Mock::wpFunction('wp_set_object_terms', array('times' => 1));
 		$post_id = 0;
 		$taxonomy = 'category';
-		$data['category'] = 'January 1, 1970';
+		$data = Datetime::createFromFormat('F j Y', 'January 12 2000');
 		// Act
 		$c = new Callbacks();
 		$c->date($post_id, $taxonomy, false, $data);

--- a/tests/test-meta_box_html.php
+++ b/tests/test-meta_box_html.php
@@ -634,7 +634,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 	 * @group unstable
 	 * @group date
 	 */
-	function testDateCallsGetMonth24Times() {
+	function testDateCallsGetMonth12Times() {
 		//arrange
 		global $wp_locale;
 		$term = new \StdClass;
@@ -642,7 +642,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
-		$wp_locale->expects( $this->exactly( 24 ) )
+		$wp_locale->expects( $this->exactly( 12 ) )
 				  ->method( 'get_month' )
 				  ->will( $this->returnValue( 'month' ) );
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
@@ -653,7 +653,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$HTML->date( 'tax', false ,false, '' );
 
 		//assert
-		// passes when get month is called 24 times
+		// passes when get month is called 12 times
 	}
 	/**
 	 * Tests that the wysiwyg() method will call wp_editor() once.
@@ -1320,7 +1320,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
-		$wp_locale->expects( $this->exactly( 24 ) )
+		$wp_locale->expects( $this->exactly( 12 ) )
 				  ->method( 'get_month' )
 				  ->will( $this->returnValue( 'month' ) );
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
@@ -1338,7 +1338,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains( $needle, $haystack );
 	}
 	/**
-	 * Tests that the date() method will draw 24 options
+	 * Tests that the date() method will draw 12 options
 	 *
 	 * @group unstable
 	 * @group date
@@ -1351,7 +1351,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
 					 ->setMethods( null )
 					 ->getMock();
-		$wp_locale->expects( $this->exactly( 24 ) )
+		$wp_locale->expects( $this->exactly( 12 ) )
 				  ->method( 'get_month' )
 				  ->will( $this->returnValue( 'month' ) );
 		\WP_Mock::wpPassthruFunction( 'esc_attr' );
@@ -1372,34 +1372,6 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 		//assert
 		$this->assertContains( $needle, $haystack );
 	}
-	/**
-	 * Tests that the date() method will draw 24 options
-	 *
-	 * @group unstable
-	 * @group date
-	 */
-	function testDatePrintsInputsForDayAndYear() {
-		//arrange
-		global $wp_locale;
-		$term = new \StdClass;
-		$term->name = '';
-		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
-					 ->setMethods( null )
-					 ->getMock();
-		\WP_Mock::wpPassthruFunction( 'esc_attr' );
-		\WP_Mock::wpFunction( 'has_term', array( 'return' => true ) );
-		\WP_Mock::wpFunction( 'get_the_terms', array( 'return' => array( $term ) ) );
-		$needle = '<input id="tax_day" type="text" name="tax_day" class="set-input_12" value="" size="2" maxlength="2" placeholder="DD"/>';
-		$needle .= '<input id="tax_year" type="text" name="tax_year" class="set-input_12" value="" size="4" maxlength="4" placeholder="YYYY"/>';
-
-		//act
-		ob_start();
-		$HTML->date( 'tax', false ,false, '', 12 );
-		$haystack = ob_get_flush();
-
-		//assert
-		$this->assertContains( $needle, $haystack );
-	}
 	function testTimeCallsSelect4Times() {
 		//arrange
 		$HTML = $this->getMockBuilder( '\CFPB\Utils\MetaBox\HTML' )
@@ -1409,7 +1381,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 			 ->method( 'select' );
 
 		//act
-		$HTML->time( 'slug', 'taxonomy', false, 'label', 1 );
+		$HTML->time( 'slug', array('date' => '1970-01-01T00:33:35+00:00'), false, 'label', 1 );
 	}
 
 	function testDatetimeCallsDateAndTime() {
@@ -1423,7 +1395,7 @@ class MetaBoxHTMLTest extends PHPUnit_Framework_TestCase {
 			 ->method( 'time' );
 
 		//act
-		$HTML->datetime( 'slug', 'taxonomy', false, 'label', 1 );
+		$HTML->datetime( 'slug', array('date' => '1970-01-01T00:33:35+00:00'), false, 'label', 1 );
 	}
 
 	function testDisplayTagsCallsHasTermToSeeIfTagsExistToBeShown() {

--- a/tests/test-meta_box_models.php
+++ b/tests/test-meta_box_models.php
@@ -901,7 +901,9 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'post_ID' => 1,
 			'category_year' => '1970' ,
 			'category_month' => 'January',
-			'category_day' => '01');
+			'category_day' => '01',
+			'category_timezone' => array('America/New_York')
+		);
 		$anything = $this->anything();
 
 		// act


### PR DESCRIPTION
The way the date/time/datetime fields are saved is by creating a taxonomy term for each date inputed. This term is then shown as a tag after saving. Unfortunately, this constrains us to using only one field for a taxonomy to save dates under. With this, you can put date/time/datetime fields in a repeated field and they will save. A couple caveats though: when dates are saved this way the data is only saved in the custom field's metadata, and the saved data will be shown in the input HTML elements and not the previous tag format. Creating a single date/time/datetime field will result in the regular behavior. It should also be noted that even though the repeated date fields don't save terms into a taxonomy, they still should have a taxonomy declared in it's instantiation in the `metabox.php` file. 

### Review
@Scotchester 