### PR TITLE
Pin versions to prevent erroneous build failures.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
         }
     ],
     "require": {
-        "10up/wp_mock": "dev-master",
+        "10up/wp_mock": "0.1.1",
         "satooshi/php-coveralls": "1.0.0",
-        "phpunit/phpcov": "dev-master"
+        "phpunit/phpcov": "2.0.2"
 
     },
     "repositories": {


### PR DESCRIPTION
wp-mock wasn't failing but i threw it in there just in case so we don't have to do this again.

@rosskarchner 
