### PR TITLE
Term description of date fields have timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 2.2.1 - 2015-06-25
+
+### Changed
+- `time`/`datetime` fields saved under a taxonomy now save the timezone in the
+    term description
+
 ## 2.2.0 - 2015-06-23
 
 ### Changed

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 2.2.0
+Version: 2.2.1
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/inc/meta-box-callbacks.php
+++ b/inc/meta-box-callbacks.php
@@ -45,10 +45,12 @@ class Callbacks {
 			if ( $tounset ) {
 				$this->Taxonomy->remove_post_term( $post_id, $tounset->term_id, $taxonomy );
 			}
-		} elseif ( isset( $date ) ) {
+		} elseif ( ! empty( $date ) ) {
 			wp_set_object_terms( $post_id, $date->format('c'), $taxonomy, $append = $multiples );
-			$term = get_term_by( 'name', $date->format('c'), $taxonomy );
-			wp_update_term( $term->term_id, $taxonomy, $args = array( 'description' => $timezone ) );
+			if ( isset( $timezone ) ) {
+				$term = get_term_by( 'name', $date->format('c'), $taxonomy );
+				wp_update_term( $term->term_id, $taxonomy, $args = array( 'description' => $timezone ) );
+			}
 		}
 	}
 }

--- a/inc/meta-box-callbacks.php
+++ b/inc/meta-box-callbacks.php
@@ -37,7 +37,7 @@ class Callbacks {
 	 * @param boolean $multiples, Determines whether the term shoud append (true) or replace (false) existing terms
 	 * @return identical to wp_set_object_terms
 	 */
-	public function date( $post_id, $taxonomy, $multiples = false, $date = array(), $term_num = null ) {
+	public function date( $post_id, $taxonomy, $multiples = false, $date = array(), $timezone = null, $term_num = null ) {
 		global $post;
 		$rmTerm = 'rm_' . $taxonomy . '_' . $term_num;
 		if ( isset( $_POST[$rmTerm] ) and !empty( $_POST[$rmTerm] ) ) {
@@ -47,6 +47,8 @@ class Callbacks {
 			}
 		} elseif ( isset( $date ) ) {
 			wp_set_object_terms( $post_id, $date->format('c'), $taxonomy, $append = $multiples );
+			$term = get_term_by( 'name', $date->format('c'), $taxonomy );
+			wp_update_term( $term->term_id, $taxonomy, $args = array( 'description' => $timezone ) );
 		}
 	}
 }

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -356,7 +356,7 @@ class Models {
 			if ( $field['key'] == $field['taxonomy'] ) {
 				$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $date, $timezone, null );
 			}
-			$validated = array( 'date' => $date->format( Datetime::ISO8601 ), 'timezone' => $timezone );
+			$validated = array( 'date' => $date->format( 'c' ), 'timezone' => $timezone );
 		}
 	}
 

--- a/inc/meta-box-models.php
+++ b/inc/meta-box-models.php
@@ -298,7 +298,7 @@ class Models {
 			}
 		}
 		foreach ( $terms_to_remove as $t ) {
-			$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], null, $t );
+			$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], null, null, $t );
 		}
 		$data = array($field['key'] => '');
 		if ( $field['type'] != 'time') {
@@ -336,7 +336,7 @@ class Models {
 				$data[$field['key']] .= ' ' . $_POST[$timezone][0];
 			}
 		}
-		$timezone = null;
+		$timezone = $_POST[$field['key'] . '_timezone'][0];
 		if ( $field['type'] == 'date' ) {
 			$date = DateTime::createFromFormat('F j Y', $data[$field['key']]);
 		} else {
@@ -354,9 +354,9 @@ class Models {
 		}
 		if ( $date ) {
 			if ( $field['key'] == $field['taxonomy'] ) {
-				$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $date, null );
+				$this->Callbacks->date( $post_ID, $field['taxonomy'], $multiple = $field['multiple'], $date, $timezone, null );
 			}
-			$validated = array( 'date' => $date->format( Datetime::ISO8601 ), 'timezone' => $_POST[$field['key'] . '_timezone'][0] );
+			$validated = array( 'date' => $date->format( Datetime::ISO8601 ), 'timezone' => $timezone );
 		}
 	}
 

--- a/tests/test-meta-box-callbacks.php
+++ b/tests/test-meta-box-callbacks.php
@@ -63,7 +63,7 @@ class MetaBoxCallbacksTest extends \PHPUnit_Framework_TestCase {
 		$_POST = array( 'rm_tax_0' => 'term' );
 		\WP_Mock::wpFunction('get_term_by', array('times' => 1, 'return' => false ) );
 		// Act
-		$c->date( 0, 'tax', false, array(), 0 );
+		$c->date( 0, 'tax', false, array(), null, 0 );
 		// Assert
 	}
 
@@ -94,7 +94,7 @@ class MetaBoxCallbacksTest extends \PHPUnit_Framework_TestCase {
 		$c = new Callbacks();
 		$c->replace_Taxonomy( $Taxonomy );
 		// Act
-		$c->date( 0, 'tax', false, array(), 0 );
+		$c->date( 0, 'tax', false, array(), null, 0 );
 		// Assert
 	}
 
@@ -124,9 +124,35 @@ class MetaBoxCallbacksTest extends \PHPUnit_Framework_TestCase {
 		$c->replace_Taxonomy($Mock);
 
 		// Act
-		$c->date($post_id, $taxonomy, false, array(), 1);
+		$c->date($post_id, $taxonomy, false, array(), null, 1);
 
 		// Assert: test fails if remove_post_term is called more or fewer than 1 time.
+	}
+
+	/**
+	 * Tests whether the date() method properly calls wp_set_objeect_terms,
+	 * get_term_by, wp_update_term
+	 *
+	 * @group isolated
+	 * @group stable
+	 * @group date
+	 * @group taxonomy_save
+	 * 
+	 */
+	function testDateGetTermByAndWPUpdateTermCalledOnceForDateData() {
+		// Arrange
+		\WP_Mock::wpFunction('wp_set_object_terms', array('times' => 1));
+		$term = new \StdClass;
+		$term->term_id = 1;
+		\WP_Mock::wpFunction('get_term_by', array('times' => 1, 'return' => $term));
+		\WP_Mock::wpFunction('wp_update_term', array('times' => 1));
+		$post_id = 0;
+		$taxonomy = 'category';
+		$data = Datetime::createFromFormat('F j Y', 'January 12 2000');
+		// Act
+		$c = new Callbacks();
+		$c->date($post_id, $taxonomy, false, $data, 'America/New_York');
+		// Assert
 	}
 }
 ?>

--- a/tests/test-meta_box_models.php
+++ b/tests/test-meta_box_models.php
@@ -938,7 +938,8 @@ class ValidationTest extends PHPUnit_Framework_TestCase {
 			'post_ID' => 1,
 			'category_year' => '' ,
 			'category_month' => 'January',
-			'category_day' => '01');
+			'category_day' => '01',
+			'category_timezone' => 'America/New_York');
 		$anything = $this->anything();
 
 		// act


### PR DESCRIPTION
When a single `datetime`/`time` is saved, it is saved in a taxonomy as a term. In this term, the description is empty. This uses the empty description to save the timezone of the field. This is useful for the event ics file generation. Without it, the event start/end times are set in the UTC timezone.

### Test
Save an unrepeated `time` or `datetime` field and look at the api output. If the term has a description that matches the timezone selected for the field, then mission accomplished.


@jimmynotjim @Scotchester