### PR TITLE
Fix placeholder bug and make timestamps more readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 2.2.2 - 2015-06-30
+
+### Changed
+- `display_tags()` now displays readable timestamps
+
+### Fixed
+- `placeholder` attribute for select fields is now checked so a Fatal Error is
+    is not thrown.
+
 ## 2.2.1 - 2015-06-25
 
 ### Changed

--- a/cms-toolkit.php
+++ b/cms-toolkit.php
@@ -13,7 +13,7 @@ think of it as a library. A collection of methods which, when installed, are
 available throughout the application and make building complex functionality 
 in WordPress a little easier.
 
-Version: 2.2.1
+Version: 2.2.2
 Author: Greg Boone, Aman Kaur, Matthew Duran, Scott Cranfill, Kurt Wall
 Author URI: https://github.com/cfpb/
 License: Public Domain work of the Federal Government

--- a/inc/meta-box-html.php
+++ b/inc/meta-box-html.php
@@ -135,6 +135,7 @@ class HTML {
 		$required = isset( $field['required'] ) ? $field['required'] : false;
 		$multiple = isset( $field['multiple'] ) ? $field['multiple'] : false;
 		$label    = isset( $field['label'] )    ? $field['label']    : null;
+		$placeholder = isset( $field['placeholder'] ) ? $field['placeholder'] : null;
 		if ( in_array( $field['type'], array('multiselect', 'select', 'taxonomyselect' ) ) ) {
 			$this->select( 
 				$field['key'], 
@@ -143,7 +144,7 @@ class HTML {
 				$multiple,
 				$value,
 				$required,
-				$field['placeholder'],
+				$placeholder,
 				$label,
 				$set_id
 			);
@@ -156,7 +157,7 @@ class HTML {
 				$multiple,
 				$required,
 				$label,
-				$placeholder = $field['placeholder'],
+				$placeholder,
 				$set_id
 			);
 		} elseif ( $field['type'] == 'post_select' or $field['type'] == 'post_multiselect' ) {
@@ -164,7 +165,6 @@ class HTML {
 			$settings = $field['params'];
 			$posts = get_posts($settings);
 			$multiple = $field['type'] == 'post_multiselect' ? 'multiple' : null;
-			$placeholder = isset( $field['placeholder'] ) ? $field['placeholder'] : null;
 			$this->post_select(
 				$field['key'],
 				$posts,
@@ -592,15 +592,17 @@ class HTML {
 								  class="tagdelbutton" data-term="<?php echo esc_attr( $term->name ) ?>"><?php
 									echo esc_attr( $term->name );
 								?></a><?php
-							?>&nbsp;<?php echo esc_attr( $term->name );
+							?>&nbsp;<?php echo esc_attr( $natdate );
 						?></span><?php
 					} else {
-						$date = strtotime( $term->name );
+						$date = Datetime::createFromFormat(Datetime::ISO8601, $term->name );
+						$data_term = $date ? $date->format('c') : $term->name;
+						$display = $date ? $date->format('F j Y h:ia T') : $term->name;
 						?><span><a id="<?php echo esc_attr( $field['taxonomy'] ) ?>" data-term-tag-num="<?php echo esc_attr( $i ) ?>"
-								  class="tagdelbutton" data-term="<?php echo esc_attr( $term->name ) ?>"><?php
-									echo esc_attr( $date );
+								  class="tagdelbutton" data-term="<?php echo esc_attr( $data_term ) ?>"><?php
+									echo esc_attr( $data_term );
 								?></a><?php
-							?>&nbsp;<?php echo esc_attr( $term->name );
+							?>&nbsp;<?php echo esc_attr( $display );
 						?></span><?php
 					}
 					$this->hidden( 'rm_' . $field['key'] . '_' . $i, null, null );


### PR DESCRIPTION
Timestamps were output in the ISO8601 format, which isn't very human readable. This changes the output so that if it is saved in that format, it outputs it like so: `July 4 2015 05:10am GMT-0400`.

Also, `placeholder` was throwing an error if it wasn't set for some select fields.

### Test
Save a date/time/datetime field and check the output. Go to the Regulation post type. Make sure that there is no error for any of the select fields in the side context.

@dpford @jimmynotjim @Scotchester 