### PR TITLE
Fix build failures caused by php-coveralls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 2.2.4 - 2016-01-05
+
+### Changed
+- Fix build failure by pinning php-coveralls version at 1.0.0
+
 ## 2.2.3 - 2015-06-23
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "10up/wp_mock": "dev-master",
-        "satooshi/php-coveralls": "dev-master",
+        "satooshi/php-coveralls": "1.0.0",
         "phpunit/phpcov": "dev-master"
 
     },


### PR DESCRIPTION
This should fix the build failures we've been seeing by pinning the version of php-coveralls to 1.0.0 which is compatible with our version of php.

Builds locally.

@rosskarchner 